### PR TITLE
[ADD] Log with uuid when permission is denied

### DIFF
--- a/tests/iris.py
+++ b/tests/iris.py
@@ -21,7 +21,6 @@ import shutil
 import time
 from docker_compose import DockerCompose
 from rest_api import RestApi
-from graphql_api import GraphQLApi
 from server_timeout_error import ServerTimeoutError
 from user import User
 

--- a/tests/iris.py
+++ b/tests/iris.py
@@ -23,6 +23,7 @@ from docker_compose import DockerCompose
 from rest_api import RestApi
 from graphql_api import GraphQLApi
 from server_timeout_error import ServerTimeoutError
+from user import User
 
 API_URL = 'http://127.0.0.1:8000'
 _API_KEY = 'B8BA5D730210B50F41C06941582D7965D57319D5685440587F98DFDC45A01594'
@@ -35,7 +36,7 @@ class Iris:
     def __init__(self):
         self._docker_compose = DockerCompose(_IRIS_PATH)
         self._api = RestApi(API_URL, _API_KEY)
-        self._graphql_api = GraphQLApi(API_URL + '/graphql', _API_KEY)
+        self._administrator = User(API_URL, _API_KEY)
 
     def _wait(self, condition, attempts, sleep_duration=1):
         count = 0
@@ -77,6 +78,16 @@ class Iris:
         }
         return self._api.post('/case/assets/add', body)
 
+    def create_user(self):
+        body = {
+            'user_name': 'aa',
+            'user_login': 'aa',
+            'user_email': 'aa@aa.eu',
+            'user_password': 'aA.1234567890'
+        }
+        user = self._api.post('/manage/users/add', body)
+        return User(API_URL, user['data']['user_api_key'])
+
     def create_case(self):
         body = {
             'case_name': 'case name',
@@ -94,7 +105,4 @@ class Iris:
         return self._api.get('/manage/cases/list')
 
     def execute_graphql_query(self, payload):
-        response = self._graphql_api.execute(payload)
-        body = response.json()
-        print(f'{payload} => {body}')
-        return body
+        return self._administrator.execute_graphql_query(payload)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -290,4 +290,4 @@ class Tests(TestCase):
                          }}'''
         }
         response = user.execute_graphql_query(payload)
-        self.assertRegex(response['errors'][0]['message'], 'Permission denied \(EID [0-9a-f-]{36}\)')
+        self.assertRegex(response['errors'][0]['message'], r'Permission denied \(EID [0-9a-f-]{36}\)')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,12 +26,12 @@ from base64 import b64encode
 class Tests(TestCase):
 
     _subject = None
+    _ioc_count = 0
 
     @classmethod
     def setUpClass(cls) -> None:
         cls._subject = Iris()
         cls._subject.start()
-        cls._ioc_count = 0
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -277,3 +277,17 @@ class Tests(TestCase):
         }
         response = self._subject.execute_graphql_query(payload)
         self.assertEqual(ioc_identifier, response['data']['case']['iocs'][0]['iocId'])
+
+    def test_graphql_case_should_return_error_log_uuid_when_permission_denied(self):
+        user = self._subject.create_user()
+        case = self._subject.create_case()
+        case_identifier = case['case_id']
+        payload = {
+            'query': f'''{{
+                             case(caseId: {case_identifier}) {{
+                                  caseId
+                             }}
+                         }}'''
+        }
+        response = user.execute_graphql_query(payload)
+        self.assertRegex(response['errors'][0]['message'], 'Permission denied \(EID [0-9a-f-]{36}\)')

--- a/tests/user.py
+++ b/tests/user.py
@@ -1,0 +1,30 @@
+#  Copyright (C) 2023 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from graphql_api import GraphQLApi
+
+
+class User:
+
+    def __init__(self, iris_url, api_key):
+        self._graphql_api = GraphQLApi(iris_url + '/graphql', api_key)
+
+    def execute_graphql_query(self, payload):
+        response = self._graphql_api.execute(payload)
+        body = response.json()
+        print(f'{payload} => {body}')
+        return body


### PR DESCRIPTION
This PR adds a warning log with an uuid when permission is denied. The error message returned by the graphql contains the uuid.
Added a corresponding non-regression test.