### PR TITLE
[FIX] Context switch button doesn't load cases

### DIFF
--- a/source/app/templates/includes/navigation.html
+++ b/source/app/templates/includes/navigation.html
@@ -43,7 +43,7 @@
 							</a>
 						</li>
 						<li class="nav-item hidden-caret">
-							<a class="nav-link" data-toggle="modal" title="Switch case" data-target="#modal_switch_context" href="#" role="button">
+							<a class="nav-link" title="Switch case" onclick="load_context_switcher();return false;" href="#" role="button">
 								<i class="flaticon-repeat"></i>
 							</a>
 						</li>

--- a/source/app/templates/includes/navigation_ext.html
+++ b/source/app/templates/includes/navigation_ext.html
@@ -44,7 +44,7 @@
 							</a>
 						</li>
 						<li class="nav-item hidden-caret">
-							<a class="nav-link" data-toggle="modal" title="Switch case" data-target="#modal_switch_context" href="#" role="button">
+							<a class="nav-link" title="Switch case" onclick="load_context_switcher();return false;" href="#" role="button">
 								<i class="flaticon-repeat"></i>
 							</a>
 						</li>


### PR DESCRIPTION
With the "[IMP] Reduced DB load at each page request by making switch case dynamic" commit it seems that the context switch button does not load the cases in the dropdown selector anymore. The "Current case:" hyperlink in the header does however correctly load all cases. This will implement the same fix so that cases also get dynamically loaded while pressing the context switch button.