### PR TITLE
Ldap groups

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -46,6 +46,8 @@ IRIS_AUTHENTICATION_TYPE=local
 #LDAP_BIND_PASSWORD=
 # base DN in which to search for users
 #LDAP_SEARCH_DN=ou=users,dc=example,dc=org
+# base DN in which to search for groups
+#LDAP_GROUP_BASE_DN=ou=IRIS,ou=groups,dc=example,dc=org
 # unique identifier to search the user
 #LDAP_ATTRIBUTE_IDENTIFIER=cn
 # name of the attribute to retrieve the user's display name

--- a/.env.model
+++ b/.env.model
@@ -43,6 +43,9 @@ IRIS_AUTHENTICATION_TYPE=local
 #LDAP_USER_PREFIX=uid=
 #LDAP_USER_SUFFIX=ou=people,dc=example,dc=com
 #LDAP_USE_SSL=False
+# bind account dn and password
+#LDAP_BIND_DN=
+#LDAP_BIND_PASSWORD=
 # base DN in which to search for users
 #LDAP_SEARCH_DN=ou=users,dc=example,dc=org
 # unique identifier to search the user

--- a/.env.model
+++ b/.env.model
@@ -32,8 +32,6 @@ IRIS_AUTHENTICATION_TYPE=local
 #IRIS_ADM_USERNAME=administrator
 # requests the just-in-time creation of users with ldap authentification (see https://github.com/dfir-iris/iris-web/issues/203)
 #IRIS_AUTHENTICATION_CREATE_USER_IF_NOT_EXIST=True
-# the group to which newly created users are initially added, default value is Analysts
-#IRIS_NEW_USERS_DEFAULT_GROUP=
 
 # -- FOR LDAP AUTHENTICATION
 #IRIS_AUTHENTICATION_TYPE=ldap

--- a/source/app/configuration.py
+++ b/source/app/configuration.py
@@ -420,6 +420,8 @@ class Config:
         LDAP_ATTRIBUTE_DISPLAY_NAME = config.load('LDAP', 'ATTRIBUTE_DISPLAY_NAME')
         LDAP_ATTRIBUTE_MAIL = config.load('LDAP', 'ATTRIBUTE_MAIL')
 
+        LDAP_GROUP_BASE_DN = config.load('LDAP', 'GROUP_BASE_DN')
+
         LDAP_USE_SSL = config.load('LDAP', 'USE_SSL', fallback='True')
         LDAP_USE_SSL = (LDAP_USE_SSL == 'True')
 

--- a/source/app/configuration.py
+++ b/source/app/configuration.py
@@ -369,7 +369,6 @@ class Config:
 
     AUTHENTICATION_TYPE = authentication_type
     AUTHENTICATION_CREATE_USER_IF_NOT_EXIST = (authentication_create_user_if_not_exists == "True")
-    IRIS_NEW_USERS_DEFAULT_GROUP = config.load('IRIS', 'NEW_USERS_DEFAULT_GROUP', fallback='Analysts')
     AUTHENTICATION_LOCAL_FALLBACK = config.load('IRIS', 'AUTHENTICATION_LOCAL_FALLBACK', fallback="True") == "True"
 
     if authentication_type == 'oidc_proxy':

--- a/source/app/configuration.py
+++ b/source/app/configuration.py
@@ -408,6 +408,9 @@ class Config:
 
         LDAP_AUTHENTICATION_TYPE = config.load('LDAP', 'AUTHENTICATION_TYPE')
 
+        LDAP_BIND_DN = config.load('LDAP', 'BIND_DN')
+        LDAP_BIND_PASSWORD = config.load('LDAP', 'BIND_PASSWORD')
+
         LDAP_SEARCH_DN = config.load('LDAP', 'SEARCH_DN')
         if authentication_create_user_if_not_exists and LDAP_SEARCH_DN is None:
             raise Exception('LDAP enabled with user provisioning: LDAP_SEARCH_DN should be set')

--- a/source/app/datamgmt/manage/manage_groups_db.py
+++ b/source/app/datamgmt/manage/manage_groups_db.py
@@ -34,6 +34,13 @@ from app.models.authorization import UserGroup
 from app.schema.marshables import AuthorizationGroupSchema
 
 
