### PR TITLE
[BUG] Correct tag handling in event creation

### DIFF
--- a/source/app/blueprints/case/templates/modal_add_case_event.html
+++ b/source/app/blueprints/case/templates/modal_add_case_event.html
@@ -41,14 +41,14 @@
                                                 <input class="form-control col-4" type="time" step="0.001" id="event_time" {% if event.event_date_wtz %} value="{{ event.event_date_wtz.strftime('%H:%M:%S.%f')[:-3] }}" {% else %} value="00:00:00.000" {% endif %}>
                                                 <span></span>
                                                 <input class="form-control col-2" type="text" id="event_tz" {% if event.event_tz %} value="{{ event.event_tz }}" {% else %} value="+00:00" {% endif %}>
-                                                <button class="btn btn-sm btn-outline-white" onclick="show_time_converter();return false;"><i class="fas fa-magic"></i></button>
+                                                <button class="btn btn-sm btn-outline-white" type="button" onclick="show_time_converter();return false;"><i class="fas fa-magic"></i></button>
                                         </div>
                                         <div class="row ml-2" id="event_date_convert" style="display:none;">
                                             <div class="input-group ">
                                                 <input class="form-control col-9" type="text" id="event_date_convert_input" placeholder="Enter date in any format and submit to try auto-parsing">
                                                 <div class="input-group-append">
                                                     <button class="btn btn-outline-secondary mr-2" type="button" onclick="time_converter();return false;">Submit</button>
-                                                    <button class="btn btn-sm btn-outline" onclick="hide_time_converter();return false;"><i class="fas fa-magic"></i></button>
+                                                    <button class="btn btn-sm btn-outline" type="button" onclick="hide_time_converter();return false;"><i class="fas fa-magic"></i></button>
                                                 </div>
                                             </div>
                                             <span id="convert_bad_feedback" class="text-danger"></span>


### PR DESCRIPTION
When creating or updating an event it was not possible to validate tag creation by pressing the Enter key. 
This one took me a while to figure despite the correction being this easy... Believe me, I feel shame 😄

Check out the bug : 
![demo](https://user-images.githubusercontent.com/6437862/162629487-d3e40ba9-888d-4348-a231-c33d429a9652.gif)