### PR TITLE
[IMP] Limit percentage display to 2 decimals

### DIFF
--- a/source/app/static/assets/js/iris/common.js
+++ b/source/app/static/assets/js/iris/common.js
@@ -312,7 +312,7 @@ function hide_loader() {
 function get_hash() {
   getMD5(
     document.getElementById("input_autofill").files[0],
-    prog => $('#btn_rfile_proc').text("Processing "+ prog * 100 + "%")
+    prog => $('#btn_rfile_proc').text("Processing "+ (prog * 100).toFixed(2) + "%")
   ).then(
     res => on_done_hash(res),
     err => console.error(err)


### PR DESCRIPTION
When registering large evidence files the processing percentage is displayed with 10+ decimals : <img width="224" alt="Screenshot 2022-01-15 at 17 45 15" src="https://user-images.githubusercontent.com/6437862/149630220-a3d0072c-c92a-4082-9bd1-dd5a48fd731d.png">

The number of decimal is now limited to 2.