+def create_group(name, description):
+    group = Group(group_name=name, group_description=description, group_permissions=0)
+    db.session.add(group)
+    db.session.commit()
+    return group
+
+
 def get_groups_list():
     groups = Group.query.all()
 

--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -34,6 +34,7 @@ from app.datamgmt.manage.manage_groups_db import get_group_by_name
 
 log = app.logger
 ldap_authentication_type = app.config.get('LDAP_AUTHENTICATION_TYPE')
+attribute_unique_identifier = app.config.get('LDAP_ATTRIBUTE_IDENTIFIER')
 
 
 def _get_unique_identifier(user_login):
@@ -69,7 +70,6 @@ def _connect_bind_account(server):
 
 def _provision_user(connection, user_login):
     search_base = app.config.get('LDAP_SEARCH_DN')
-    attribute_unique_identifier = app.config.get('LDAP_ATTRIBUTE_IDENTIFIER')
     unique_identifier = conv.escape_filter_chars(_get_unique_identifier(user_login))
     attribute_display_name = app.config.get('LDAP_ATTRIBUTE_DISPLAY_NAME')
     attribute_mail = app.config.get('LDAP_ATTRIBUTE_MAIL')
@@ -134,11 +134,12 @@ def ldap_authenticate(ldap_user_name, ldap_user_pwd):
     if not connection:
         return False
 
-    if not get_active_user_by_login(ldap_user_name) and app.config.get('AUTHENTICATION_CREATE_USER_IF_NOT_EXIST'):
+    if app.config.get('AUTHENTICATION_CREATE_USER_IF_NOT_EXIST'):
         connection = _connect_bind_account(server)
         if not connection:
             return False
-        _provision_user(connection, ldap_user_name)
+        if not get_active_user_by_login(ldap_user_name):
+            _provision_user(connection, ldap_user_name)
 
     log.info(f"Successful authenticated user")
 

--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -70,8 +70,8 @@ def _provision_user(connection, user_login):
     #      => should factor and reuse this code bit as a function
     #      => also, it should probably be more secure to use the secrets module (instead of random)
     password = ''.join(random.choices(string.printable[:-6], k=16))
-    # TODO It seems email unicity is required (a fixed email causes a problem at the second account creation)
-    #      The email either comes from the ldap or is forged from the login to ensure unicity
+    # TODO It seems email uniqueness is required (a fixed email causes a problem at the second account creation)
+    #      The email either comes from the ldap or is forged from the login to ensure uniqueness
     user = create_user(user_name, user_login, password, user_email, True)
     initial_group = get_group_by_name(app.config.get('IRIS_NEW_USERS_DEFAULT_GROUP'))
     add_user_to_group(user.id, initial_group.group_id)

--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -42,8 +42,6 @@ def _get_unique_identifier(user_login):
 
 
 def _provision_user(connection, user_login):
-    if get_active_user_by_login(user_login):
-        return
     search_base = app.config.get('LDAP_SEARCH_DN')
     attribute_unique_identifier = app.config.get('LDAP_ATTRIBUTE_IDENTIFIER')
     unique_identifier = conv.escape_filter_chars(_get_unique_identifier(user_login))
@@ -118,7 +116,7 @@ def ldap_authenticate(ldap_user_name, ldap_user_pwd):
             log.error(f"Cannot bind to ldap server: {conn.last_error} ")
             return False
 
-        if app.config.get('AUTHENTICATION_CREATE_USER_IF_NOT_EXIST'):
+        if not get_active_user_by_login(ldap_user_name) and app.config.get('AUTHENTICATION_CREATE_USER_IF_NOT_EXIST'):
             _provision_user(conn, ldap_user_name)
 
     except ldap3.core.exceptions.LDAPInvalidCredentialsResult as e:

--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -119,6 +119,8 @@ def _parse_cn(distinguished_name):
 
 def _update_user_groups(user, ldap_user_entry):
     ldap_group_names = ldap_user_entry['memberOf'].value
+    if ldap_group_names is None:
+        ldap_group_names = []
     if isinstance(ldap_group_names, str):
         ldap_group_names = [ldap_group_names]
 

--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -33,10 +33,11 @@ from app.datamgmt.manage.manage_users_db import add_user_to_group
 from app.datamgmt.manage.manage_groups_db import get_group_by_name
 
 log = app.logger
