### PR TITLE
Fix task_hook_wrapper

### DIFF
--- a/source/app/iris_engine/module_handler/module_handler.py
+++ b/source/app/iris_engine/module_handler/module_handler.py
@@ -452,9 +452,10 @@ def task_hook_wrapper(self, module_name, hook_name, hook_ui_name, data, init_use
         if isinstance(deser_data, list):
             _obj = []
             for dse_data in deser_data:
-                obj = db.session.merge(dse_data)
-                db.session.commit()
-                _obj.append(obj)
+                if not isinstance(dse_data, int):
+                    obj = db.session.merge(dse_data)
+                    db.session.commit()
+                    _obj.append(obj)
 
         elif isinstance(deser_data, str) or isinstance(deser_data, int):
             _obj = [deser_data]


### PR DESCRIPTION
When we run that module against an IOC, the value of deser_data is a list containing an integer and an object. Inside the for loop, the dse_data takes the integer value and cannot be merged inside the database. We need the object from that list. Added check for filtering out the integer values.