### PR TITLE
Some configuration checks when LDAP and automatic user creation are set

### DIFF
--- a/source/app/configuration.py
+++ b/source/app/configuration.py
@@ -404,7 +404,12 @@ class Config:
         LDAP_AUTHENTICATION_TYPE = config.load('LDAP', 'AUTHENTICATION_TYPE')
 
         LDAP_SEARCH_DN = config.load('LDAP', 'SEARCH_DN')
+        if authentication_create_user_if_not_exists and LDAP_SEARCH_DN is None:
+            raise Exception('LDAP enabled with user provisioning: LDAP_SEARCH_DN should be set')
         LDAP_ATTRIBUTE_IDENTIFIER = config.load('LDAP', 'ATTRIBUTE_IDENTIFIER')
+        if authentication_create_user_if_not_exists and LDAP_ATTRIBUTE_IDENTIFIER is None:
+            raise Exception('LDAP enabled with user provisioning: LDAP_ATTRIBUTE_IDENTIFIER should be set')
+
         LDAP_ATTRIBUTE_DISPLAY_NAME = config.load('LDAP', 'ATTRIBUTE_DISPLAY_NAME')
         LDAP_ATTRIBUTE_MAIL = config.load('LDAP', 'ATTRIBUTE_MAIL')
 


### PR DESCRIPTION
These are just some additional configuration checks to help the user avoid configuration states the code will not be able to handle.
