### PR TITLE
[IMP] Fixed broken Links in CODESTYLE.md and CONTRIBUTING.md

### DIFF
--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -10,7 +10,7 @@ Try to follow the repository convention :
 
 ## Code
 The code should be pretty easy to apprehend. It's not perfect but it will improve over time.   
-Some documentation about development is available [here](https://dfir-iris.github.io/development/).   
+Some documentation about development is available [here](https://docs.dfir-iris.org/development/).   
 Here are the main takes : 
 
 - **Routes** : these are the things that describes how URI should be handled. Routes are split by categories as in the UI menu. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,10 @@ Please try to follow the templates that are provided for feature requests and bu
 is not already mentioned in the [roadmap](https://github.com/orgs/dfir-iris/projects/1/views/4). If an issue is similar 
 but not fit perfectly with what you have in mind, you can add comments to it, and it will take into account.  
 
-If you want to report a security issue, please read the [security page](https://github.com/dfir-iris/iris-web/SECURITY.md).   
+If you want to report a security issue, please read the [security page](./SECURITY.md).   
 
 ## Pull requests 
-Please make sure to follow the [code guideline](https://github.com/dfir-iris/iris-web/CODESTYLE.md) when writing your code.  
+Please make sure to follow the [code guideline](./CODESTYLE.md) when writing your code.  
 The pull requests must be submitted on the `develop` branch of the project. Ensure that before submitting you are 
 up-to-date with it.  
 


### PR DESCRIPTION
I noticed two hyperlinks to the github.io domain who i rewrote to the dedicated domain. 
Also the absolute URLs in the Contributing document were not resolved correct by github, so i replaced them with relative links. 