### PR TITLE
Fixes file size limit in evidence

### DIFF
--- a/source/app/alembic/versions/c832bd69f827_evidence_file_size_int_to_bigint.py
+++ b/source/app/alembic/versions/c832bd69f827_evidence_file_size_int_to_bigint.py
@@ -1,0 +1,28 @@
+"""Evidence file_size int to bigint
+
+Revision ID: c832bd69f827
+Revises: b664ca1203a4
+Create Date: 2022-04-11 21:49:30.739817
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c832bd69f827'
+down_revision = 'b664ca1203a4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('case_received_file', 'file_size',
+                    existing_type=sa.INTEGER(),
+                    type_=sa.BigInteger(),
+                    existing_nullable=False)
+    pass
+
+
+def downgrade():
+    pass

--- a/source/app/models/models.py
+++ b/source/app/models/models.py
@@ -557,7 +557,7 @@ class CaseReceivedFile(db.Model):
     date_added = Column(DateTime)
     file_hash = Column(String(65))
     file_description = Column(Text)
-    file_size = Column(Integer)
+    file_size = Column(BigInteger)
     case_id = Column(ForeignKey('cases.case_id'))
     user_id = Column(ForeignKey('user.id'))
     custom_attributes = Column(JSON)


### PR DESCRIPTION
Fixes #89, integer limit of file_size in table evidence. Switched to bigint which is unlikely to be reached. 