### PR TITLE
Graphql iocs

### DIFF
--- a/source/app/blueprints/case/case_ioc_routes.py
+++ b/source/app/blueprints/case/case_ioc_routes.py
@@ -65,7 +65,7 @@ from app.util import ac_case_requires
 from app.util import response_error
 from app.util import response_success
 from app.business.iocs import create
-from app.business.iocs import remove_from_case
+from app.business.iocs import delete
 from app.business.errors import BusinessProcessingError
 
 case_ioc_blueprint = Blueprint(
@@ -250,7 +250,7 @@ def case_add_ioc_modal(caseid):
 @ac_api_case_requires(CaseAccessLevel.full_access)
 def case_delete_ioc(cur_id, caseid):
     try:
-        remove_from_case(cur_id, caseid)
+        delete(cur_id, caseid)
     except BusinessProcessingError as e:
         return response_error(e.get_message())
 

--- a/source/app/blueprints/case/case_ioc_routes.py
+++ b/source/app/blueprints/case/case_ioc_routes.py
@@ -296,7 +296,7 @@ def case_update_ioc(cur_id, caseid):
     try:
         ioc = get_ioc(cur_id, caseid)
         if not ioc:
-            return response_error("Invalid IOC ID for this case")
+            return response_error('Invalid IOC ID for this case')
 
         request_data = call_modules_hook('on_preload_ioc_update', data=request.get_json(), caseid=caseid)
 
@@ -307,7 +307,7 @@ def case_update_ioc(cur_id, caseid):
         ioc_sc.user_id = current_user.id
 
         if not check_ioc_type_id(type_id=ioc_sc.ioc_type_id):
-            return response_error("Not a valid IOC type")
+            return response_error('Not a valid IOC type')
 
         update_ioc_state(caseid=caseid)
         db.session.commit()
@@ -315,13 +315,13 @@ def case_update_ioc(cur_id, caseid):
         ioc_sc = call_modules_hook('on_postload_ioc_update', data=ioc_sc, caseid=caseid)
 
         if ioc_sc:
-            track_activity(f"updated ioc \"{ioc_sc.ioc_value}\"", caseid=caseid)
-            return response_success(f"Updated ioc \"{ioc_sc.ioc_value}\"", data=ioc_schema.dump(ioc))
+            track_activity(f'updated ioc "{ioc_sc.ioc_value}"', caseid=caseid)
+            return response_success(f'Updated ioc "{ioc_sc.ioc_value}"', data=ioc_schema.dump(ioc))
 
-        return response_error("Unable to update ioc for internal reasons")
+        return response_error('Unable to update ioc for internal reasons')
 
     except marshmallow.exceptions.ValidationError as e:
-        return response_error(msg="Data error", data=e.messages)
+        return response_error(msg='Data error', data=e.messages)
 
 
 @case_ioc_blueprint.route('/case/ioc/<int:cur_id>/comments/modal', methods=['GET'])

--- a/source/app/blueprints/case/case_ioc_routes.py
+++ b/source/app/blueprints/case/case_ioc_routes.py
@@ -36,8 +36,6 @@ from app.datamgmt.case.case_db import get_case
 from app.datamgmt.case.case_iocs_db import add_comment_to_ioc
 from app.datamgmt.case.case_iocs_db import add_ioc
 from app.datamgmt.case.case_iocs_db import add_ioc_link
-from app.datamgmt.case.case_iocs_db import check_ioc_type_id
-from app.datamgmt.case.case_iocs_db import delete_ioc
 from app.datamgmt.case.case_iocs_db import delete_ioc_comment
 from app.datamgmt.case.case_iocs_db import get_case_ioc_comment
 from app.datamgmt.case.case_iocs_db import get_case_ioc_comments
@@ -51,7 +49,6 @@ from app.datamgmt.case.case_iocs_db import get_tlps
 from app.datamgmt.case.case_iocs_db import get_tlps_dict
 from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
 from app.datamgmt.states import get_ioc_state
-from app.datamgmt.states import update_ioc_state
 from app.forms import ModalAddCaseAssetForm
 from app.forms import ModalAddCaseIOCForm
 from app.iris_engine.module_handler.module_handler import call_modules_hook
@@ -65,6 +62,7 @@ from app.util import ac_case_requires
 from app.util import response_error
 from app.util import response_success
 from app.business.iocs import create
+from app.business.iocs import update
 from app.business.iocs import delete
 from app.business.errors import BusinessProcessingError
 
@@ -129,11 +127,11 @@ def case_ioc_state(caseid):
 @case_ioc_blueprint.route('/case/ioc/add', methods=['POST'])
 @ac_api_case_requires(CaseAccessLevel.full_access)
 def case_add_ioc(caseid):
-    add_ioc_schema = IocSchema()
+    ioc_schema = IocSchema()
 
     try:
         ioc, msg = create(request.get_json(), caseid)
-        return response_success(msg, data=add_ioc_schema.dump(ioc))
+        return response_success(msg, data=ioc_schema.dump(ioc))
     except BusinessProcessingError as e:
         return response_error(e.get_message(), data=e.get_data())
 
@@ -293,35 +291,13 @@ def case_view_ioc(cur_id, caseid):
 @case_ioc_blueprint.route('/case/ioc/update/<int:cur_id>', methods=['POST'])
 @ac_api_case_requires(CaseAccessLevel.full_access)
 def case_update_ioc(cur_id, caseid):
+    ioc_schema = IocSchema()
+
     try:
-        ioc = get_ioc(cur_id, caseid)
-        if not ioc:
-            return response_error('Invalid IOC ID for this case')
-
-        request_data = call_modules_hook('on_preload_ioc_update', data=request.get_json(), caseid=caseid)
-
-        # validate before saving
-        ioc_schema = IocSchema()
-        request_data['ioc_id'] = cur_id
-        ioc_sc = ioc_schema.load(request_data, instance=ioc)
-        ioc_sc.user_id = current_user.id
-
-        if not check_ioc_type_id(type_id=ioc_sc.ioc_type_id):
-            return response_error('Not a valid IOC type')
-
-        update_ioc_state(caseid=caseid)
-        db.session.commit()
-
-        ioc_sc = call_modules_hook('on_postload_ioc_update', data=ioc_sc, caseid=caseid)
-
-        if ioc_sc:
-            track_activity(f'updated ioc "{ioc_sc.ioc_value}"', caseid=caseid)
-            return response_success(f'Updated ioc "{ioc_sc.ioc_value}"', data=ioc_schema.dump(ioc))
-
-        return response_error('Unable to update ioc for internal reasons')
-
-    except marshmallow.exceptions.ValidationError as e:
-        return response_error(msg='Data error', data=e.messages)
+        ioc, msg = update(cur_id, request.get_json(), caseid)
+        return response_success(msg, data=ioc_schema.dump(ioc))
+    except BusinessProcessingError as e:
+        return response_error(e.get_message(), data=e.get_data())
 
 
 @case_ioc_blueprint.route('/case/ioc/<int:cur_id>/comments/modal', methods=['GET'])

--- a/source/app/blueprints/graphql/cases.py
+++ b/source/app/blueprints/graphql/cases.py
@@ -17,12 +17,23 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from graphene_sqlalchemy import SQLAlchemyObjectType
+from graphene import List
 from graphene.relay import Node
 
 from app.models.cases import Cases
+from app.blueprints.graphql.iocs import IOCObject
+from app.business.iocs import get_iocs
 
 
 class CaseObject(SQLAlchemyObjectType):
     class Meta:
         model = Cases
         interfaces = [Node]
+
+    # TODO add filters
+    # TODO do pagination (maybe present it as a relay Connection?)
+    iocs = List(IOCObject, description='Get IOCs associated with the case')
+
+    @staticmethod
+    def resolve_iocs(root: Cases, info):
+        return get_iocs(root.case_id)

--- a/source/app/blueprints/graphql/graphql_route.py
+++ b/source/app/blueprints/graphql/graphql_route.py
@@ -32,6 +32,7 @@ from app.util import response_error
 from app.datamgmt.manage.manage_cases_db import get_filtered_cases
 from app.blueprints.graphql.cases import CaseObject
 from app.blueprints.graphql.iocs import IOCCreate
+from app.blueprints.graphql.iocs import IOCUpdate
 from app.blueprints.graphql.iocs import IOCDelete
 
 
@@ -49,6 +50,7 @@ class Query(ObjectType):
 
 class Mutation(ObjectType):
     ioc_create = IOCCreate.Field()
+    ioc_update = IOCUpdate.Field()
     ioc_delete = IOCDelete.Field()
 
 

--- a/source/app/blueprints/graphql/graphql_route.py
+++ b/source/app/blueprints/graphql/graphql_route.py
@@ -31,7 +31,7 @@ from app.util import is_user_authenticated
 from app.util import response_error
 from app.datamgmt.manage.manage_cases_db import get_filtered_cases
 from app.blueprints.graphql.cases import CaseObject
-from app.blueprints.graphql.iocs import AddIoc
+from app.blueprints.graphql.iocs import CreateIoc
 
 
 class Query(ObjectType):
@@ -47,7 +47,7 @@ class Query(ObjectType):
 
 
 class Mutation(ObjectType):
-    create_ioc = AddIoc.Field()
+    ioc_create = CreateIoc.Field()
 
 
 def _check_authentication_wrapper(f):

--- a/source/app/blueprints/graphql/graphql_route.py
+++ b/source/app/blueprints/graphql/graphql_route.py
@@ -26,6 +26,8 @@ from graphql_server.flask import GraphQLView
 from graphene import ObjectType
 from graphene import Schema
 from graphene import List
+from graphene import Float
+from graphene import Field
 
 from app.util import is_user_authenticated
 from app.util import response_error
@@ -34,6 +36,7 @@ from app.blueprints.graphql.cases import CaseObject
 from app.blueprints.graphql.iocs import IOCCreate
 from app.blueprints.graphql.iocs import IOCUpdate
 from app.blueprints.graphql.iocs import IOCDelete
+from app.business.cases import get_case_by_identifier
 
 
 class Query(ObjectType):
@@ -41,11 +44,16 @@ class Query(ObjectType):
 
     # starting with the conversion of '/manage/cases/filter'
     cases = List(CaseObject, description='Retrieves cases')
+    case = Field(CaseObject, case_id=Float(), description='Retrieve a case by its identifier')
 
     @staticmethod
     def resolve_cases(root, info):
         # TODO add all parameters to filter
         return get_filtered_cases(current_user.id)
+
+    @staticmethod
+    def resolve_case(root, info, case_id):
+        return get_case_by_identifier(case_id)
 
 
 class Mutation(ObjectType):

--- a/source/app/blueprints/graphql/graphql_route.py
+++ b/source/app/blueprints/graphql/graphql_route.py
@@ -31,7 +31,8 @@ from app.util import is_user_authenticated
 from app.util import response_error
 from app.datamgmt.manage.manage_cases_db import get_filtered_cases
 from app.blueprints.graphql.cases import CaseObject
-from app.blueprints.graphql.iocs import CreateIoc
+from app.blueprints.graphql.iocs import IOCCreate
+from app.blueprints.graphql.iocs import IOCDelete
 
 
 class Query(ObjectType):
@@ -47,7 +48,8 @@ class Query(ObjectType):
 
 
 class Mutation(ObjectType):
-    ioc_create = CreateIoc.Field()
+    ioc_create = IOCCreate.Field()
+    ioc_delete = IOCDelete.Field()
 
 
 def _check_authentication_wrapper(f):

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -67,6 +67,7 @@ class IOCUpdate(Mutation):
 
     class Arguments:
         ioc_id = NonNull(Float)
+        # TODO shouldn't this argument be optional? (unless we want to add the IOC to another case?)
         case_id = NonNull(Float)
         # TODO shouldn't this argument be optional?
         type_id = NonNull(Int)
@@ -74,20 +75,22 @@ class IOCUpdate(Mutation):
         tlp_id = NonNull(Int)
         # TODO shouldn't this argument be optional?
         value = NonNull(String)
-        #description = String()
-        #tags = String()
-        #custom attributes?
-        #enrichment?
+        description = String()
+        tags = String()
 
     ioc = Field(IocObject)
 
     @staticmethod
-    def mutate(root, info, ioc_id, case_id, type_id, tlp_id, value):
+    def mutate(root, info, ioc_id, case_id, type_id, tlp_id, value, description=None, tags=None):
         request = {
             'ioc_type_id': type_id,
             'ioc_tlp_id': tlp_id,
             'ioc_value': value
         }
+        if description:
+            request['ioc_description'] = description
+        if description:
+            request['ioc_tags'] = tags
         ioc, _ = update(ioc_id, request, case_id)
         return IOCCreate(ioc=ioc)
 

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -44,18 +44,18 @@ class CreateIoc(Mutation):
         tlp_id = NonNull(Int)
         value = NonNull(String)
         description = String()
-        # TODO add this non mandatory arguments
-        #tags =
+        tags = String()
 
     ioc = Field(IocObject)
 
     @staticmethod
-    def mutate(root, info, case_id, type_id, tlp_id, value, description=None):
+    def mutate(root, info, case_id, type_id, tlp_id, value, description=None, tags=None):
         request = {
             'ioc_type_id': type_id,
             'ioc_tlp_id': tlp_id,
             'ioc_value': value,
-            'ioc_description': description
+            'ioc_description': description,
+            'ioc_tags': tags
         }
         ioc, _ = create(request, case_id)
         return CreateIoc(ioc=ioc)

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -26,7 +26,9 @@ from graphene import String
 
 from app.models.models import Ioc
 from app.business.iocs import create
+from app.business.iocs import update
 from app.business.iocs import delete
+
 
 class IocObject(SQLAlchemyObjectType):
     class Meta:
@@ -58,6 +60,35 @@ class IOCCreate(Mutation):
             'ioc_tags': tags
         }
         ioc, _ = create(request, case_id)