+ldap_authentication_type = app.config.get('LDAP_AUTHENTICATION_TYPE')
 
 
 def _get_unique_identifier(user_login):
-    if app.config.get('LDAP_AUTHENTICATION_TYPE').lower() == 'ntlm':
+    if ldap_authentication_type.lower() == 'ntlm':
         return user_login[user_login.find('\\')+1:]
     return user_login
 
@@ -46,7 +47,7 @@ def _bind_user(server, ldap_user, ldap_user_pwd):
                             user=ldap_user,
                             password=ldap_user_pwd,
                             auto_referrals=False,
-                            authentication=app.config.get('LDAP_AUTHENTICATION_TYPE'))
+                            authentication=ldap_authentication_type)
 
     try:
         if not connection.bind():
@@ -100,7 +101,7 @@ def ldap_authenticate(ldap_user_name, ldap_user_pwd):
     """
     Authenticate to the LDAP server
     """
-    if app.config.get('LDAP_AUTHENTICATION_TYPE').lower() != 'ntlm':
+    if ldap_authentication_type.lower() != 'ntlm':
         ldap_user_name = conv.escape_filter_chars(ldap_user_name)
         ldap_user = f"{app.config.get('LDAP_USER_PREFIX')}{ldap_user_name.strip()}{ ','+app.config.get('LDAP_USER_SUFFIX') if app.config.get('LDAP_USER_SUFFIX') else ''}"
     else:

--- a/source/app/iris_engine/access_control/ldap_handler.py
+++ b/source/app/iris_engine/access_control/ldap_handler.py
@@ -31,12 +31,14 @@ from app.datamgmt.manage.manage_users_db import get_active_user_by_login
 from app.datamgmt.manage.manage_users_db import create_user
 from app.datamgmt.manage.manage_users_db import update_user_groups
 from app.datamgmt.manage.manage_groups_db import get_group_by_name
+from app.datamgmt.manage.manage_groups_db import create_group
 
 _log = app.logger
 _ldap_authentication_type = app.config.get('LDAP_AUTHENTICATION_TYPE')
 _attribute_unique_identifier = app.config.get('LDAP_ATTRIBUTE_IDENTIFIER')
 _attribute_display_name = app.config.get('LDAP_ATTRIBUTE_DISPLAY_NAME')
 _attribute_mail = app.config.get('LDAP_ATTRIBUTE_MAIL')
+_ldap_group_base_dn = app.config.get('LDAP_GROUP_BASE_DN')
 
 
 def _get_unique_identifier(user_login):
@@ -114,8 +116,11 @@ def _update_user_groups(user, ldap_user_entry):
     ldap_group_names = ldap_user_entry['memberOf'].value
     if isinstance(ldap_group_names, str):
         ldap_group_names = [ldap_group_names]
+
     groups = []
     for ldap_group_name in ldap_group_names:
+        if not ldap_group_name.endswith(_ldap_group_base_dn):
+            continue
         group_name = _parse_cn(ldap_group_name)
         group = get_group_by_name(group_name)
         if group is None:

--- a/source/app/models/authorization.py
+++ b/source/app/models/authorization.py
@@ -87,6 +87,8 @@ class Group(db.Model):
                         server_default=text('gen_random_uuid()'), unique=True)
     group_name = Column(Text, nullable=False, unique=True)
     group_description = Column(Text)
+
+    # this is a mask of values defined in enum Permissions
     group_permissions = Column(BigInteger, nullable=False)
     group_auto_follow = Column(Boolean, nullable=False, default=False)
     group_auto_follow_access_level = Column(BigInteger, nullable=False, default=0)


### PR DESCRIPTION
This is an improvement to ldap authentication. The purposes of this pull request are:
* introduction of a bind account in order to emit requests to the ldap (rather than use the user's account),
* synchronization of groups declared in ldap with groups in IRIS.

The following variables are added to the .env:
* `LDAP_BIND_DN`: distinguished name of the bind account
* `LDAP_BIND_PASSWORD`: password of the bind account
* `LDAP_GROUP_BASE_DN`: distinguished name for the group names

More precisely, when the flag `AUTHENTICATION_CREATE_USER_IF_NOT_EXIST` is set, then the groups of the user will be synchronized with the groups it present in its `memberOf` field in ldap and which are in `LDAP_GROUP_BASE_DN`.
