### PR TITLE
Add newly created users after a LDAP authentication to group Analysts

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -32,6 +32,8 @@ IRIS_AUTHENTICATION_TYPE=local
 #IRIS_ADM_USERNAME=administrator
 # requests the just-in-time creation of users with ldap authentification (see https://github.com/dfir-iris/iris-web/issues/203)
 #IRIS_AUTHENTICATION_CREATE_USER_IF_NOT_EXIST=True
+# the group to which newly created users are initially added, default value is Analysts
+#IRIS_NEW_USERS_DEFAULT_GROUP=
 
 # -- FOR LDAP AUTHENTICATION
 #IRIS_AUTHENTICATION_TYPE=ldap

--- a/source/app/configuration.py
+++ b/source/app/configuration.py
@@ -366,6 +366,7 @@ class Config:
 
     AUTHENTICATION_TYPE = authentication_type
     AUTHENTICATION_CREATE_USER_IF_NOT_EXIST = (authentication_create_user_if_not_exists == "True")
+    IRIS_NEW_USERS_DEFAULT_GROUP = config.load('IRIS', 'NEW_USERS_DEFAULT_GROUP', fallback='Analysts')
 
     if authentication_type == 'oidc_proxy':
         AUTHENTICATION_LOGOUT_URL = authentication_logout_url

--- a/source/app/datamgmt/manage/manage_groups_db.py
+++ b/source/app/datamgmt/manage/manage_groups_db.py
@@ -80,6 +80,11 @@ def get_group(group_id):
     return group
 
 
+def get_group_by_name(group_name):
+    groups = Group.query.filter(Group.group_name == group_name)
+    return groups.first()
+
+
 def get_group_with_members(group_id):
     group = get_group(group_id)
     if not group:

--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -30,7 +30,7 @@ from app import app
 from app.datamgmt.manage.manage_users_db import get_active_user_by_login
 from app.datamgmt.manage.manage_users_db import create_user
 from app.datamgmt.manage.manage_users_db import add_user_to_group
-from app.iris_engine.access_control.utils import ac_get_group_analysts
+from app.datamgmt.manage.manage_groups_db import get_group_by_name
 
 log = app.logger
 
@@ -75,8 +75,8 @@ def _provision_user(connection, user_login):
     # TODO It seems email unicity is required (a fixed email causes a problem at the second account creation)
     #      The email either comes from the ldap or is forged from the login to ensure unicity
     user = create_user(user_name, user_login, password, user_email, True)
-    ganalysts = ac_get_group_analysts()
-    add_user_to_group(user.id, ganalysts.group_id)
+    initial_group = get_group_by_name(app.config.get('IRIS_NEW_USERS_DEFAULT_GROUP'))
+    add_user_to_group(user.id, initial_group.group_id)
 
 
 def ldap_authenticate(ldap_user_name, ldap_user_pwd):

--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -27,7 +27,10 @@ from ldap3 import Tls
 from ldap3.utils import conv
 
 from app import app
-from app.datamgmt.manage.manage_users_db import create_user, get_active_user_by_login
+from app.datamgmt.manage.manage_users_db import get_active_user_by_login
+from app.datamgmt.manage.manage_users_db import create_user
+from app.datamgmt.manage.manage_users_db import add_user_to_group
+from app.iris_engine.access_control.utils import ac_get_group_analysts
 
 log = app.logger
 
@@ -71,7 +74,9 @@ def _provision_user(connection, user_login):
     password = ''.join(random.choices(string.printable[:-6], k=16))
     # TODO It seems email unicity is required (a fixed email causes a problem at the second account creation)
     #      The email either comes from the ldap or is forged from the login to ensure unicity
-    create_user(user_name, user_login, password, user_email, True)
+    user = create_user(user_name, user_login, password, user_email, True)
+    ganalysts = ac_get_group_analysts()
+    add_user_to_group(user.id, ganalysts.group_id)
 
 
 def ldap_authenticate(ldap_user_name, ldap_user_pwd):

