### PR TITLE
Docx report enhancements

### DIFF
--- a/source/app/datamgmt/reporter/report_db.py
+++ b/source/app/datamgmt/reporter/report_db.py
@@ -220,6 +220,7 @@ def export_case_tm_json(case_id):
     timeline = CasesEvent.query.with_entities(
         CasesEvent.event_id,
         CasesEvent.event_title,
+        CasesEvent.event_in_summary,
         CasesEvent.event_date,
         CasesEvent.event_tz,
         CasesEvent.event_date_wtz,

--- a/source/app/iris_engine/reporter/ImageHandler.py
+++ b/source/app/iris_engine/reporter/ImageHandler.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+#
+#  IRIS Source Code
+#  Copyright (C) 2021 - Airbus CyberSecurity (SAS)
+#  ir@cyberactionlab.net
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import logging
+import os
+import shutil
+import uuid
+import re
+
+from pathlib import Path
+from docxtpl import DocxTemplate, Subdoc
+
+from docx_generator.globals.picture_globals import PictureGlobals
+
+from app.datamgmt.datastore.datastore_db import datastore_get_local_file_path
+
+class ImageHandler(PictureGlobals):
+    def __init__(self, template: DocxTemplate, base_path: str):
+        self._logger = logging.getLogger(__name__)
+        PictureGlobals.__init__(self, template, base_path)
+
+    def _process_remote(self, image_path: str) -> str:
+        """
+        Checks if the given Link is a datasotre-link and if so, save the image locally for further processing.
+        :
+        A Datastore Links looks like this: https://localhost:4433/datastore/file/view/2?cid=1
+        """
+        res = re.search(r'datastore\/file\/view\/(\d+)\?cid=(\d+)', image_path)
+        if image_path[:4] == 'http' and len(res.groups()) == 2:
+            file_id = res.groups(0)[0]
+            case_id = res.groups(0)[1]
+            has_error, dsf = datastore_get_local_file_path(file_id, case_id)
+
+            if has_error:
+                raise RenderingError(self._logger, f'File-ID {file_id} does not exist in Case {case_id}')
+            if not Path(dsf.file_local_name).is_file():
+                raise RenderingError(self._logger, f'File {dsf.file_local_name} does not exists on the server. Update or delete virtual entry')
+
+            file_ext = os.path.splitext(dsf.file_original_name)[1]
+            file_name = os.path.join(self._output_path, str(uuid.uuid4())) + file_ext
+            return_value = shutil.copy(dsf.file_local_name, file_name)
+            return return_value
+        return super()._process_remote(image_path)

--- a/source/app/iris_engine/reporter/ImageHandler.py
+++ b/source/app/iris_engine/reporter/ImageHandler.py
@@ -2,7 +2,8 @@
 #
 #  IRIS Source Code
 #  Copyright (C) 2021 - Airbus CyberSecurity (SAS)
-#  ir@cyberactionlab.net
+#  contact@dfir-iris.org
+#  Created by Lukas Zurschmiede @LukyLuke
 #
 #  This program is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU Lesser General Public

--- a/source/app/iris_engine/reporter/reporter.py
+++ b/source/app/iris_engine/reporter/reporter.py
@@ -45,6 +45,7 @@ from app.models import CasesEvent
 from app.models import Ioc
 from app.models import IocAssetLink
 from app.models import IocLink
+from app.iris_engine.reporter.ImageHandler import ImageHandler
 
 LOG_FORMAT = '%(asctime)s :: %(levelname)s :: %(module)s :: %(funcName)s :: %(message)s'
 log.basicConfig(level=log.INFO, format=LOG_FORMAT)
@@ -84,7 +85,8 @@ class IrisMakeDocReport(object):
         output_file_path = os.path.join(self._tmp, name)
 
         try:
-            generator = DocxGenerator()
+            image_handler = ImageHandler(template = None, base_path = '/')
+            generator = DocxGenerator(image_handler = image_handler)
             generator.generate_docx("/",
                                     os.path.join(app.config['TEMPLATES_PATH'], report.internal_reference),
                                     case_info,


### PR DESCRIPTION
Two changes for better reports in IRIS.


## CaseEvents

To have only the `Show in summary` timeline events in a report, this field is needed there to filter for it.
We use this for example to show the most important Events below the management summary.

## Images in Docx-Reports

Since DFIR-IRIS has a datastore where images can be attached, we need them also as evidence or whatever in our reports for the customer. For this I have implemented an ImageHandler in the docx-generator ( https://github.com/dfir-iris/docx-generator/pull/1 ) and the counterpart here to copy and append images from the datastore

Thanks for your work!
Lukas