### PR TITLE
Create volume for database container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       - DB_PASS
     networks:
       - iris_backend
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
 
   app:
     build:
@@ -127,6 +130,7 @@ services:
 volumes:
   iris-downloads:
   user_templates:
+  db_data:
 
 networks:
   iris_backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,6 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
 
-
   app:
     build:
       context: .


### PR DESCRIPTION
Hey guys, 

this is my attempt on #78.

I used the docker-native volume handling.
One could argue, that writing the database to the `./docker` folder could make migrations between hosts easier, but I'm not sure, if that's really needed.

Cheers,
Matthias