### PR TITLE
Delete character escaping for passwords

### DIFF
--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -78,7 +78,6 @@ def ldap_authenticate(ldap_user_name, ldap_user_pwd):
     """
     Authenticate to the LDAP server
     """
-    ldap_user_pwd = conv.escape_filter_chars(ldap_user_pwd)
     if app.config.get('LDAP_AUTHENTICATION_TYPE').lower() != 'ntlm':
         ldap_user_name = conv.escape_filter_chars(ldap_user_name)
         ldap_user = f"{app.config.get('LDAP_USER_PREFIX')}{ldap_user_name.strip()}{ ','+app.config.get('LDAP_USER_SUFFIX') if app.config.get('LDAP_USER_SUFFIX') else ''}"


### PR DESCRIPTION
Hello,

Escaping character will cause passwords check failure in case of characters like ```*``` (I would tend to think that no escape_filter_chars() is needed at all in this file).

This is a pull request so passwords with "strange" characters can work.

Kind regards.