### PR TITLE
Issue395 faster tests

### DIFF
--- a/tests/docker_compose.py
+++ b/tests/docker_compose.py
@@ -31,5 +31,4 @@ class DockerCompose:
         return subprocess.check_output(['docker', 'compose', 'logs', '--no-color'], cwd=self._docker_compose_path, universal_newlines=True)
 
     def stop(self):
-        subprocess.check_call(['docker', 'compose', 'down'], cwd=self._docker_compose_path)
-        subprocess.check_call(['docker', 'volume', 'prune', '--all', '--force'])
+        subprocess.check_call(['docker', 'compose', 'down', '--volumes'], cwd=self._docker_compose_path)

--- a/tests/docker_compose.py
+++ b/tests/docker_compose.py
@@ -25,11 +25,11 @@ class DockerCompose:
         self._docker_compose_path = docker_compose_path
 
     def start(self):
-        subprocess.check_call(['docker-compose', 'up', '--detach'], cwd=self._docker_compose_path)
+        subprocess.check_call(['docker', 'compose', 'up', '--detach'], cwd=self._docker_compose_path)
 
     def extract_all_logs(self):
-        return subprocess.check_output(['docker-compose', 'logs', '--no-color'], cwd=self._docker_compose_path, universal_newlines=True)
+        return subprocess.check_output(['docker', 'compose', 'logs', '--no-color'], cwd=self._docker_compose_path, universal_newlines=True)
 
     def stop(self):
-        subprocess.check_call(['docker-compose', 'down'], cwd=self._docker_compose_path)
+        subprocess.check_call(['docker', 'compose', 'down'], cwd=self._docker_compose_path)
         subprocess.check_call(['docker', 'volume', 'prune', '--all', '--force'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -22,12 +22,16 @@ from iris import Iris
 
 class Tests(TestCase):
 
-    def setUp(self) -> None:
-        self._subject = Iris()
-        self._subject.start()
+    _subject = None
 
-    def tearDown(self) -> None:
-        self._subject.stop()
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._subject = Iris()
+        cls._subject.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._subject.stop()
 
     def test_create_asset_should_not_fail(self):
         response = self._subject.create_asset()
@@ -38,10 +42,12 @@ class Tests(TestCase):
         self.assertEqual('success', response['status'])
 
     def test_create_case_should_add_a_new_case(self):
+        response = self._subject.get_cases()
+        initial_case_count = len(response['data'])
         self._subject.create_case()
         response = self._subject.get_cases()
         case_count = len(response['data'])
-        self.assertEqual(2, case_count)
+        self.assertEqual(initial_case_count + 1, case_count)
 
     def test_update_case_should_not_require_case_name_issue_358(self):
         response = self._subject.create_case()

--- a/tests/tests_which_require_a_clean_slate.py
+++ b/tests/tests_which_require_a_clean_slate.py
@@ -17,6 +17,7 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from unittest import TestCase
+from unittest import skip
 from iris import Iris
 
 
@@ -35,6 +36,7 @@ class TestsWhichRequireACleanSlate(TestCase):
     def tearDown(self) -> None:
         self._subject.stop()
 
+    @skip
     def test_create_case_should_add_a_new_case(self):
         """
         This test is also present in the main test suite tests.py (although in a slightly more complex form

--- a/tests/tests_which_require_a_clean_slate.py
+++ b/tests/tests_which_require_a_clean_slate.py
@@ -1,0 +1,48 @@
+#  IRIS Source Code
+#  Copyright (C) 2023 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from unittest import TestCase
+from iris import Iris
+
+
+class TestsWhichRequireACleanSlate(TestCase):
+    """
+    In this test suite, each test is started from a clean slate: the state of IRIS after a fresh install.
+    This is achieved by stopping and removing containers, networks and modules (docker compose down) after each test.
+    In consequence tests run in this context will be costlier.
+    So, whenever possible try to avoid adding tests to this suite.
+    """
+
+    def setUp(self) -> None:
+        self._subject = Iris()
+        self._subject.start()
+
+    def tearDown(self) -> None:
+        self._subject.stop()
+
+    def test_create_case_should_add_a_new_case(self):
+        """
+        This test is also present in the main test suite tests.py (although in a slightly more complex form
+        to be independent of the initial the database state)
+        This was just to give an example of a test which requires starting from an empty database.
+        It may thus be removed when we have more interesting tests to add to this suite.
+        """
+        self._subject.create_case()
+        response = self._subject.get_cases()
+        case_count = len(response['data'])
+        self.assertEqual(2, case_count)


### PR DESCRIPTION
To close #395.
Execution time of tests are as follows:
* before separation 2m35s (https://github.com/dfir-iris/iris-web/actions/runs/8080037727/job/22075722292)
* with only the fast test suite 44s (https://github.com/dfir-iris/iris-web/actions/runs/8108096252/job/22160683407)
* with also one test in the test suite which stops dockers between each tests 1m17s (https://github.com/dfir-iris/iris-web/actions/runs/8108705942/job/22162420240)

Note: the test suite which is costly was not really necessary for the test we currently have. I still included it with one test so we have an example in the future, if we ever need it. The current test is not very useful (I made a "translated" version in the fast test suite), it can be removed...