+        return IOCCreate(ioc=ioc)
+
+
+class IOCUpdate(Mutation):
+
+    class Arguments:
+        ioc_id = NonNull(Float)
+        case_id = NonNull(Float)
+        # TODO shouldn't this argument be optional?
+        type_id = NonNull(Int)
+        # TODO shouldn't this argument be optional?
+        tlp_id = NonNull(Int)
+        # TODO shouldn't this argument be optional?
+        value = NonNull(String)
+        #description = String()
+        #tags = String()
+        #custom attributes?
+        #enrichment?
+
+    ioc = Field(IocObject)
+
+    @staticmethod
+    def mutate(root, info, ioc_id, case_id, type_id, tlp_id, value):
+        request = {
+            'ioc_type_id': type_id,
+            'ioc_tlp_id': tlp_id,
+            'ioc_value': value
+        }
+        ioc, _ = update(ioc_id, request, case_id)
         return IOCCreate(ioc=ioc)
 
 

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -30,7 +30,7 @@ from app.business.iocs import update
 from app.business.iocs import delete
 
 
-class IocObject(SQLAlchemyObjectType):
+class IOCObject(SQLAlchemyObjectType):
     class Meta:
         model = Ioc
 
@@ -48,7 +48,7 @@ class IOCCreate(Mutation):
         description = String()
         tags = String()
 
