### PR TITLE
[ADD] Add Web-certificates to be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ source/app/static/assets/dist/
 source/app/static/assets/img/graph/*
 !source/app/static/assets/img/graph/*.png
 run_nv_test.py
+!certificates/web_certificates/iris_dev_*
+certificates/web_certificates/*.pem


### PR DESCRIPTION
I thought it might be a good idea to include web-certificates in .gitignore, so no one exposes their certificates by accident. The included dev certificates are excempted to be still included in the repository.