### PR TITLE
add pool_pre_ping option

### DIFF
--- a/source/app/__init__.py
+++ b/source/app/__init__.py
@@ -98,7 +98,8 @@ app.config.from_object('app.configuration.Config')
 cache = Cache(app)
 
 SQLALCHEMY_ENGINE_OPTIONS = {
-    "json_deserializer": partial(json.loads, object_pairs_hook=collections.OrderedDict)
+    "json_deserializer": partial(json.loads, object_pairs_hook=collections.OrderedDict),
+    "pool_pre_ping": True
 }
 
 db = SQLAlchemy(app, engine_options=SQLALCHEMY_ENGINE_OPTIONS)  # flask-sqlalchemy


### PR DESCRIPTION
While working in IRIS, I often caught error 500, and the modules also did not work  (text of the error from the application is below).

This PR solved the specified problem, there are no more problems with the operation of the application.

Error on IRIS side:
```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) server closed the connection unexpectedly
This probably means the server terminated abnormally
[SQL: <SQL QUERY> ]

(Background on this error at: https://sqlalche.me/e/20/e3q8)
```

Error description:
```
OperationalError

Exception raised for errors that are related to the database’s operation and not necessarily under the control of the programmer, e.g. an unexpected disconnect occurs, the data source name is not found, a transaction could not be processed, a memory allocation error occurred during processing, etc.

This error is a [DBAPI Error](https://docs.sqlalchemy.org/en/20/errors.html#error-dbapi) and originates from the database driver (DBAPI), not SQLAlchemy itself.

The OperationalError is the most common (but not the only) error class used by drivers in the context of the database connection being dropped, or not being able to connect to the database. For tips on how to deal with this, see the section [Dealing with Disconnects](https://docs.sqlalchemy.org/en/20/core/pooling.html#pool-disconnects).
```