-    ioc = Field(IocObject)
+    ioc = Field(IOCObject)
 
     @staticmethod
     def mutate(root, info, case_id, type_id, tlp_id, value, description=None, tags=None):
@@ -78,7 +78,7 @@ class IOCUpdate(Mutation):
         description = String()
         tags = String()
 
-    ioc = Field(IocObject)
+    ioc = Field(IOCObject)
 
     @staticmethod
     def mutate(root, info, ioc_id, case_id, type_id, tlp_id, value, description=None, tags=None):

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -26,14 +26,14 @@ from graphene import String
 
 from app.models.models import Ioc
 from app.business.iocs import create
-
+from app.business.iocs import delete
 
 class IocObject(SQLAlchemyObjectType):
     class Meta:
         model = Ioc
 
 
-class CreateIoc(Mutation):
+class IOCCreate(Mutation):
 
     class Arguments:
         # note: it seems really too difficult to work with IDs.
@@ -58,4 +58,18 @@ class CreateIoc(Mutation):
             'ioc_tags': tags
         }
         ioc, _ = create(request, case_id)
-        return CreateIoc(ioc=ioc)
+        return IOCCreate(ioc=ioc)
+
+
+# TODO: this mutation does both IOC creation and IOC link onto case: maybe we should distinguish the two actions
+class IOCDelete(Mutation):
+    class Arguments:
+        ioc_id = NonNull(Float)
+        case_id = NonNull(Float)
+
+    message = String()
+
+    @staticmethod
+    def mutate(root, info, ioc_id, case_id):
+        message = delete(ioc_id, case_id)
+        return IOCDelete(message=message)

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -43,18 +43,19 @@ class AddIoc(Mutation):
         type_id = NonNull(Int)
         tlp_id = NonNull(Int)
         value = NonNull(String)
