### PR TITLE
Small cleanup related to the caseid and call_modules_hook

### DIFF
--- a/source/app/iris_engine/module_handler/module_handler.py
+++ b/source/app/iris_engine/module_handler/module_handler.py
@@ -487,7 +487,7 @@ def task_hook_wrapper(self, module_name, hook_name, hook_ui_name, data, init_use
         msg = f"Failed to run hook {hook_name} with module {module_name}. Error {str(e)}"
         log.critical(msg)
         log.exception(e)
-        task_status = IStatus.I2Error(message=msg, logs=[traceback.format_exc()], user=init_user, caseid=caseid)
+        task_status = IStatus.I2Error(message=msg, logs=[traceback.format_exc()], user=init_user)
 
     return task_status
 


### PR DESCRIPTION
At first, I thought the caseid parameter of call_modules_hook and task_hook_wrapper were not consumed anywhere.
So I started this branch with the intention of removing it.
Then I found the indirect way it is used through DIM tasks (see https://github.com/orgs/dfir-iris/discussions/2#discussioncomment-9018842 for more details)

I still would like to remove the caseid on the call_module_hooks method. But we need to discuss first...