### PR TITLE
[ADD] Add the ability to batch upload IOC by providing a CSV file

### DIFF
--- a/source/app/blueprints/case/case_ioc_routes.py
+++ b/source/app/blueprints/case/case_ioc_routes.py
@@ -29,7 +29,7 @@ from app.configuration import misp_url
 from app.datamgmt.case.case_assets_db import get_assets_types
 from app.datamgmt.case.case_db import get_case
 from app.datamgmt.case.case_iocs_db import get_detailed_iocs, get_ioc_links, add_ioc, add_ioc_link, \
-    get_tlps, get_ioc, delete_ioc
+    get_tlps, get_tlps_dict, get_ioc, delete_ioc
 from app.datamgmt.states import get_ioc_state, update_ioc_state
 from app.forms import ModalAddCaseAssetForm, ModalAddCaseIOCForm
 from app.iris_engine.utils.tracker import track_activity
@@ -69,6 +69,7 @@ def case_list_ioc(caseid):
     ret['ioc'] = []
     for ioc in iocs:
         out = ioc._asdict()
+
         # Get links of the IoCs seen in other cases
         ial = get_ioc_links(ioc.ioc_id, caseid)
 
@@ -115,13 +116,62 @@ def case_add_ioc(caseid):
             return response_error("IOC already exists and linked to this case")
 
         if ioc:
-            track_activity("added ioc {}".format(ioc.ioc_value), caseid=caseid)
+            track_activity("added ioc {} via file upload".format(ioc.ioc_value), caseid=caseid)
 
             msg = "IOC already existed in DB. Updated with info on DB." if existed else "IOC added"
 
             return response_success(msg=msg, data=add_ioc_schema.dump(ioc))
 
         return response_error("Unable to create IOC for internal reasons")
+
+    except marshmallow.exceptions.ValidationError as e:
+        return response_error(msg="Data error", data=e.messages, status=400)
+
+@case_ioc_blueprint.route('/case/ioc/upload', methods=['POST'])
+@api_login_required
+def case_upload_ioc(caseid):
+
+    try:
+        # validate before saving
+        add_ioc_schema = IocSchema()
+        jsdata = request.get_json()
+
+        # get IOC list from request
+        csv_data=jsdata["CSVData"].split("\n")
+        ioc_list = []
+        tlp_Dict  = get_tlps_dict()
+        for csv_line in csv_data:
+            line = csv_line.split(",")
+            if len(line) >= 3:
+                ioc_list.append({"ioc_value": line[0], 
+                                "ioc_type": line[1], 
+                                "ioc_description": line[2],
+                                "ioc_tags": "",
+                                "ioc_tlp_id": tlp_Dict[line[3]]})
+
+        for ioc_element in ioc_list:
+
+            ioc = add_ioc_schema.load(ioc_element)
+
+            if ioc.ioc_type not in choices_ioc_types:
+                return response_error("Not a valid IOC type")
+
+            ioc, existed = add_ioc(ioc=ioc,
+                                user_id=current_user.id,
+                                caseid=caseid
+                                )
+            link_existed = add_ioc_link(ioc.ioc_id, caseid)
+
+            if link_existed:
+                return response_error("IOC already exists and linked to this case")
+
+            if ioc:
+                track_activity("added ioc {}".format(ioc.ioc_value), caseid=caseid)
+                msg = "IOC already existed in DB. Updated with info on DB." if existed else "IOC added"
+            else:
+                return response_error("Unable to create IOC for internal reasons")
+
+        return response_success(msg=msg, data="")
 
     except marshmallow.exceptions.ValidationError as e:
         return response_error(msg="Data error", data=e.messages, status=400)

--- a/source/app/blueprints/case/templates/case_ioc.html
+++ b/source/app/blueprints/case/templates/case_ioc.html
@@ -18,6 +18,7 @@
 
 
         {% if current_user.is_authenticated %}
+        {{ form.hidden_tag() }}
          <nav class="navbar navbar-header navbar-expand-lg pt-2 pb-2 bg-primary-gradient">
                 <div class="container-fluid">
                     <div class="collapse" id="search-nav">