-        # TODO add these non mandatory arguments
-        #description =
+        description = String()
+        # TODO add this non mandatory arguments
         #tags =
 
     ioc = Field(IocObject)
 
     @staticmethod
-    def mutate(root, info, case_id, type_id, tlp_id, value):
+    def mutate(root, info, case_id, type_id, tlp_id, value, description=None):
         request = {
             'ioc_type_id': type_id,
             'ioc_tlp_id': tlp_id,
-            'ioc_value': value
+            'ioc_value': value,
+            'ioc_description': description
         }
         ioc, _ = create(request, case_id)
         return AddIoc(ioc=ioc)

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -21,6 +21,7 @@ from graphene import Field
 from graphene import Mutation
 from graphene import NonNull
 from graphene import Int
+from graphene import Float
 from graphene import String
 
 from app.models.models import Ioc
@@ -38,8 +39,7 @@ class CreateIoc(Mutation):
         # note: it seems really too difficult to work with IDs.
         #       I don't understand why graphql_relay.from_global_id does not seem to work...
         # note: I prefer NonNull rather than the syntax required=True
-        # TODO: Integers in graphql are only 32 bits. => will this be a problem? Should we use either float or string?
-        case_id = NonNull(Int)
+        case_id = NonNull(Float)
         type_id = NonNull(Int)
         tlp_id = NonNull(Int)
         value = NonNull(String)

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -32,10 +32,10 @@ class IocObject(SQLAlchemyObjectType):
         model = Ioc
 
 
-class AddIoc(Mutation):
+class CreateIoc(Mutation):
 
     class Arguments:
-        # TODO: it seems really too difficult to work with IDs.
+        # note: it seems really too difficult to work with IDs.
         #       I don't understand why graphql_relay.from_global_id does not seem to work...
         # note: I prefer NonNull rather than the syntax required=True
         # TODO: Integers in graphql are only 32 bits. => will this be a problem? Should we use either float or string?
@@ -58,4 +58,4 @@ class AddIoc(Mutation):
             'ioc_description': description
         }
         ioc, _ = create(request, case_id)
-        return AddIoc(ioc=ioc)
+        return CreateIoc(ioc=ioc)

--- a/source/app/business/cases.py
+++ b/source/app/business/cases.py
@@ -25,6 +25,13 @@ from app.datamgmt.manage.manage_cases_db import delete_case
 from app.business.errors import BusinessProcessingError
 from app.business.permissions import check_current_user_has_some_case_access
 from app.business.permissions import check_current_user_has_some_permission
