### PR TITLE
Do not escape_filter_chars for NTLM username

### DIFF
--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -32,9 +32,9 @@ def ldap_authenticate(ldap_user_name, ldap_user_pwd):
     """
     Authenticate to the LDAP server
     """
-    ldap_user_name = conv.escape_filter_chars(ldap_user_name)
     ldap_user_pwd = conv.escape_filter_chars(ldap_user_pwd)
     if app.config.get("LDAP_AUTHENTICATION_TYPE").lower() != 'ntlm':
+        ldap_user_name = conv.escape_filter_chars(ldap_user_name)
         ldap_user = f"{app.config.get('LDAP_USER_PREFIX')}{ldap_user_name.strip()},{app.config.get('LDAP_USER_SUFFIX')}"
     else:
         ldap_user = f"{ldap_user_name.strip()}"


### PR DESCRIPTION
In order to close #210 switching the escape_filter_chars in the non-NTLM section is resolving the issue of the backslash not being escape properly.