### PR TITLE
Update case.notes.js to allow auto image upload from copy and paste

### DIFF
--- a/source/app/static/assets/js/iris/case.notes.js
+++ b/source/app/static/assets/js/iris/case.notes.js
@@ -21,6 +21,10 @@ const preventFormDefaultBehaviourOnSubmit = (event) => {
     return false;
 };
 
+var editor = ace.edit("editor_detail",
+    {autoScrollEditorIntoView: true,
+    minLines: 4
+    });
 
 function Collaborator( session_id, n_id ) {
     this.collaboration_socket = collaborator_socket;
@@ -357,6 +361,45 @@ async function note_detail(id) {
 
     });
 }
+
+function handle_ed_paste(event) {
+    filename = null;
+    const { items } = event.originalEvent.clipboardData;
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i]; 
+
+      if (item.kind === 'string') {
+        item.getAsString(function (s){
+            filename = $.trim(s.replace(/\t|\n|\r/g, '')).substring(0, 40);
+        });
+      }
+
+      if (item.kind === 'file') {
+        const blob = item.getAsFile();
+		
+        if (blob !== null) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+				notify_success('The file is uploading in background. Don\'t leave the page');
+
+                if (filename === null) {
+					filename = random_filename(25);
+                }
+
+                upload_interactive_data(e.target.result, filename, function(data){
+                    url = data.data.file_url + case_param();
+                    event.preventDefault();
+                    editor.insertSnippet(`\n![${filename}](${url} =40%x40%)\n`);
+                });
+            };
+			reader.readAsDataURL(blob);
+        } else {
+            notify_error('Unsupported direct paste of this item. Use datastore to upload.');
+        }
+      }
+    }
+}
+
 
 function refresh_ppl_list() {
     $('#ppl_list_viewing').empty();

--- a/source/app/static/assets/js/iris/case.notes.js
+++ b/source/app/static/assets/js/iris/case.notes.js
@@ -389,7 +389,7 @@ function handle_ed_paste(event) {
                 upload_interactive_data(e.target.result, filename, function(data){
                     url = data.data.file_url + case_param();
                     event.preventDefault();
-                    editor.insertSnippet(`\n![${filename}](${url} =40%x40%)\n`);
+                    note_editor.insertSnippet(`\n![${filename}](${url} =100%x40%)\n`);
                 });
             };
 			reader.readAsDataURL(blob);


### PR DESCRIPTION
Historically you use to be able to copy and paste images into the note section and it would auto upload to the datastore, for some reason that no longer works, and when troubleshooting it appears some code was missing from the modified file.

Adding as a pull request to the [FR] drag & drop images into cases / add image button to toolbar #342 request as whilst it fixing what may be a bug it's also a feature so figured it could go here.

code outcome allows a user to copy and paste an image directly into a notes markdown field.