### PR TITLE
Change CELERY_HOST to CELERY_BROKER

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -23,4 +23,4 @@ SECRET_KEY=AVerySuperSecretKey-SoNotThisOne
 SECURITY_PASSWORD_SALT=ARandomSalt-NotThisOneEither
 ## WORKER
 IRIS_WORKER=1
-CELERY_HOST=rabbitmq
+CELERY_BROKER=amqp://rabbitmq

--- a/source/app/config.docker.ini
+++ b/source/app/config.docker.ini
@@ -11,7 +11,7 @@ SECRET_KEY = AVerySuperSecretKey-SoNotThisOne
 SECURITY_PASSWORD_SALT = ARandomSalt-NotThisOneEither
 
 [CELERY]
-HOST = rabbitmq
+BROKER = amqp://rabbitmq
 
 [DEVELOPMENT]
 IS_DEV_INSTANCE = False

--- a/source/app/config.model.ini
+++ b/source/app/config.model.ini
@@ -11,7 +11,7 @@ SECRET_KEY = AVerySuperSecretKey-SoNotThisOne
 SECURITY_PASSWORD_SALT = ARandomSalt-NotThisOneEither
 
 [CELERY]
-HOST = localhost
+BROKER = amqp://localhost
 
 [DEVELOPMENT]
 IS_DEV_INSTANCE = False

--- a/source/app/configuration.py
+++ b/source/app/configuration.py
@@ -37,7 +37,7 @@ PGA_ACCOUNT_ = os.environ.get('POSTGRES_USER', config.get('POSTGRES', 'PGA_ACCOU
 PGA_PASSWD_ = os.environ.get('POSTGRES_PASSWORD', config.get('POSTGRES', 'PGA_PASSWD'))
 PG_SERVER_ = os.environ.get('DB_HOST', config.get('POSTGRES', 'PG_SERVER'))
 PG_PORT_ = os.environ.get('DB_PORT', config.get('POSTGRES', 'PG_PORT'))
-CELERY_HOST_ = os.environ.get('CELERY_HOST', config.get('CELERY', 'HOST'))
+CELERY_BROKER_ = os.environ.get('CELERY_BROKER', config.get('CELERY', 'BROKER'))
 
 if os.environ.get('IRIS_WORKER') is None:
     # Flask needs it for CSRF token and stuff
@@ -62,8 +62,10 @@ SQLALCHEMY_BASEA_URI = "postgresql+psycopg2://{user}:{passwd}@{server}:{port}/".
 
 # --------- CELERY ---------
 class CeleryConfig():
+
+    print(CELERY_BROKER_)
     result_backend = "db+" + SQLALCHEMY_BASE_URI + "iris_tasks"  # use database as storage
-    broker_url = f"amqp://{CELERY_HOST_}"
+    broker_url = CELERY_BROKER_
     result_extended = True
     result_serializer = "json"
     worker_pool_restarts = True


### PR DESCRIPTION
In #129 I made the Celery Host configurable, however it was still limited to rabbitmq only. This PR changes it to use a full broker url, which allows to use all different brokers celery supports.