@@ -36,6 +37,11 @@
                             <button class="btn btn-dark btn-sm" onclick="add_ioc();">
                                 <span class="menu-title">Add IOC</span>
                             </button>
+                        </li>
+                        <li class="nav-item">
+                            <button data-toggle="modal" class="btn btn-dark btn-sm" data-target="#modal_upload_ioc" class="btn btn-dark btn-sm">
+                                <span class="menu-title">Upload IOC list</span>
+                           </button>
                         </li>
 					</ul>
             </div>

--- a/source/app/datamgmt/case/case_iocs_db.py
+++ b/source/app/datamgmt/case/case_iocs_db.py
@@ -183,3 +183,10 @@ def add_ioc_link(ioc_id, caseid):
 
 def get_tlps():
     return [(tlp.tlp_id, tlp.tlp_name) for tlp in Tlp.query.all()]
+
+
+def get_tlps_dict():
+    tlpDict = {}
+    for tlp in Tlp.query.all():
+        tlpDict[tlp.tlp_name]=tlp.tlp_id 
+    return tlpDict

--- a/source/app/static/assets/js/iris/common.js
+++ b/source/app/static/assets/js/iris/common.js
@@ -265,6 +265,43 @@ function add_rfile() {
     return false;
 }
 
+function upload_ioc() {
+
+    var file = $("#input_upload_ioc").get(0).files[0];
+    var reader = new FileReader();
+    reader.onload = function (e) { 
+        fileData = e.target.result 
+        var data = new Object();
+        data['csrf_token'] = $('#csrf_token').val();
+        data['CSVData'] = fileData;
+        $.ajax({
+            url: '/case/ioc/upload' + case_param(),
+            type: "POST",
+            data: JSON.stringify(data),
+            contentType: "application/json;charset=UTF-8",
+            dataType: "json",
+            success: function (data) {
+                jsdata = data;
+                if (jsdata.status == "success") {
+                    reload_iocs();
+                    $('#modal_upload_ioc').modal('hide');
+                    notify_success("IOC uploaded");
+    
+                } else {
+                    notify_error("Unable to upload IOC file. " + jsdata.message)
+                }
+            },
+            error: function (error) {
+                notify_error(error.responseJSON.message);
+                propagate_form_api_errors(error.responseJSON.data);
+            }
+        });
+    };
+    reader.readAsText(file)
+
+    return false;
+}
+
 var last_state = null;
 var need_check = true;
 function update_last_resfresh() {

--- a/source/app/static/assets/js/iris/common.js
+++ b/source/app/static/assets/js/iris/common.js
@@ -302,6 +302,23 @@ function upload_ioc() {
     return false;
 }
 
+function generate_sample_csv(){
+    csv_data = "ioc_value,ioc_type,ioc_description,ioc_tags,ioc_tlp\n"
+    csv_data += "1.1.1.1,IP,Cloudfare DNS IP address,Cloudfare|DNS,green\n"
+    csv_data += "wannacry.exe,File,Wannacry sample found,Wannacry|Malware|PE,amber"
+    download_file("sample.csv", "text/csv", csv_data);
+}
+
+function download_file(filename, contentType, data) {
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:' + contentType + ';charset=utf-8,' + encodeURIComponent(data));
+    element.setAttribute('download', filename);
+    element.style.display = 'none';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+}
+
 var last_state = null;
 var need_check = true;
 function update_last_resfresh() {

--- a/source/app/templates/includes/footer.html
+++ b/source/app/templates/includes/footer.html
@@ -114,24 +114,24 @@
 
             <div class="modal-body">
                 <div class="form-group">
-                    <label for="rfile_desc" class="placeholder">File description</label>
-                    <p>The expected CSV must be in this format : </p>
-                    <p>&lt;Value&gt;,&lt;Type&gt;,&lt;Description&gt;,&lt;TLP&gt;,Tags separated with &quot;|&quot;</p>
-                    <p>Example : </p>
-                    <pre>
-                      <code>
-1.1.1.1,IP,This is a description,green,DontWorryThisIsAnExample|Cloudfare|DNS
-8.8.8.8,IP,This is a description,green,DontWorryThisIsAnExample|Google|DNS
-9.9.9.9,IP,This is a description,green,DontWorryThisIsAnExample|Quad9|DNS
-                    </code>
-                    </pre>
+                    <label for="ioc_format" class="placeholder">Expected CSV File format</label>
+                    <textarea class="form-control col-md-12 col-sm-12 sizable-textarea" rows="2" disabled>ioc_value,ioc_type,ioc_description,ioc_tags,ioc_tlp
+&lt;Value&gt;,&lt;Type&gt;,&lt;Description&gt;,&lt;TLP&gt;,Tags separated with &quot;|&quot;</textarea>
+                </div>
+                <div class="form-group">
+                    <label class="placeholder">CSV File format example</label>
+                    <textarea class="form-control col-md-12 col-sm-12 sizable-textarea" rows="3" disabled>ioc_value,ioc_type,ioc_description,ioc_tags,ioc_tlp
+1.1.1.1,IP,Cloudfare DNS IP address,Cloudfare|DNS,green
+wannacry.exe,File,Wannacry sample found,Wannacry|Malware|PE,amber</textarea> 
                 </div>
                   <div class="form-group">
+                      <label class="placeholder">Choose CSV file to import : </label>
                       <input id="input_upload_ioc" type="file" accept="text/csv">
                   </div>
             </div>
 
             <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" onclick="generate_sample_csv();">Download sample CSV</button>
               <button type="button" class="btn btn-success" onclick="upload_ioc();">Upload</button>
             </div>
           </div><!-- /.modal-content -->

--- a/source/app/templates/includes/footer.html
+++ b/source/app/templates/includes/footer.html
@@ -101,5 +101,43 @@
       </div><!-- /.modal-dialog -->
     </div>
 
+    <div class="modal fade " tabindex="-1" role="dialog" id="modal_upload_ioc" data-backdrop="true">
+      <div class="modal-lg modal-dialog" role="document">
+        <form method="post" action="" id="form_upload_ioc">
+
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5>Upload IOC list (CSV format)</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                  aria-hidden="true">&times;</span></button>
+            </div>
+
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="rfile_desc" class="placeholder">File description</label>
+                    <p>The expected CSV must be in this format : </p>
+                    <p>&lt;Value&gt;,&lt;Type&gt;,&lt;Description&gt;,&lt;TLP&gt;,Tags separated with &quot;|&quot;</p>
+                    <p>Example : </p>
+                    <pre>
+                      <code>
+1.1.1.1,IP,This is a description,green,DontWorryThisIsAnExample|Cloudfare|DNS
+8.8.8.8,IP,This is a description,green,DontWorryThisIsAnExample|Google|DNS
+9.9.9.9,IP,This is a description,green,DontWorryThisIsAnExample|Quad9|DNS
+                    </code>
+                    </pre>
+                </div>
+                  <div class="form-group">
+                      <input id="input_upload_ioc" type="file" accept="text/csv">
+                  </div>
+            </div>
+
+            <div class="modal-footer">
+              <button type="button" class="btn btn-success" onclick="upload_ioc();">Upload</button>
+            </div>
+          </div><!-- /.modal-content -->
+        </form>
+      </div><!-- /.modal-dialog -->
+    </div>
+
 
 {% endif %}


### PR DESCRIPTION
This PR : 
- allows to upload a lot of IOC at once by providing a CSV import 
- add an upload dialog that shows expected format, provide an example and a sample CSV (check screenshots in Discord)

Please note that : 
- during the process no file is uploaded to the backend, the CSV in sent to the backend as a string
- TLP are checked and converted into their respective database id
- provided data is compared to the db schema
- types are not verified (cf. below)
- recent modifications in branch "i25_ioc_management" will have impact on this code