### PR TITLE
Issue #252 Case insensitive login

### DIFF
--- a/source/app/blueprints/case/case_tasks_routes.py
+++ b/source/app/blueprints/case/case_tasks_routes.py
@@ -32,6 +32,7 @@ from flask_wtf import FlaskForm
 
 from app import db
 from app.blueprints.case.case_comments import case_comment_update
+from app.datamgmt.manage.manage_users_db import get_user
 from app.datamgmt.case.case_db import get_case
 from app.datamgmt.case.case_tasks_db import add_comment_to_task
 from app.datamgmt.case.case_tasks_db import add_task
@@ -205,10 +206,10 @@ def case_task_view_modal(cur_id, caseid, url_redir):
 
     form.task_title.render_kw = {'value': task.task_title}
     form.task_description.data = task.task_description
-    user_name, = User.query.with_entities(User.name).filter(User.id == task.task_userid_update).first()
+    user = get_user(task.task_userid_update)
     comments_map = get_case_tasks_comments_count([task.id])
 
-    return render_template("modal_add_case_task.html", form=form, task=task, user_name=user_name,
+    return render_template("modal_add_case_task.html", form=form, task=task, user_name=user.name,
                            comments_map=comments_map, attributes=task.custom_attributes)
 
 

--- a/source/app/blueprints/case/case_timeline_routes.py
+++ b/source/app/blueprints/case/case_timeline_routes.py
@@ -57,6 +57,7 @@ from app.datamgmt.case.case_events_db import update_event_assets
 from app.datamgmt.case.case_events_db import update_event_iocs
 from app.datamgmt.case.case_iocs_db import get_ioc_by_value
 from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
+from app.datamgmt.manage.manage_users_db import get_user
 from app.datamgmt.states import get_timeline_state
 from app.datamgmt.states import update_timeline_state
 from app.forms import CaseEventForm
@@ -749,9 +750,9 @@ def event_view_modal(cur_id, caseid, url_redir):
     iocs_prefill = get_event_iocs_ids(cur_id, caseid)
     comments_map = get_case_events_comments_count([cur_id])
 
-    usr_name, = User.query.filter(User.id == event.user_id).with_entities(User.name).first()
+    user = get_user(event.user_id)
 
-    return render_template("modal_add_case_event.html", form=form, event=event, user_name=usr_name, tags=event_tags,
+    return render_template("modal_add_case_event.html", form=form, event=event, user_name=user.name, tags=event_tags,
                            assets=assets, iocs=iocs, comments_map=comments_map,
                            assets_prefill=assets_prefill, iocs_prefill=iocs_prefill,
                            category=event.category, attributes=event.custom_attributes)

--- a/source/app/blueprints/dashboard/dashboard_routes.py
+++ b/source/app/blueprints/dashboard/dashboard_routes.py
@@ -39,6 +39,7 @@ from app.datamgmt.dashboard.dashboard_db import get_global_task, list_user_cases
 from app.datamgmt.dashboard.dashboard_db import get_tasks_status
 from app.datamgmt.dashboard.dashboard_db import list_global_tasks
 from app.datamgmt.dashboard.dashboard_db import list_user_tasks
+from app.datamgmt.manage.manage_users_db import get_user
 from app.datamgmt.manage.manage_users_db import get_users_ordered_by_name
 from app.forms import CaseGlobalTaskForm
 from app.iris_engine.module_handler.module_handler import call_modules_hook
@@ -319,10 +320,10 @@ def edit_gtask_modal(cur_id, caseid):
     # Render the task
     form.task_title.render_kw = {'value': task.task_title}
     form.task_description.data = task.task_description
-    user_name, = User.query.with_entities(User.name).filter(User.id == task.task_userid_update).first()
+    user = get_user(task.task_userid_update)
 
     return render_template("modal_add_global_task.html", form=form, task=task,
-                           uid=task.task_assignee_id, user_name=user_name)
+                           uid=task.task_assignee_id, user_name=user.name)
 
 
 @dashboard_blueprint.route('/global/tasks/update/<int:cur_id>', methods=['POST'])

--- a/source/app/blueprints/dashboard/dashboard_routes.py
+++ b/source/app/blueprints/dashboard/dashboard_routes.py
@@ -39,6 +39,7 @@ from app.datamgmt.dashboard.dashboard_db import get_global_task, list_user_cases
 from app.datamgmt.dashboard.dashboard_db import get_tasks_status
 from app.datamgmt.dashboard.dashboard_db import list_global_tasks
 from app.datamgmt.dashboard.dashboard_db import list_user_tasks
+from app.datamgmt.manage.manage_users_db import get_users_ordered_by_name
 from app.forms import CaseGlobalTaskForm
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
@@ -267,7 +268,7 @@ def add_gtask_modal(caseid):
 
     form = CaseGlobalTaskForm()
 
-    form.task_assignee_id.choices = [(user.id, user.name) for user in User.query.filter(User.active == True).order_by(User.name).all()]
+    form.task_assignee_id.choices = [(user.id, user.name) for user in get_users_ordered_by_name()]
     form.task_status_id.choices = [(a.id, a.status_name) for a in get_tasks_status()]
 
     return render_template("modal_add_global_task.html", form=form, task=task, uid=current_user.id, user_name=None)
@@ -312,8 +313,7 @@ def add_gtask(caseid):
 def edit_gtask_modal(cur_id, caseid):
     form = CaseGlobalTaskForm()
     task = GlobalTasks.query.filter(GlobalTasks.id == cur_id).first()
-    form.task_assignee_id.choices = [(user.id, user.name) for user in
-                                     User.query.filter(User.active == True).order_by(User.name).all()]
+    form.task_assignee_id.choices = [(user.id, user.name) for user in get_users_ordered_by_name()]
     form.task_status_id.choices = [(a.id, a.status_name) for a in get_tasks_status()]
 
     # Render the task
@@ -331,7 +331,7 @@ def edit_gtask(cur_id, caseid):
 
     form = CaseGlobalTaskForm()
     task = GlobalTasks.query.filter(GlobalTasks.id == cur_id).first()
-    form.task_assignee_id.choices = [(user.id, user.name) for user in User.query.filter(User.active == True).order_by(User.name).all()]
+    form.task_assignee_id.choices = [(user.id, user.name) for user in get_users_ordered_by_name()]
     form.task_status_id.choices = [(a.id, a.status_name) for a in get_tasks_status()]
 
     if not task:

--- a/source/app/datamgmt/alerts/alerts_db.py
+++ b/source/app/datamgmt/alerts/alerts_db.py
@@ -1187,7 +1187,7 @@ def remove_case_alerts_by_ids(alert_ids: List[int]) -> None:
     db.session.commit()
 
 
-def delete_alerts(alert_ids: List[int]) -> tuple[bool, str]:
+def delete_alerts(alert_ids: List[int]) -> Tuple[bool, str]:
     """
     Delete multiples alerts from the database
 

--- a/source/app/datamgmt/case/case_tasks_db.py
+++ b/source/app/datamgmt/case/case_tasks_db.py
@@ -24,6 +24,7 @@ from sqlalchemy import desc, and_
 
 from app import db
 from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
+from app.datamgmt.manage.manage_users_db import get_user
 from app.datamgmt.manage.manage_users_db import get_users_list_restricted_from_case
 from app.datamgmt.states import update_tasks_state
 from app.models import CaseTasks, TaskAssignee
@@ -192,7 +193,7 @@ def update_task_assignees(task, task_assignee_list, caseid):
         if uid not in allowed_users:
             continue
 
-        user = User.query.filter(User.id == uid).first()
+        user = get_user(uid)
         if user:
             ta = TaskAssignee()
             ta.task_id = task.id

--- a/source/app/datamgmt/manage/manage_groups_db.py
+++ b/source/app/datamgmt/manage/manage_groups_db.py
@@ -22,6 +22,7 @@ from sqlalchemy import and_
 from app import db
 from app.datamgmt.case.case_db import get_case
 from app.datamgmt.manage.manage_cases_db import list_cases_id
+from app.datamgmt.manage.manage_users_db import get_user
 from app.iris_engine.access_control.utils import ac_access_level_mask_from_val_list, ac_ldp_group_removal
 from app.iris_engine.access_control.utils import ac_access_level_to_list
 from app.iris_engine.access_control.utils import ac_auto_update_user_effective_access
@@ -168,7 +169,7 @@ def update_group_members(group, members):
     users_to_remove = set_cur_groups - set_members
 
     for uid in users_to_add:
-        user = User.query.filter(User.id == uid).first()
+        user = get_user(uid)
         if user:
             ug = UserGroup()
             ug.group_id = group.group_id

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -62,6 +62,14 @@ def get_active_user_by_login(username):
     return user
 
 
+def get_active_user_by_api_key(api_key):
+    user = User.query.filter(
+        User.api_key == api_key,
+        User.active == True
+    ).first()
+    return user
+
+
 def get_user_details(user_id, include_api_key=False):
 
     user = get_user(user_id)

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -123,11 +123,6 @@ def delete_user(user_id):
     db.session.commit()
 
 
-def list_users_id():
-    users = User.query.with_entities(User.user_id).all()
-    return users
-
-
 def get_users_ordered_by_name():
     return User.query.filter(User.active == True).order_by(User.name).all()
 

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -46,7 +46,7 @@ def get_user(user_id):
 
 
 def get_user_by_username(username):
-    user = User.query.filter(User.user == username).first()
+    user = User.query.filter(User.user.ilike(username)).first()
     return user
 
 
@@ -56,7 +56,7 @@ def get_user_by_email(user_email):
 
 def get_active_user_by_login(username):
     user = User.query.filter(
-        User.user == username,
+        User.user.ilike(username),
         User.active == True
     ).first()
     return user

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -122,6 +122,10 @@ def list_users_id():
     return users
 
 
+def get_users_ordered_by_name():
+    return User.query.filter(User.active == True).order_by(User.name).all()
+
+
 def get_users_list():
     users = User.query.all()
 

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -64,7 +64,7 @@ def get_active_user_by_login(username):
 
 def get_user_details(user_id, include_api_key=False):
 
-    user = User.query.filter(User.id == user_id).first()
+    user = get_user(user_id)
 
     if not user:
         return None
@@ -93,8 +93,8 @@ def get_user_details(user_id, include_api_key=False):
 
 
 def user_exists(user_name, user_email):
-    user = User.query.filter_by(user=user_name).first()
-    user_by_email = User.query.filter_by(email=user_email).first()
+    user = get_user_by_username(user_name)
+    user_by_email = get_user_by_mail(user_email)
 
     return user or user_by_email
 

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -45,6 +45,12 @@ def get_user(user_id):
     return user
 
 
+# TODO Isn't this doing the exact same thing as get_user?
+#      Replace all calls to get_user by calls to get_user_by_id and remove get_user?
+def get_user_by_id(user_id: int):
+    return User.query.get(user_id)
+
+
 def get_user_by_username(username):
     user = User.query.filter(User.user.ilike(username)).first()
     return user

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -50,7 +50,7 @@ def get_user_by_username(username):
     return user
 
 
-def get_user_by_mail(user_email):
+def get_user_by_email(user_email):
     return User.query.filter(User.email == user_email).first()
 
 
@@ -102,7 +102,7 @@ def get_user_details(user_id, include_api_key=False):
 
 def user_exists(user_name, user_email):
     user = get_user_by_username(user_name)
-    user_by_email = get_user_by_mail(user_email)
+    user_by_email = get_user_by_email(user_email)
 
     return user or user_by_email
 

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -40,9 +40,13 @@ from app.models.authorization import UserGroup
 from app.models.authorization import UserOrganisation
 
 
-def get_user(user_id, id_key: str = 'id'):
-    user = User.query.filter(getattr(User, id_key) == user_id).first()
+def get_user(user_id):
+    user = User.query.filter(User.id == user_id).first()
     return user
+
+
+def get_user_by_mail(user_email):
+    return User.query.filter(User.email == user_email).first()
 
 
 def get_active_user_by_login(username):

--- a/source/app/post_init.py
+++ b/source/app/post_init.py
@@ -30,7 +30,7 @@ import socket
 import time
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import create_engine, exc, or_
+from sqlalchemy import create_engine, exc
 from sqlalchemy_utils import create_database
 from sqlalchemy_utils import database_exists
 
@@ -40,6 +40,8 @@ from app import celery
 from app import db
 from app.datamgmt.iris_engine.modules_db import iris_module_disable_by_id
 from app.datamgmt.manage.manage_groups_db import add_case_access_to_group
+from app.datamgmt.manage.manage_users_db import get_user_by_username
+from app.datamgmt.manage.manage_users_db import get_user_by_mail
 from app.datamgmt.manage.manage_users_db import add_user_to_group
 from app.datamgmt.manage.manage_users_db import add_user_to_organisation
 from app.iris_engine.access_control.utils import ac_add_user_effective_access
@@ -930,10 +932,9 @@ def create_safe_admin(def_org, gadm):
         admin_email = 'administrator@localhost'
 
     # Check if admin user already exists
-    user = User.query.filter(or_(
-        User.user == admin_username,
-        User.email == admin_email
-    )).first()
+    user = get_user_by_username(admin_username)
+    if not user:
+        user = get_user_by_mail(admin_email)
     password = None
 
     if not user:

--- a/source/app/post_init.py
+++ b/source/app/post_init.py
@@ -41,7 +41,7 @@ from app import db
 from app.datamgmt.iris_engine.modules_db import iris_module_disable_by_id
 from app.datamgmt.manage.manage_groups_db import add_case_access_to_group
 from app.datamgmt.manage.manage_users_db import get_user_by_username
-from app.datamgmt.manage.manage_users_db import get_user_by_mail
+from app.datamgmt.manage.manage_users_db import get_user_by_email
 from app.datamgmt.manage.manage_users_db import add_user_to_group
 from app.datamgmt.manage.manage_users_db import add_user_to_organisation
 from app.iris_engine.access_control.utils import ac_add_user_effective_access
@@ -934,7 +934,7 @@ def create_safe_admin(def_org, gadm):
     # Check if admin user already exists
     user = get_user_by_username(admin_username)
     if not user:
-        user = get_user_by_mail(admin_email)
+        user = get_user_by_email(admin_email)
     password = None
 
     if not user:

--- a/source/app/schema/marshables.py
+++ b/source/app/schema/marshables.py
@@ -49,7 +49,7 @@ from app import ma
 from app.datamgmt.datastore.datastore_db import datastore_get_standard_path
 from app.datamgmt.manage.manage_attribute_db import merge_custom_attributes
 from app.datamgmt.manage.manage_users_db import get_user_by_username
-from app.datamgmt.manage.manage_users_db import get_user_by_mail
+from app.datamgmt.manage.manage_users_db import get_user_by_email
 from app.iris_engine.access_control.utils import ac_mask_from_val_list
 from app.models import AnalysisStatus, CaseClassification, SavedFilter, DataStorePath, IrisModuleHook, Tags, \
     ReviewStatus
@@ -748,7 +748,7 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
                         type=str,
                         allow_none=True)
 
-        usr = get_user_by_mail(email)
+        usr = get_user_by_email(email)
         if usr and usr.id != user_id:
             raise marshmallow.exceptions.ValidationError('User email already taken',
                                                          field_name="user_email")

--- a/source/app/schema/marshables.py
+++ b/source/app/schema/marshables.py
@@ -48,6 +48,7 @@ from app import db
 from app import ma
 from app.datamgmt.datastore.datastore_db import datastore_get_standard_path
 from app.datamgmt.manage.manage_attribute_db import merge_custom_attributes
+from app.datamgmt.manage.manage_users_db import get_user_by_username
 from app.iris_engine.access_control.utils import ac_mask_from_val_list
 from app.models import AnalysisStatus, CaseClassification, SavedFilter, DataStorePath, IrisModuleHook, Tags, \
     ReviewStatus
@@ -709,13 +710,9 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
                         type=str,
                         allow_none=True)
 
-        luser = User.query.filter(
-            User.user == user
-        ).all()
-        for usr in luser:
-            if usr.id != user_id:
-                raise marshmallow.exceptions.ValidationError('User name already taken',
-                                                             field_name="user_login")
+        usr = get_user_by_username(user)
+        if usr and usr.id != user_id:
+            raise marshmallow.exceptions.ValidationError('User name already taken', field_name="user_login")
 
         return data
 

--- a/source/app/schema/marshables.py
+++ b/source/app/schema/marshables.py
@@ -49,6 +49,7 @@ from app import ma
 from app.datamgmt.datastore.datastore_db import datastore_get_standard_path
 from app.datamgmt.manage.manage_attribute_db import merge_custom_attributes
 from app.datamgmt.manage.manage_users_db import get_user_by_username
+from app.datamgmt.manage.manage_users_db import get_user_by_mail
 from app.iris_engine.access_control.utils import ac_mask_from_val_list
 from app.models import AnalysisStatus, CaseClassification, SavedFilter, DataStorePath, IrisModuleHook, Tags, \
     ReviewStatus
@@ -747,13 +748,10 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
                         type=str,
                         allow_none=True)
 
-        luser = User.query.filter(
-            User.email == email
-        ).all()
-        for usr in luser:
-            if usr.id != user_id:
-                raise marshmallow.exceptions.ValidationError('User email already taken',
-                                                             field_name="user_email")
+        usr = get_user_by_mail(email)
+        if usr and usr.id != user_id:
+            raise marshmallow.exceptions.ValidationError('User email already taken',
+                                                         field_name="user_email")
 
         return data
 

--- a/source/app/schema/marshables.py
+++ b/source/app/schema/marshables.py
@@ -50,6 +50,7 @@ from app.datamgmt.datastore.datastore_db import datastore_get_standard_path
 from app.datamgmt.manage.manage_attribute_db import merge_custom_attributes
 from app.datamgmt.manage.manage_users_db import get_user_by_username
 from app.datamgmt.manage.manage_users_db import get_user_by_email
+from app.datamgmt.manage.manage_users_db import get_user
 from app.iris_engine.access_control.utils import ac_mask_from_val_list
 from app.models import AnalysisStatus, CaseClassification, SavedFilter, DataStorePath, IrisModuleHook, Tags, \
     ReviewStatus
@@ -1401,7 +1402,7 @@ class GlobalTasksSchema(ma.SQLAlchemyAutoSchema):
                         field_name='task_assignee_id', 
                         type=int)
         
-        user = User.query.filter(User.id == data.get('task_assignee_id')).count()
+        user = get_user(data.get('task_assignee_id'))
         if not user:
             raise marshmallow.exceptions.ValidationError("Invalid user id for assignee",
                                                          field_name="task_assignees_id")

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -62,7 +62,7 @@ from app import app
 from app import db
 from app.datamgmt.case.case_db import case_exists
 from app.datamgmt.case.case_db import get_case
-from app.datamgmt.manage.manage_users_db import get_user
+from app.datamgmt.manage.manage_users_db import get_user_by_mail
 from app.iris_engine.access_control.utils import ac_fast_check_user_has_case_access
 from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
 from app.iris_engine.utils.tracker import track_activity
@@ -368,7 +368,7 @@ def _local_authentication_process(incoming_request: Request):
 
 
 def _authenticate_with_email(user_email):
-    user = get_user(user_email, id_key="email")
+    user = get_user_by_mail(user_email)
     if not user:
         log.error(f'User with email {user_email} is not registered in the IRIS')
         return False

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -62,7 +62,7 @@ from app import app
 from app import db
 from app.datamgmt.case.case_db import case_exists
 from app.datamgmt.case.case_db import get_case
-from app.datamgmt.manage.manage_users_db import get_user_by_mail
+from app.datamgmt.manage.manage_users_db import get_user_by_email
 from app.iris_engine.access_control.utils import ac_fast_check_user_has_case_access
 from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
 from app.iris_engine.utils.tracker import track_activity
@@ -368,7 +368,7 @@ def _local_authentication_process(incoming_request: Request):
 
 
 def _authenticate_with_email(user_email):
-    user = get_user_by_mail(user_email)
+    user = get_user_by_email(user_email)
     if not user:
         log.error(f'User with email {user_email} is not registered in the IRIS')
         return False

--- a/source/app/views.py
+++ b/source/app/views.py
@@ -64,6 +64,7 @@ from app.blueprints.profile.profile_routes import profile_blueprint
 from app.blueprints.reports.reports_route import reports_blueprint
 from app.blueprints.search.search_routes import search_blueprint
 from app.models.authorization import User
+from app.datamgmt.manage.manage_users_db import get_user_by_id
 from app.datamgmt.manage.manage_users_db import get_active_user_by_api_key
 from app.post_init import run_post_init
 
@@ -118,7 +119,7 @@ except Exception as e:
 # provide login manager with load_user callback
 @lm.user_loader
 def load_user(user_id):
-    return User.query.get(int(user_id))
+    return get_user_by_id(int(user_id))
 
 
 @lm.request_loader

--- a/source/app/views.py
+++ b/source/app/views.py
@@ -64,6 +64,7 @@ from app.blueprints.profile.profile_routes import profile_blueprint
 from app.blueprints.reports.reports_route import reports_blueprint
 from app.blueprints.search.search_routes import search_blueprint
 from app.models.authorization import User
+from app.datamgmt.manage.manage_users_db import get_active_user_by_api_key
 from app.post_init import run_post_init
 
 app.register_blueprint(dashboard_blueprint)
@@ -126,10 +127,7 @@ def load_user_from_request(request):
     # first, try to login using the api_key url arg
     api_key = request.args.get('api_key')
     if api_key:
-        user = User.query.filter(
-            User.api_key == api_key,
-            User.active == True
-        ).first()
+        user = get_active_user_by_api_key(api_key)
         if user:
             return user
 
@@ -138,10 +136,7 @@ def load_user_from_request(request):
     if api_key:
         api_key = api_key.replace('Bearer ', '', 1)
 
-        user = User.query.filter(
-            User.api_key == api_key,
-            User.active == True
-        ).first()
+        user = get_active_user_by_api_key(api_key)
 
         if user:
             return user

--- a/source/tests/performance/test_burst_db_interaction.py
+++ b/source/tests/performance/test_burst_db_interaction.py
@@ -30,6 +30,7 @@ from app import db
 from app.datamgmt.case.case_assets_db import create_asset
 from app.datamgmt.case.case_notes_db import add_note
 from app.datamgmt.case.case_notes_db import add_note_group
+from app.datamgmt.manage.manage_users_db import get_user
 from app.datamgmt.manage.manage_users_db import create_user
 from app.models.cases import Cases
 from app.models.cases import CasesEvent
@@ -84,7 +85,7 @@ class TestBurstDBInteraction(TestCase):
                 description=f"Testing case number {str(i)}",
                 soc_id=f"SOC{str(i)}",
                 gen_report=False,
-                user=(User.query.filter(User.id == random.randrange(1, users_nb)).first()),
+                user=(get_user(random.randrange(1, users_nb))),
                 client_name=f"client_{str(random.randrange(1, client_nb))}"
             )
 


### PR DESCRIPTION
This is a proposition to enable case insensitive login as described in issue #252.
This change does not require any database migration, since only the retrieval of a user by its login has change. It is now done with a case insensitive query (ilike)
However this change assumes no two users were, in a previous version of DFIR-IRIS, created with logins which are the same when compared in a case insensitive way (for instance whitekernel and WhiteKernel)
Maybe, in addition to these changes, a script which checks this is the case, should be proposed in the migration note...