### PR TITLE
Add value validation for iocs

### DIFF
--- a/source/app/alembic/versions/ad4e0cd17597_add_ioctype_validation.py
+++ b/source/app/alembic/versions/ad4e0cd17597_add_ioctype_validation.py
@@ -1,0 +1,48 @@
+"""Add IocType validation
+
+Revision ID: ad4e0cd17597
+Revises: cd519d2d24df
+Create Date: 2022-08-04 15:37:44.484997
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+from sqlalchemy import engine_from_config
+from sqlalchemy.engine import reflection
+
+revision = 'ad4e0cd17597'
+down_revision = 'cd519d2d24df'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not _table_has_column('ioc_type', 'type_validation_regex'):
+        op.add_column('ioc_type',
+                      sa.Column('type_validation_regex', sa.String(255))
+                      )
+
+    if not _table_has_column('ioc_type', 'type_validation_expect'):
+        op.add_column('ioc_type',
+                      sa.Column('type_validation_expect', sa.String(255))
+                      )
+
+
+def downgrade():
+    op.drop_column('ioc_type', 'type_validation_regex')
+
+
+def _table_has_column(table, column):
+    config = op.get_context().config
+    engine = engine_from_config(
+        config.get_section(config.config_ini_section), prefix='sqlalchemy.')
+    insp = reflection.Inspector.from_engine(engine)
+    has_column = False
+
+    for col in insp.get_columns(table):
+        if column != col['name']:
+            continue
+        has_column = True
+    return has_column

--- a/source/app/blueprints/manage/manage_ioc_types_routes.py
+++ b/source/app/blueprints/manage/manage_ioc_types_routes.py
@@ -76,6 +76,8 @@ def view_ioc_modal(cur_id, caseid, url_redir):
     form.type_name.render_kw = {'value': ioct.type_name}
     form.type_description.render_kw = {'value': ioct.type_description}
     form.type_taxonomy.data = ioct.type_taxonomy
+    form.type_validation_regex.data = ioct.type_validation_regex
+    form.type_validation_expect.data = ioct.type_validation_expect
 
     return render_template("modal_add_ioc_type.html", form=form, ioc_type=ioct)
 

--- a/source/app/blueprints/manage/templates/manage_objects.html
+++ b/source/app/blueprints/manage/templates/manage_objects.html
@@ -88,6 +88,7 @@
                                     <th>Name</th>
                                     <th>Description</th>
                                     <th>Taxonomy</th>
+                                    <th>Validation regex</th>
                                 </tr>
                             </thead>
                             <tfoot>
@@ -95,6 +96,7 @@
                                     <th>Name</th>
                                     <th>Description</th>
                                     <th>Taxonomy</th>
+                                    <th>Validation regex</th>
                                 </tr>
                             </tfoot>
                         </table>

--- a/source/app/blueprints/manage/templates/modal_add_ioc_type.html
+++ b/source/app/blueprints/manage/templates/modal_add_ioc_type.html
@@ -22,6 +22,14 @@
                     <label for="type_taxonomy" class="placeholder">Type taxonomy</label>
                     {{ form.type_taxonomy(class='form-control',  autocomplete="off") }}
                 </div>
+                <div class="form-group mt-3">
+                    <label for="type_description" class="placeholder">Type validation regex</label>
+                    {{ form.type_validation_regex(class='form-control', autocomplete="off") }}
+                </div>
+                <div class="form-group mt-3">
+                    <label for="type_description" class="placeholder">Type validation expect explanation</label>
+                    {{ form.type_validation_expect(class='form-control', autocomplete="off") }}
+                </div>
 
             {% if ioc_type.type_id %}
                 <button type="button" class="btn btn-outline-danger mt-5"

--- a/source/app/datamgmt/case/case_iocs_db.py
+++ b/source/app/datamgmt/case/case_iocs_db.py
@@ -205,6 +205,8 @@ def get_ioc_types_list():
         IocType.type_name,
         IocType.type_description,
         IocType.type_taxonomy,
+        IocType.type_validation_regex,
+        IocType.type_validation_expect,
     ).all()
 
     l_types = [row._asdict() for row in ioc_types]

--- a/source/app/forms.py
+++ b/source/app/forms.py
@@ -72,6 +72,8 @@ class AddIocTypeForm(FlaskForm):
     type_name = StringField(u'Type name', validators=[DataRequired()])
     type_description = StringField(u'Type description', validators=[DataRequired()])
     type_taxonomy = TextAreaField(u'Type taxonomy')
+    type_validation_regex = StringField(u'Type validation regex')
+    type_validation_expect = StringField(u'Type validation expectation')
 
 
 class AddCustomerForm(FlaskForm):

--- a/source/app/models/models.py
+++ b/source/app/models/models.py
@@ -398,6 +398,8 @@ class IocType(db.Model):
     type_name = Column(Text)
     type_description = Column(Text)
     type_taxonomy = Column(Text)
+    type_validation_regex = Column(Text)
+    type_validation_expect = Column(Text)
 
 
 class IocLink(db.Model):
@@ -647,7 +649,7 @@ class IrisModuleHook(db.Model):
 class IrisReport(db.Model):
     __tablename__ = 'iris_reports'
 
-    report_id = Column(db.Integer,Sequence("iris_reports_id_seq"), primary_key=True)
+    report_id = Column(db.Integer, Sequence("iris_reports_id_seq"), primary_key=True)
     case_id = Column(ForeignKey('cases.case_id'), nullable=False)
     report_title = Column(String(155))
     report_date = Column(DateTime)

--- a/source/app/post_init.py
+++ b/source/app/post_init.py
@@ -540,7 +540,9 @@ def create_safe_ioctypes():
     create_safe(db.session, IocType, type_name="attachment", type_description="Attachment with external information",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="authentihash",
-                type_description="Authenticode executable signature hash", type_taxonomy="")
+                type_description="Authenticode executable signature hash", type_taxonomy="",
+                type_validation_regex="[a-f0-9]{64}", type_validation_expect="64 hexadecimal characters"
+                )
     create_safe(db.session, IocType, type_name="boolean", type_description="Boolean value - to be used in objects",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="btc", type_description="Bitcoin Address", type_taxonomy="")
@@ -605,43 +607,61 @@ def create_safe_ioctypes():
     create_safe(db.session, IocType, type_name="filename-pattern", type_description="A pattern in the name of a file",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="filename|authentihash", type_description="A checksum in md5 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{64}', type_validation_expect="filename|64 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|impfuzzy",
                 type_description="Import fuzzy hash - a fuzzy hash created based on the imports in the sample.",
-                type_taxonomy="")
+                type_taxonomy="", )
     create_safe(db.session, IocType, type_name="filename|imphash",
-                type_description="Import hash - a hash created based on the imports in the sample.", type_taxonomy="")
+                type_description="Import hash - a hash created based on the imports in the sample.", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{32}', type_validation_expect="filename|32 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|md5",
-                type_description="A filename and an md5 hash separated by a |", type_taxonomy="")
+                type_description="A filename and an md5 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{32}', type_validation_expect="filename|32 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|pehash",
-                type_description="A filename and a PEhash separated by a |", type_taxonomy="")
+                type_description="A filename and a PEhash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{40}', type_validation_expect="filename|40 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha1",
-                type_description="A filename and an sha1 hash separated by a |", type_taxonomy="")
+                type_description="A filename and an sha1 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{40}', type_validation_expect="filename|40 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha224",
-                type_description="A filename and a sha-224 hash separated by a |", type_taxonomy="")
+                type_description="A filename and a sha-224 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{56}', type_validation_expect="filename|56 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha256",
-                type_description="A filename and an sha256 hash separated by a |", type_taxonomy="")
+                type_description="A filename and an sha256 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{64}', type_validation_expect="filename|64 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha3-224",
-                type_description="A filename and an sha3-224 hash separated by a |", type_taxonomy="")
+                type_description="A filename and an sha3-224 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{56}', type_validation_expect="filename|56 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha3-256",
-                type_description="A filename and an sha3-256 hash separated by a |", type_taxonomy="")
+                type_description="A filename and an sha3-256 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{64}', type_validation_expect="filename|64 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha3-384",
-                type_description="A filename and an sha3-384 hash separated by a |", type_taxonomy="")
+                type_description="A filename and an sha3-384 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{96}', type_validation_expect="filename|96 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha3-512",
-                type_description="A filename and an sha3-512 hash separated by a |", type_taxonomy="")
+                type_description="A filename and an sha3-512 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{128}', type_validation_expect="filename|128 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha384",
-                type_description="A filename and a sha-384 hash separated by a |", type_taxonomy="")
+                type_description="A filename and a sha-384 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{96}', type_validation_expect="filename|96 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha512",
-                type_description="A filename and a sha-512 hash separated by a |", type_taxonomy="")
+                type_description="A filename and a sha-512 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{128}', type_validation_expect="filename|128 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha512/224",
-                type_description="A filename and a sha-512/224 hash separated by a |", type_taxonomy="")
+                type_description="A filename and a sha-512/224 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{56}', type_validation_expect="filename|56 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|sha512/256",
-                type_description="A filename and a sha-512/256 hash separated by a |", type_taxonomy="")
+                type_description="A filename and a sha-512/256 hash separated by a |", type_taxonomy="",
+                type_validation_regex='.+\|[a-f0-9]{64}', type_validation_expect="filename|64 hexadecimal characters")
     create_safe(db.session, IocType, type_name="filename|ssdeep", type_description="A checksum in ssdeep format",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="filename|tlsh",
                 type_description="A filename and a Trend Micro Locality Sensitive Hash separated by a |",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex='.+\|t?[a-f0-9]{35,}',
+                type_validation_expect="filename|at least 35 hexadecimal characters, optionally starting with t1 instead of hexadecimal characters"
+                )
     create_safe(db.session, IocType, type_name="filename|vhash",
                 type_description="A filename and a VirusTotal hash separated by a |", type_taxonomy="")
     create_safe(db.session, IocType, type_name="first-name", type_description="First name of a natural person",
@@ -651,7 +671,8 @@ def create_safe_ioctypes():
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="gene", type_description="GENE - Go Evtx sigNature Engine",
                 type_taxonomy="")
-    create_safe(db.session, IocType, type_name="git-commit-id", type_description="A git commit ID.", type_taxonomy="")
+    create_safe(db.session, IocType, type_name="git-commit-id", type_description="A git commit ID.", type_taxonomy="",
+                type_validation_regex="[a-f0-9]{40}", type_validation_expect="40 hexadecimal characters")
     create_safe(db.session, IocType, type_name="github-organisation", type_description="A github organisation",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="github-repository", type_description="A github repository",
@@ -660,10 +681,12 @@ def create_safe_ioctypes():
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="hassh-md5",
                 type_description="hassh is a network fingerprinting standard which can be used to identify specific Client SSH implementations. The fingerprints can be easily stored, searched and shared in the form of an MD5 fingerprint.",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{32}", type_validation_expect="32 hexadecimal characters")
     create_safe(db.session, IocType, type_name="hasshserver-md5",
                 type_description="hasshServer is a network fingerprinting standard which can be used to identify specific Server SSH implementations. The fingerprints can be easily stored, searched and shared in the form of an MD5 fingerprint.",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{32}", type_validation_expect="32 hexadecimal characters")
     create_safe(db.session, IocType, type_name="hex", type_description="A value in hexadecimal format",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="hostname", type_description="A full host/dnsname of an attacker",
@@ -679,7 +702,8 @@ def create_safe_ioctypes():
     create_safe(db.session, IocType, type_name="impfuzzy",
                 type_description="A fuzzy hash of import table of Portable Executable format", type_taxonomy="")
     create_safe(db.session, IocType, type_name="imphash",
-                type_description="Import hash - a hash created based on the imports in the sample.", type_taxonomy="")
+                type_description="Import hash - a hash created based on the imports in the sample.", type_taxonomy="",
+                type_validation_regex="[a-f0-9]{32}", type_validation_expect="32 hexadecimal characters")
     create_safe(db.session, IocType, type_name="ip-any",
                 type_description="A source or destination IP address of the attacker or C&C server", type_taxonomy="")
     create_safe(db.session, IocType, type_name="ip-dst",
@@ -692,10 +716,12 @@ def create_safe_ioctypes():
                 type_description="IP source and port number separated by a |", type_taxonomy="")
     create_safe(db.session, IocType, type_name="ja3-fingerprint-md5",
                 type_description="JA3 is a method for creating SSL/TLS client fingerprints that should be easy to produce on any platform and can be easily shared for threat intelligence.",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{32}", type_validation_expect="32 hexadecimal characters")
     create_safe(db.session, IocType, type_name="jabber-id", type_description="Jabber ID", type_taxonomy="")
     create_safe(db.session, IocType, type_name="jarm-fingerprint",
-                type_description="JARM is a method for creating SSL/TLS server fingerprints.", type_taxonomy="")
+                type_description="JARM is a method for creating SSL/TLS server fingerprints.", type_taxonomy="",
+                type_validation_regex="[a-f0-9]{62}", type_validation_expect="62 hexadecimal characters")
     create_safe(db.session, IocType, type_name="kusto-query",
                 type_description="Kusto query - Kusto from Microsoft Azure is a service for storing and running interactive analytics over Big Data.",
                 type_taxonomy="")
@@ -706,7 +732,8 @@ def create_safe_ioctypes():
     create_safe(db.session, IocType, type_name="malware-sample",
                 type_description="Attachment containing encrypted malware sample", type_taxonomy="")
     create_safe(db.session, IocType, type_name="malware-type", type_description="Malware type", type_taxonomy="")
-    create_safe(db.session, IocType, type_name="md5", type_description="A checksum in md5 format", type_taxonomy="")
+    create_safe(db.session, IocType, type_name="md5", type_description="A checksum in md5 format", type_taxonomy="",
+                type_validation_regex="[a-f0-9]{32}", type_validation_expect="32 hexadecimal characters")
     create_safe(db.session, IocType, type_name="middle-name", type_description="Middle name of a natural person",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="mime-type",
@@ -731,7 +758,8 @@ def create_safe_ioctypes():
                 type_description="Microsoft Program database (PDB) path information", type_taxonomy="")
     create_safe(db.session, IocType, type_name="pehash",
                 type_description="PEhash - a hash calculated based of certain pieces of a PE executable file",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{40}", type_validation_expect="40 hexadecimal characters")
     create_safe(db.session, IocType, type_name="pgp-private-key", type_description="A PGP private key",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="pgp-public-key", type_description="A PGP public key", type_taxonomy="")
@@ -743,27 +771,38 @@ def create_safe_ioctypes():
     create_safe(db.session, IocType, type_name="regkey", type_description="Registry key or value", type_taxonomy="")
     create_safe(db.session, IocType, type_name="regkey|value", type_description="Registry value + data separated by |",
                 type_taxonomy="")
-    create_safe(db.session, IocType, type_name="sha1", type_description="A checksum in sha1 format", type_taxonomy="")
+    create_safe(db.session, IocType, type_name="sha1", type_description="A checksum in sha1 format", type_taxonomy="",
+                type_validation_regex="[a-f0-9]{40}", type_validation_expect="40 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha224", type_description="A checksum in sha-224 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{56}", type_validation_expect="56 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha256", type_description="A checksum in sha256 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{64}", type_validation_expect="64 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha3-224", type_description="A checksum in sha3-224 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{56}", type_validation_expect="56 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha3-256", type_description="A checksum in sha3-256 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{64}", type_validation_expect="64 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha3-384", type_description="A checksum in sha3-384 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{96}", type_validation_expect="96 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha3-512", type_description="A checksum in sha3-512 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{128}", type_validation_expect="128 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha384", type_description="A checksum in sha-384 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{96}", type_validation_expect="96 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha512", type_description="A checksum in sha-512 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{128}", type_validation_expect="128 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha512/224", type_description="A checksum in the sha-512/224 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{56}", type_validation_expect="56 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sha512/256", type_description="A checksum in the sha-512/256 format",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{64}", type_validation_expect="64 hexadecimal characters")
     create_safe(db.session, IocType, type_name="sigma",
                 type_description="Sigma - Generic Signature Format for SIEM Systems", type_taxonomy="")
     create_safe(db.session, IocType, type_name="size-in-bytes", type_description="Size expressed in bytes",
@@ -789,12 +828,15 @@ def create_safe_ioctypes():
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="telfhash",
                 type_description="telfhash is symbol hash for ELF files, just like imphash is imports hash for PE files.",
-                type_taxonomy="")
+                type_taxonomy="",
+                type_validation_regex="[a-f0-9]{70}", type_validation_expect="70 hexadecimal characters")
     create_safe(db.session, IocType, type_name="text", type_description="Name, ID or a reference", type_taxonomy="")
     create_safe(db.session, IocType, type_name="threat-actor", type_description="A string identifying the threat actor",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="tlsh",
-                type_description="A checksum in the Trend Micro Locality Sensitive Hash format", type_taxonomy="")
+                type_description="A checksum in the Trend Micro Locality Sensitive Hash format", type_taxonomy="",
+                type_validation_regex="^t?[a-f0-9]{35,}",
+                type_validation_expect="at least 35 hexadecimal characters, optionally starting with t1 instead of hexadecimal characters")
     create_safe(db.session, IocType, type_name="travel-details", type_description="Travel details", type_taxonomy="")
     create_safe(db.session, IocType, type_name="twitter-id", type_description="Twitter ID", type_taxonomy="")
     create_safe(db.session, IocType, type_name="uri", type_description="Uniform Resource Identifier", type_taxonomy="")
@@ -832,11 +874,14 @@ def create_safe_ioctypes():
                 type_description="A windows service name. This is the name used internally by windows. Not to be confused with the windows-service-displayname.",
                 type_taxonomy="")
     create_safe(db.session, IocType, type_name="x509-fingerprint-md5",
-                type_description="X509 fingerprint in MD5 format", type_taxonomy="")
+                type_description="X509 fingerprint in MD5 format", type_taxonomy="",
+                type_validation_regex="[a-f0-9]{32}", type_validation_expect="32 hexadecimal characters")
     create_safe(db.session, IocType, type_name="x509-fingerprint-sha1",
-                type_description="X509 fingerprint in SHA-1 format", type_taxonomy="")
+                type_description="X509 fingerprint in SHA-1 format", type_taxonomy="",
+                type_validation_regex="[a-f0-9]{40}", type_validation_expect="40 hexadecimal characters")
     create_safe(db.session, IocType, type_name="x509-fingerprint-sha256",
-                type_description="X509 fingerprint in SHA-256 format", type_taxonomy="")
+                type_description="X509 fingerprint in SHA-256 format", type_taxonomy="",
+                type_validation_regex="[a-f0-9]{64}", type_validation_expect="64 hexadecimal characters")
     create_safe(db.session, IocType, type_name="xmr", type_description="Monero Address", type_taxonomy="")
     create_safe(db.session, IocType, type_name="yara", type_description="Yara signature", type_taxonomy="")
     create_safe(db.session, IocType, type_name="zeek", type_description="An NIDS rule in the Zeek rule-format",

--- a/source/app/schema/marshables.py
+++ b/source/app/schema/marshables.py
@@ -18,6 +18,8 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import datetime
+import re
+
 from flask_login import current_user
 
 from pathlib import Path
@@ -189,7 +191,7 @@ class IocSchema(ma.SQLAlchemyAutoSchema):
 
     @pre_load
     def verify_data(self, data, **kwargs):
-        ioc_type = IocType.query.filter(IocType.type_id == data.get('ioc_type_id')).count()
+        ioc_type = IocType.query.filter(IocType.type_id == data.get('ioc_type_id')).first()
         if not ioc_type:
             raise marshmallow.exceptions.ValidationError("Invalid ioc type ID",
                                                          field_name="ioc_type_id")
@@ -198,6 +200,13 @@ class IocSchema(ma.SQLAlchemyAutoSchema):
         if not tlp_id:
             raise marshmallow.exceptions.ValidationError("Invalid TLP ID",
                                                          field_name="ioc_tlp_id")
+
+        if ioc_type.type_validation_regex:
+            if not re.fullmatch(ioc_type.type_validation_regex, data.get('ioc_value'), re.IGNORECASE):
+                error = f"The input doesn\'t match the expected format " \
+                        f"(expected: {ioc_type.type_validation_expect or ioc_type.type_validation_regex})"
+                raise marshmallow.exceptions.ValidationError(error,
+                                                             field_name="ioc_ioc_value")
 
         return data
 
@@ -449,6 +458,8 @@ class IocTypeSchema(ma.SQLAlchemyAutoSchema):
     type_name = auto_field('type_name', required=True, validate=Length(min=2), allow_none=False)
     type_description = auto_field('type_description', required=True, validate=Length(min=2), allow_none=False)
     type_taxonomy = auto_field('type_taxonomy')
+    type_validation_regex = auto_field('type_validation_regex')
+    type_validation_expect = auto_field('type_validation_expect')
 
     class Meta:
         model = IocType

--- a/source/app/static/assets/js/iris/manage_objects.js
+++ b/source/app/static/assets/js/iris/manage_objects.js
@@ -216,6 +216,13 @@ $('#ioc_table').dataTable({
                 if (type === 'display') { data = sanitizeHTML(data);}
                 return data;
             }
+        },
+        {
+            "data": "type_validation_regex",
+            "render": function ( data, type, row ) {
+                if (type === 'display') { data = sanitizeHTML(data);}
+                return data;
+            }
         }
     ]
  });


### PR DESCRIPTION
Currently the IoC values are allowing everything as value. However, it might be good to check that they match the value of the selected type. This PR implements this by adding a regex field to IocType, which will be checked during validation.

Currently I only added regex for the hashes, and the filename|hash types. But after this method is in place it is easy to add more regex values. If a user decides to add a custom type it also easy to add a regex, since it is expose to the UI as well.