--- a/source/app/iris_engine/access_control/utils.py
+++ b/source/app/iris_engine/access_control/utils.py
@@ -63,6 +63,12 @@ def ac_combine_groups_access(groups_list):
     return users
 
 
+def ac_get_group_analysts():
+    return Group.query.filter(
+        Group.group_name == "Analysts"
+    ).first()
+
+
 def ac_get_mask_analyst():
     """
     Return a standard access mask for analysts

--- a/source/app/iris_engine/access_control/utils.py
+++ b/source/app/iris_engine/access_control/utils.py
@@ -63,12 +63,6 @@ def ac_combine_groups_access(groups_list):
     return users
 
 
-def ac_get_group_analysts():
-    return Group.query.filter(
-        Group.group_name == "Analysts"
-    ).first()
-
-
 def ac_get_mask_analyst():
     """
     Return a standard access mask for analysts

--- a/source/app/post_init.py
+++ b/source/app/post_init.py
@@ -43,7 +43,7 @@ from app.datamgmt.manage.manage_users_db import add_user_to_organisation
 from app.iris_engine.access_control.utils import ac_add_user_effective_access
 from app.iris_engine.demo_builder import create_demo_cases
 from app.iris_engine.access_control.utils import ac_get_mask_analyst
-from app.iris_engine.access_control.utils import ac_get_group_analysts
+from app.datamgmt.manage.manage_groups_db import get_group_by_name
 from app.iris_engine.access_control.utils import ac_get_mask_full_permissions
 from app.iris_engine.module_handler.module_handler import check_module_health
 from app.iris_engine.module_handler.module_handler import instantiate_module_from_name
@@ -691,7 +691,7 @@ def create_safe_auth_model():
     except exc.IntegrityError:
         db.session.rollback()
         log.warning('Analysts group integrity error. Group permissions were probably changed. Updating.')
-        ganalysts = ac_get_group_analysts()
+        ganalysts = get_group_by_name("Analysts")
 
     if ganalysts.group_permissions != ac_get_mask_analyst():
         ganalysts.group_permissions = ac_get_mask_analyst()

--- a/source/app/post_init.py
+++ b/source/app/post_init.py
@@ -43,6 +43,7 @@ from app.datamgmt.manage.manage_users_db import add_user_to_organisation
 from app.iris_engine.access_control.utils import ac_add_user_effective_access
 from app.iris_engine.demo_builder import create_demo_cases
 from app.iris_engine.access_control.utils import ac_get_mask_analyst
+from app.iris_engine.access_control.utils import ac_get_group_analysts
 from app.iris_engine.access_control.utils import ac_get_mask_full_permissions
 from app.iris_engine.module_handler.module_handler import check_module_health
 from app.iris_engine.module_handler.module_handler import instantiate_module_from_name
@@ -690,9 +691,7 @@ def create_safe_auth_model():
     except exc.IntegrityError:
         db.session.rollback()
         log.warning('Analysts group integrity error. Group permissions were probably changed. Updating.')
-        ganalysts = Group.query.filter(
-            Group.group_name == "Analysts"
-        ).first()
+        ganalysts = ac_get_group_analysts()
 
     if ganalysts.group_permissions != ac_get_mask_analyst():
         ganalysts.group_permissions = ac_get_mask_analyst()


### PR DESCRIPTION
When IRIS_AUTHENTICATION_CREATE_USER_IF_NOT_EXIST is true and the authentication type is ldap, then users that do not yet exist in the IRIS database are automatically created during their first login.
This is a proposition to also add these newly created users into the group Analysts. Otherwise, they can't do much with the tool.
This suits best to our current use-case. However, there are probably alternatives. For instance, the default permissions/groups could be configurable, or maybe extracted from the ldap...

Note: in order to avoid code duplication, I introduced method `ac_get_group_analysts` in `app.iris_engine.access_control.utils` (it's called from both the `post_init` and `ldap_handler`). However, I hesitated about where to put this method: it may equally well find itself in `app.datamgmt.manage.manage_groups_db`, or yet some other place...