### PR TITLE
Have the REST request that registers a module return the module information

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.1
+current_version = 2.2.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>.*)-(?P<build>\d+))?

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center">
   Incident Response Investigation System
   <br>
-  <i>Current Version v2.2.1</i>
+  <i>Current Version v2.2.2</i>
   <br>
   <a href="https://v200.beta.dfir-iris.org">Online Demonstration</a>
 </p>
@@ -52,7 +52,7 @@ git clone https://github.com/dfir-iris/iris-web.git
 cd iris-web
 
 # Checkout to the last tagged version 
-git checkout v2.2.1
+git checkout v2.2.2
 
 # Copy the environment file 
 cp .env.model .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     build:
       context: docker/db
     container_name: iriswebapp_db
-    image: iriswebapp_db:v2.2.1
+    image: iriswebapp_db:v2.2.2
     restart: always
     # Used for debugging purposes, should be deleted for production
     ports:
@@ -48,7 +48,7 @@ services:
     build:
       context: .
       dockerfile: docker/webApp/Dockerfile
-    image: iriswebapp_app:v2.2.1
+    image: iriswebapp_app:v2.2.2
     container_name: iriswebapp_app
     command: ['nohup', './iris-entrypoint.sh', 'iriswebapp']
     volumes:
@@ -86,7 +86,7 @@ services:
     build:
       context: .
       dockerfile: docker/webApp/Dockerfile
-    image: iriswebapp_app:v2.2.1
+    image: iriswebapp_app:v2.2.2
     container_name: iriswebapp_worker
     command: ['./wait-for-iriswebapp.sh', 'app:8000', './iris-entrypoint.sh', 'iris-worker']
     volumes:
@@ -122,7 +122,7 @@ services:
       args:
         NGINX_CONF_GID: 1234
         NGINX_CONF_FILE: nginx.conf
-    image: iriswebapp_nginx:v2.2.1
+    image: iriswebapp_nginx:v2.2.2
     container_name: iriswebapp_nginx
     environment:
       - IRIS_UPSTREAM_SERVER

--- a/source/app/configuration.py
+++ b/source/app/configuration.py
@@ -265,7 +265,7 @@ class CeleryConfig:
 # --------- APP ---------
 class Config:
     # Handled by bumpversion
-    IRIS_VERSION = "v2.2.1"
+    IRIS_VERSION = "v2.2.2"
 
     API_MIN_VERSION = "2.0.0"
     API_MAX_VERSION = "2.0.2"

--- a/source/app/datamgmt/iris_engine/modules_db.py
+++ b/source/app/datamgmt/iris_engine/modules_db.py
@@ -63,7 +63,7 @@ def iris_module_add(module_name, module_human_name, module_description,
     except Exception:
         return None
 
-    return im.id
+    return im
 
 
 def is_mod_configured(mod_config):

--- a/source/app/iris_engine/module_handler/module_handler.py
+++ b/source/app/iris_engine/module_handler/module_handler.py
@@ -257,25 +257,25 @@ def register_module(module_name):
 
     if not module_name:
         log.error("Provided module has no names")
-        return None, ["Module has no names"]
+        return None, "Module has no names"
 
     try:
 
         mod_inst, _ = instantiate_module_from_name(module_name=module_name)
         if not mod_inst:
             log.error("Module could not be instantiated")
-            return None, ["Module could not be instantiated"]
+            return None, "Module could not be instantiated"
 
         if iris_module_exists(module_name=module_name):
             log.warning("Module already exists in Iris")
-            return None, ["Module already exists in Iris"]
+            return None, "Module already exists in Iris"
 
         # Auto parse the configuration and fill with default
         log.info('Parsing configuration')
         mod_config = preset_init_mod_config(mod_inst.get_init_configuration())
 
         log.info('Adding module')
-        modu_id = iris_module_add(module_name=module_name,
+        module = iris_module_add(module_name=module_name,
                                   module_human_name=mod_inst.get_module_name(),
                                   module_description=mod_inst.get_module_description(),
                                   module_config=mod_config,
@@ -286,16 +286,16 @@ def register_module(module_name):
                                   module_type=mod_inst.get_module_type()
                                   )
 
-        if not modu_id:
-            return None, ["Unable to register module"]
+        if module is None:
+            return None, "Unable to register module"
 
         if mod_inst.get_module_type() == 'module_processor':
-            mod_inst.register_hooks(module_id=modu_id)
+            mod_inst.register_hooks(module_id=module.id)
 
     except Exception as e:
-        return None, ["Fatal - {}".format(e.__str__())]
+        return None, "Fatal - {}".format(e.__str__())
 
-    return modu_id, ["Module registered"]
+    return module, "Module registered"
 
 
 def iris_update_hooks(module_name, module_id):

--- a/source/app/post_init.py
+++ b/source/app/post_init.py
@@ -1443,21 +1443,21 @@ def register_default_modules():
     modules = ['iris_vt_module', 'iris_misp_module', 'iris_check_module',
                'iris_webhooks_module', 'iris_intelowl_module']
 
-    for module in modules:
-        class_, _ = instantiate_module_from_name(module)
+    for module_name in modules:
+        class_, _ = instantiate_module_from_name(module_name)
         is_ready, logs = check_module_health(class_)
 
         if not is_ready:
-            log.info("Attempted to initiate {mod}. Got {err}".format(mod=module, err=",".join(logs)))
+            log.info("Attempted to initiate {mod}. Got {err}".format(mod=module_name, err=",".join(logs)))
             return False
 
-        mod_id, logs = register_module(module)
-        if mod_id is None:
-            log.info("Attempted to add {mod}. Got {err}".format(mod=module, err=",".join(logs)))
+        module, logs = register_module(module_name)
+        if module is None:
+            log.info("Attempted to add {mod}. Got {err}".format(mod=module_name, err=",".join(logs)))
 
         else:
-            iris_module_disable_by_id(mod_id)
-            log.info('Successfully registered {mod}'.format(mod=module))
+            iris_module_disable_by_id(module.id)
+            log.info('Successfully registered {mod}'.format(mod=module_name))
 
 def custom_assets_symlinks():
     try:

--- a/source/app/schema/marshables.py
+++ b/source/app/schema/marshables.py
@@ -72,6 +72,7 @@ from app.models.authorization import Group
 from app.models.authorization import Organisation
 from app.models.authorization import User
 from app.models.cases import CaseState
+from app.models import IrisModule
 from app.util import file_sha256sum, str_to_bool
 from app.util import stream_sha256sum
 
@@ -995,3 +996,8 @@ class SavedFilterSchema(ma.SQLAlchemyAutoSchema):
         include_fk = True
         include_relationships = True
 
+
+class IrisModuleSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = IrisModule
+        load_instance = True


### PR DESCRIPTION
Here is a proposition so that request POST `/manage/modules/add` returns the newly registered module information.
This need arises with the automation of a DFIR-IRIS deployment. In some cases, after DFIR-IRIS is deployed, we want to register and then configure a module automatically. To do so we first perform a POST on `/manage/modules/add` and then a POST on `/manage/modules/import-config/{module_identifier}` using ansible. So in order to configure the module we need to know the module identifier. Unfortunately, for the time being, route `/manage/modules/add` does not return this information.