### PR TITLE
Update nginx.conf for Security HTTP headers to work.

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -102,14 +102,6 @@ http {
     access_log /var/log/nginx/audit_platform_access.log main;
     error_log  /var/log/nginx/audit_platform_error.log debug;
 
-    # SECURITY HEADERS
-    add_header X-XSS-Protection             "1; mode=block";
-    add_header X-Frame-Options              DENY;
-    add_header X-Content-Type-Options       nosniff;
-    # max-age = 31536000s = 1 year
-    add_header Strict-Transport-Security    "max-age=31536000: includeSubDomains" always;
-    add_header Front-End-Https              on;
-
     server {
         listen          ${INTERFACE_HTTPS_PORT} ssl;
         server_name     ${SERVER_NAME};
@@ -118,6 +110,14 @@ http {
         error_page      500 502 503 504  /50x.html;
 
         add_header Content-Security-Policy $csp_header;
+        
+        # SECURITY HEADERS
+        add_header X-XSS-Protection             "1; mode=block";
+        add_header X-Frame-Options              DENY;
+        add_header X-Content-Type-Options       nosniff;
+        # max-age = 31536000s = 1 year
+        add_header Strict-Transport-Security    "max-age=31536000: includeSubDomains" always;
+        add_header Front-End-Https              on;
 
         location / {
             proxy_pass  http://${IRIS_UPSTREAM_SERVER}:${IRIS_UPSTREAM_PORT};


### PR DESCRIPTION
Modify the location of Security Headers in a way that nginx would accept the headers and send them to the client.

In the current configuration the Security Headers are not presented to the client.