### PR TITLE
Make docker container crash when app crashes

### DIFF
--- a/docker/webApp/iris-entrypoint.sh
+++ b/docker/webApp/iris-entrypoint.sh
@@ -26,10 +26,8 @@ target=${1-:app}
 printf "Running ${target} ...\n"
 
 if [[ "${target}" == iris-worker ]] ; then
-    celery -A app.celery worker -E -B -l INFO &
+    celery -A app.celery worker -E -B -l INFO
 else
-    gunicorn app:app --worker-class eventlet --bind 0.0.0.0:8000 --timeout 180 --worker-connections 1000 --log-level=info &
+    gunicorn app:app --worker-class eventlet --bind 0.0.0.0:8000 --timeout 180 --worker-connections 1000 --log-level=info
 fi
-
-while true; do sleep 2; done
 


### PR DESCRIPTION
Currently both the app and the worker run in the background in the docker container. If it crashes for some reason the docker container does not crash, and thus the app becomes unreachable. However, if we let the full container crash docker could restart the container.

I am not sure if there was a specific reason why it was done this way in the past. I do not see any reason why it should run in the background, but if there is any please let me know!