+from app.datamgmt.case.case_db import get_case
+
+
+def get_case_by_identifier(case_identifier):
+    check_current_user_has_some_case_access(case_identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
+
+    return get_case(case_identifier)
 
 
 def delete(case_identifier, context_case_identifier):

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -76,6 +76,8 @@ def create(request_json, case_identifier):
 
 # TODO most probably this method should not require a case_identifier... Since the IOC gets modified for all cases...
 def update(identifier, request_json, case_identifier):
+    check_current_user_has_some_case_access_stricter([CaseAccessLevel.full_access])
+
     try:
         ioc = get_ioc(identifier, case_identifier)
         if not ioc:
@@ -111,6 +113,8 @@ def update(identifier, request_json, case_identifier):
 
 
 def delete(identifier, case_identifier):
+    check_current_user_has_some_case_access_stricter([CaseAccessLevel.full_access])
+
     call_modules_hook('on_preload_ioc_delete', data=identifier, caseid=case_identifier)
     ioc = get_ioc(identifier, case_identifier)
 

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -66,7 +66,7 @@ def create(request_json, case_identifier):
     if ioc:
         track_activity(f'added ioc "{ioc.ioc_value}"', caseid=case_identifier)
 
-        msg = "IOC already existed in DB. Updated with info on DB." if existed else "IOC added"
+        msg = 'IOC already existed in DB. Updated with info on DB.' if existed else 'IOC added'
         return ioc, msg
 
     raise BusinessProcessingError('Unable to create IOC for internal reasons')

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -25,6 +25,7 @@ from app.datamgmt.case.case_iocs_db import add_ioc
 from app.datamgmt.case.case_iocs_db import add_ioc_link
 from app.datamgmt.case.case_iocs_db import check_ioc_type_id
 from app.datamgmt.case.case_iocs_db import get_ioc
+from app.datamgmt.case.case_iocs_db import get_iocs_by_case
 from app.datamgmt.case.case_iocs_db import delete_ioc
 from app.datamgmt.states import update_ioc_state
 from app.schema.marshables import IocSchema
@@ -129,3 +130,9 @@ def delete(identifier, case_identifier):
 
     track_activity(f'deleted IOC "{ioc.ioc_value}"', caseid=case_identifier)
     return f'IOC {identifier} deleted'
+
+
+def get_iocs(case_identifier):
+    check_current_user_has_some_case_access_stricter([CaseAccessLevel.read_only, CaseAccessLevel.full_access])
+
+    return get_iocs_by_case(case_identifier)

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -74,6 +74,7 @@ def create(request_json, case_identifier):
     raise BusinessProcessingError('Unable to create IOC for internal reasons')
 
 
+# TODO most probably this method should not require a case_identifier... Since the IOC gets modified for all cases...
 def update(identifier, request_json, case_identifier):
     try:
         ioc = get_ioc(identifier, case_identifier)

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -72,7 +72,7 @@ def create(request_json, case_identifier):
     raise BusinessProcessingError('Unable to create IOC for internal reasons')
 
 
-def remove_from_case(identifier, case_identifier):
+def delete(identifier, case_identifier):
     call_modules_hook('on_preload_ioc_delete', data=identifier, caseid=case_identifier)
     ioc = get_ioc(identifier, case_identifier)
 
@@ -80,10 +80,10 @@ def remove_from_case(identifier, case_identifier):
         raise BusinessProcessingError('Not a valid IOC for this case')
 
     if not delete_ioc(ioc, case_identifier):
-        track_activity(f"unlinked IOC ID {ioc.ioc_value}", caseid=case_identifier)
+        track_activity(f'unlinked IOC ID {ioc.ioc_value}', caseid=case_identifier)
         return f'IOC {identifier} unlinked'
 
     call_modules_hook('on_postload_ioc_delete', data=identifier, caseid=case_identifier)
 
-    track_activity(f"deleted IOC \"{ioc.ioc_value}\"", caseid=case_identifier)
+    track_activity(f'deleted IOC "{ioc.ioc_value}"', caseid=case_identifier)
     return f'IOC {identifier} deleted'

--- a/source/app/business/permissions.py
+++ b/source/app/business/permissions.py
@@ -26,7 +26,7 @@ from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_
 from app.business.errors import PermissionDeniedError
 
 
-# When moving down premission checks from the REST layer into the business layer,
+# When moving down permission checks from the REST layer into the business layer,
 # this method is used to replace manual calls to ac_fast_check_current_user_has_case_access
 def check_current_user_has_some_case_access(case_identifier, access_levels):
     if not ac_fast_check_current_user_has_case_access(case_identifier, access_levels):
@@ -35,7 +35,7 @@ def check_current_user_has_some_case_access(case_identifier, access_levels):
 
 # TODO: really this and the previous method should be merged.
 #       This one comes from ac_api_case_requires, whereas the other one comes from the way api_delete_case was written...
-# When moving down premission checks from the REST layer into the business layer,
+# When moving down permission checks from the REST layer into the business layer,
 # this method is used to replace annotation ac_api_case_requires
 def check_current_user_has_some_case_access_stricter(access_levels):
     redir, caseid, has_access = get_case_access(request, access_levels, from_api=True)
@@ -48,7 +48,7 @@ def check_current_user_has_some_case_access_stricter(access_levels):
         raise PermissionDeniedError()
 
 
-# When moving down premission checks from the REST layer into the business layer,
+# When moving down permission checks from the REST layer into the business layer,
 # this method is used to replace annotation ac_api_requires
 def check_current_user_has_some_permission(permissions):
     if 'permissions' not in session:

--- a/source/app/business/permissions.py
+++ b/source/app/business/permissions.py
@@ -26,6 +26,8 @@ from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_
 from app.business.errors import PermissionDeniedError
 
 
+# When moving down premission checks from the REST layer into the business layer,
+# this method is used to replace manual calls to ac_fast_check_current_user_has_case_access
 def check_current_user_has_some_case_access(case_identifier, access_levels):
     if not ac_fast_check_current_user_has_case_access(case_identifier, access_levels):
         raise PermissionDeniedError()
@@ -33,6 +35,8 @@ def check_current_user_has_some_case_access(case_identifier, access_levels):
 
 # TODO: really this and the previous method should be merged.
 #       This one comes from ac_api_case_requires, whereas the other one comes from the way api_delete_case was written...
+# When moving down premission checks from the REST layer into the business layer,
+# this method is used to replace annotation ac_api_case_requires
 def check_current_user_has_some_case_access_stricter(access_levels):
     redir, caseid, has_access = get_case_access(request, access_levels, from_api=True)
 
@@ -44,6 +48,8 @@ def check_current_user_has_some_case_access_stricter(access_levels):
         raise PermissionDeniedError()
 
 
+# When moving down premission checks from the REST layer into the business layer,
+# this method is used to replace annotation ac_api_requires
 def check_current_user_has_some_permission(permissions):
     if 'permissions' not in session:
         session['permissions'] = ac_get_effective_permissions_of_user(current_user)

--- a/source/app/datamgmt/case/case_iocs_db.py
+++ b/source/app/datamgmt/case/case_iocs_db.py
@@ -47,6 +47,13 @@ def get_iocs(caseid):
     return iocs
 
 
+def get_iocs_by_case(case_identifier) -> list[Ioc]:
+    return Ioc.query.filter(
+        IocLink.case_id == case_identifier,
+        IocLink.ioc_id == Ioc.ioc_id
+    ).all()
+
+
 def get_ioc(ioc_id, caseid=None):
     if caseid:
         return IocLink.query.with_entities(

--- a/source/app/datamgmt/case/case_iocs_db.py
+++ b/source/app/datamgmt/case/case_iocs_db.py
@@ -174,7 +174,7 @@ def find_ioc(ioc_value, ioc_type_id):
     return ioc
 
 
-def add_ioc(ioc, user_id, caseid):
+def add_ioc(ioc: Ioc, user_id, caseid):
     if not ioc:
         return None, False
 

--- a/tests/iris.py
+++ b/tests/iris.py
@@ -95,4 +95,6 @@ class Iris:
 
     def execute_graphql_query(self, payload):
         response = self._graphql_api.execute(payload)
-        return response.json()
+        body = response.json()
+        print(f'{payload} => {body}')
+        return body

--- a/tests/iris.py
+++ b/tests/iris.py
@@ -84,7 +84,8 @@ class Iris:
             'case_customer': 1,
             'case_soc_id': ''
         }
-        return self._api.post('/manage/cases/add', body)
+        response = self._api.post('/manage/cases/add', body)
+        return response['data']
 
     def update_case(self, case_identifier, data):
         return self._api.post(f'/manage/cases/update/{case_identifier}', data)

--- a/tests/rest_api.py
+++ b/tests/rest_api.py
@@ -37,9 +37,9 @@ class RestApi:
         print(f'GET {url} => {response.status_code} {body}')
         return body
 
-    def post(self, path, payload):
+    def post(self, path, payload, query_parameters=None):
         url = self._build_url(path)
-        response = requests.post(url, headers=self._headers, json=payload)
+        response = requests.post(url, headers=self._headers, params=query_parameters, json=payload)
         body = response.json()
         print(f'POST {url} {payload} => {response.status_code} {body}')
         return body

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -90,22 +90,29 @@ class Tests(TestCase):
         self.assertEqual(b64encode(b'CaseObject:1').decode(), first_case['id'])
 
     def test_graphql_create_ioc_should_not_fail(self):
-        payload = {
-            'query': f'''mutation {{
-                             createIoc(caseId: 1, typeId: 1, tlpId: 1, value: "8.8.8.8",
-                                       description: "some description", tags: "") {{
-                                           ioc {{ iocValue }}
-                             }}
-                         }}'''
-        }
         case = self._subject.create_case()
         case_identifier = case['case_id']
         payload = {
             'query': f'''mutation {{
-                             createIoc(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "8.8.8.8") {{
+                             createIoc(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "8.8.8.8") {{
                                            ioc {{ iocValue }}
                              }}
                          }}'''
         }
         body = self._subject.execute_graphql_query(payload)
         self.assertNotIn('errors', body)
+
+    def test_graphql_create_ioc_should_allow_optional_description_to_be_set(self):
+        case = self._subject.create_case()
+        case_identifier = case['case_id']
+        description = 'some description'
+        payload = {
+            'query': f'''mutation {{
+                             createIoc(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "8.8.8.8"
+                                       description: "{description}") {{
+                                           ioc {{ iocValue iocDescription }}
+                             }}
+                         }}'''
+        }
+        response = self._subject.execute_graphql_query(payload)
+        self.assertEqual(description, response['data']['createIoc']['ioc']['iocDescription'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -192,3 +192,27 @@ class Tests(TestCase):
         }
         response = self._subject.execute_graphql_query(payload)
         self.assertIsNone(response['data']['iocCreate']['ioc']['iocTags'])
+
+    def test_graphql_update_ioc_should_update_tlp(self):
+        case = self._subject.create_case()
+        case_identifier = case['case_id']
+        ioc_value = self._generate_new_dummy_ioc_value()
+        payload = {
+            'query': f'''mutation {{
+                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "{ioc_value}") {{
+                                           ioc {{ iocId }}
+                             }}
+                         }}'''
+        }
+        response = self._subject.execute_graphql_query(payload)
+        ioc_identifier = response['data']['iocCreate']['ioc']['iocId']
+        payload = {
+            'query': f'''mutation {{
+                             iocUpdate(iocId: {ioc_identifier} caseId: {case_identifier}
+                                       typeId: 1 tlpId: 2 value: "{ioc_value}") {{
+                                           ioc {{ iocTlpId }}
+                             }}
+                         }}'''
+        }
+        response = self._subject.execute_graphql_query(payload)
+        self.assertEqual(2, response['data']['iocUpdate']['ioc']['iocTlpId'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -116,3 +116,18 @@ class Tests(TestCase):
         }
         response = self._subject.execute_graphql_query(payload)
         self.assertEqual(description, response['data']['iocCreate']['ioc']['iocDescription'])
+
+    def test_graphql_create_ioc_should_allow_optional_tags_to_be_set(self):
+        case = self._subject.create_case()
+        case_identifier = case['case_id']
+        tags = 'tag1,tag2'
+        payload = {
+            'query': f'''mutation {{
+                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "8.8.8.8"
+                                       tags: "{tags}") {{
+                                           ioc {{ iocTags }}
+                             }}
+                         }}'''
+        }
+        response = self._subject.execute_graphql_query(payload)
+        self.assertEqual(tags, response['data']['iocCreate']['ioc']['iocTags'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -103,7 +103,7 @@ class Tests(TestCase):
         ioc_value = self._generate_new_dummy_ioc_value()
         payload = {
             'query': f'''mutation {{
-                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "{ioc_value}") {{
+                             iocCreate(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "{ioc_value}") {{
                                            ioc {{ iocValue }}
                              }}
                          }}'''
@@ -117,7 +117,7 @@ class Tests(TestCase):
         ioc_value = self._generate_new_dummy_ioc_value()
         payload = {
             'query': f'''mutation {{
-                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "{ioc_value}") {{
+                             iocCreate(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "{ioc_value}") {{
                                  ioc {{ iocId }}
                              }}
                          }}'''
@@ -141,7 +141,7 @@ class Tests(TestCase):
         ioc_value = self._generate_new_dummy_ioc_value()
         payload = {
             'query': f'''mutation {{
-                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "{ioc_value}"
+                             iocCreate(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "{ioc_value}",
                                        description: "{description}") {{
                                            ioc {{ iocDescription }}
                              }}
@@ -157,7 +157,7 @@ class Tests(TestCase):
         ioc_value = self._generate_new_dummy_ioc_value()
         payload = {
             'query': f'''mutation {{
-                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "{ioc_value}"
+                             iocCreate(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "{ioc_value}",
                                        tags: "{tags}") {{
                                            ioc {{ iocTags }}
                              }}
@@ -173,7 +173,7 @@ class Tests(TestCase):
         ioc_value = self._generate_new_dummy_ioc_value()
         payload = {
             'query': f'''mutation {{
-                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "{ioc_value}") {{
+                             iocCreate(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "{ioc_value}") {{
                                            ioc {{ iocId iocDescription }}
                              }}
                          }}'''
@@ -184,7 +184,7 @@ class Tests(TestCase):
         tags = 'tag1,tag2'
         payload = {
             'query': f'''mutation {{
-                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "{ioc_value}"
+                             iocCreate(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "{ioc_value}",
                                        tags: "{tags}") {{
                                            ioc {{ iocId iocTags }}
                              }}
@@ -199,7 +199,7 @@ class Tests(TestCase):
         ioc_value = self._generate_new_dummy_ioc_value()
         payload = {
             'query': f'''mutation {{
-                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "{ioc_value}") {{
+                             iocCreate(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "{ioc_value}") {{
                                            ioc {{ iocId }}
                              }}
                          }}'''
@@ -208,8 +208,8 @@ class Tests(TestCase):
         ioc_identifier = response['data']['iocCreate']['ioc']['iocId']
         payload = {
             'query': f'''mutation {{
-                             iocUpdate(iocId: {ioc_identifier} caseId: {case_identifier}
-                                       typeId: 1 tlpId: 2 value: "{ioc_value}") {{
+                             iocUpdate(iocId: {ioc_identifier}, caseId: {case_identifier},
+                                       typeId: 1, tlpId: 2, value: "{ioc_value}") {{
                                            ioc {{ iocTlpId }}
                              }}
                          }}'''

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -216,3 +216,28 @@ class Tests(TestCase):
         }
         response = self._subject.execute_graphql_query(payload)
         self.assertEqual(2, response['data']['iocUpdate']['ioc']['iocTlpId'])
+
+    def test_graphql_update_ioc_should_update_optional_parameter_description(self):
+        case = self._subject.create_case()
+        case_identifier = case['case_id']
+        ioc_value = self._generate_new_dummy_ioc_value()
+        payload = {
+            'query': f'''mutation {{
+                             iocCreate(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "{ioc_value}") {{
+                                           ioc {{ iocId }}
+                             }}
+                         }}'''
+        }
+        response = self._subject.execute_graphql_query(payload)
+        ioc_identifier = response['data']['iocCreate']['ioc']['iocId']
+        description = 'some description'
+        payload = {
+            'query': f'''mutation {{
+                             iocUpdate(iocId: {ioc_identifier}, caseId: {case_identifier},
+                                       typeId: 1, tlpId: 2, value: "{ioc_value}", description: "{description}") {{
+                                           ioc {{ iocDescription }}
+                             }}
+                         }}'''
+        }
+        response = self._subject.execute_graphql_query(payload)
+        self.assertEqual(description, response['data']['iocUpdate']['ioc']['iocDescription'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -110,7 +110,7 @@ class Tests(TestCase):
             'query': f'''mutation {{
                              createIoc(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "8.8.8.8"
                                        description: "{description}") {{
-                                           ioc {{ iocValue iocDescription }}
+                                           ioc {{ iocDescription }}
                              }}
                          }}'''
         }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -241,3 +241,17 @@ class Tests(TestCase):
         }
         response = self._subject.execute_graphql_query(payload)
         self.assertEqual(description, response['data']['iocUpdate']['ioc']['iocDescription'])
+
+    def test_graphql_case_should_return_a_case_by_its_identifier(self):
+        case = self._subject.create_case()
+        case_identifier = case['case_id']
+        payload = {
+            'query': f'''{{
+                             case(caseId: {case_identifier}) {{
+                                  caseId
+                             }}
+                         }}'''
+        }
+        response = self._subject.execute_graphql_query(payload)
+        print(response)
+        self.assertEqual(case_identifier, response['data']['case']['caseId'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -253,5 +253,27 @@ class Tests(TestCase):
                          }}'''
         }
         response = self._subject.execute_graphql_query(payload)
-        print(response)
         self.assertEqual(case_identifier, response['data']['case']['caseId'])
+
+    def test_graphql_iocs_should_return_all_iocs_of_a_case(self):
+        case = self._subject.create_case()
+        case_identifier = case['case_id']
+        ioc_value = self._generate_new_dummy_ioc_value()
+        payload = {
+            'query': f'''mutation {{
+                             iocCreate(caseId: {case_identifier}, typeId: 1, tlpId: 1, value: "{ioc_value}") {{
+                                           ioc {{ iocId }}
+                             }}
+                         }}'''
+        }
+        response = self._subject.execute_graphql_query(payload)
+        ioc_identifier = response['data']['iocCreate']['ioc']['iocId']
+        payload = {
+            'query': f'''{{
+                             case(caseId: {case_identifier}) {{
+                                 iocs {{ iocId }}
+                             }}
+                         }}'''
+        }
+        response = self._subject.execute_graphql_query(payload)
+        self.assertEqual(ioc_identifier, response['data']['case']['iocs'][0]['iocId'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -94,7 +94,7 @@ class Tests(TestCase):
         case_identifier = case['case_id']
         payload = {
             'query': f'''mutation {{
-                             createIoc(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "8.8.8.8") {{
+                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "8.8.8.8") {{
                                            ioc {{ iocValue }}
                              }}
                          }}'''
@@ -108,11 +108,11 @@ class Tests(TestCase):
         description = 'some description'
         payload = {
             'query': f'''mutation {{
-                             createIoc(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "8.8.8.8"
+                             iocCreate(caseId: {case_identifier} typeId: 1 tlpId: 1 value: "8.8.8.8"
                                        description: "{description}") {{
                                            ioc {{ iocDescription }}
                              }}
                          }}'''
         }
         response = self._subject.execute_graphql_query(payload)
-        self.assertEqual(description, response['data']['createIoc']['ioc']['iocDescription'])
+        self.assertEqual(description, response['data']['iocCreate']['ioc']['iocDescription'])


### PR DESCRIPTION
This PR improves the graphql API with mutations and field related to iocs. It adds:
* mutation ioc_create
* mutation ioc_update
* mutation ioc_delete
* field iocs on the CaseObject to retrieve the list of all iocs associated with the case
* query case to retrieve a case by its identifier
Issue #451 is not completely finished (filters and pagination are not yet implemented for field iocs).
But this branch was getting too long. So it seemed like a good point to capitalize the work done so far into develop (also to avoid potential conflicts when rebasing)