### PR TITLE
Trying to simplify no cid required

### DIFF
--- a/source/app/blueprints/activities/activities_routes.py
+++ b/source/app/blueprints/activities/activities_routes.py
@@ -27,7 +27,7 @@ import app
 from app.datamgmt.activities.activities_db import get_all_users_activities
 from app.datamgmt.activities.activities_db import get_users_activities
 from app.models.authorization import Permissions
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_success
 
@@ -52,8 +52,8 @@ def activities_index(caseid: int, url_redir):
 
 
 @activities_blueprint.route('/activities/list', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.activities_read, Permissions.all_activities_read, no_cid_required=True)
-def list_activities(caseid):
+@ac_api_requires(Permissions.activities_read, Permissions.all_activities_read)
+def list_activities():
     # Get User activities from database
 
     user_activities = get_users_activities()
@@ -65,8 +65,8 @@ def list_activities(caseid):
 
 
 @activities_blueprint.route('/activities/list-all', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.all_activities_read, no_cid_required=True)
-def list_all_activities(caseid):
+@ac_api_requires(Permissions.all_activities_read)
+def list_all_activities():
     # Get User activities from database
 
     user_activities = get_all_users_activities()

--- a/source/app/blueprints/activities/activities_routes.py
+++ b/source/app/blueprints/activities/activities_routes.py
@@ -27,7 +27,7 @@ import app
 from app.datamgmt.activities.activities_db import get_all_users_activities
 from app.datamgmt.activities.activities_db import get_users_activities
 from app.models.authorization import Permissions
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_success
 
@@ -52,7 +52,7 @@ def activities_index(caseid: int, url_redir):
 
 
 @activities_blueprint.route('/activities/list', methods=['GET'])
-@ac_api_requires(Permissions.activities_read, Permissions.all_activities_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.activities_read, Permissions.all_activities_read, no_cid_required=True)
 def list_activities(caseid):
     # Get User activities from database
 
@@ -65,7 +65,7 @@ def list_activities(caseid):
 
 
 @activities_blueprint.route('/activities/list-all', methods=['GET'])
-@ac_api_requires(Permissions.all_activities_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.all_activities_read, no_cid_required=True)
 def list_all_activities(caseid):
     # Get User activities from database
 

--- a/source/app/blueprints/activities/activities_routes.py
+++ b/source/app/blueprints/activities/activities_routes.py
@@ -16,7 +16,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-# IMPORTS ------------------------------------------------
 import os
 from flask import Blueprint
 from flask import redirect
@@ -41,7 +40,6 @@ activities_blueprint = Blueprint(
 basedir = os.path.abspath(os.path.dirname(app.__file__))
 
 
-# CONTENT ------------------------------------------------
 @activities_blueprint.route('/activities', methods=['GET'])
 @ac_requires(Permissions.activities_read, Permissions.all_activities_read)
 def activities_index(caseid: int, url_redir):
@@ -54,7 +52,7 @@ def activities_index(caseid: int, url_redir):
 
 
 @activities_blueprint.route('/activities/list', methods=['GET'])
-@ac_api_requires(Permissions.activities_read, Permissions.all_activities_read)
+@ac_api_requires(Permissions.activities_read, Permissions.all_activities_read, no_cid_required=True)
 def list_activities(caseid):
     # Get User activities from database
 
@@ -67,7 +65,7 @@ def list_activities(caseid):
 
 
 @activities_blueprint.route('/activities/list-all', methods=['GET'])
-@ac_api_requires(Permissions.all_activities_read)
+@ac_api_requires(Permissions.all_activities_read, no_cid_required=True)
 def list_all_activities(caseid):
     # Get User activities from database
 

--- a/source/app/blueprints/alerts/alerts_routes.py
+++ b/source/app/blueprints/alerts/alerts_routes.py
@@ -39,7 +39,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.alerts import AlertStatus
 from app.models.authorization import Permissions
 from app.schema.marshables import AlertSchema, CaseSchema, CommentSchema, CaseAssetsSchema, IocSchema
-from app.util import ac_api_requires, response_error, add_obj_history_entry, ac_requires
+from app.util import ac_api_requires_deprecated, response_error, add_obj_history_entry, ac_requires
 from app.util import response_success
 
 alerts_blueprint = Blueprint(
@@ -51,7 +51,7 @@ alerts_blueprint = Blueprint(
 
 # CONTENT ------------------------------------------------
 @alerts_blueprint.route('/alerts/filter', methods=['GET'])
-@ac_api_requires(Permissions.alerts_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_read, no_cid_required=True)
 def alerts_list_route(caseid) -> Response:
     """
     Get a list of alerts from the database
@@ -147,7 +147,7 @@ def alerts_list_route(caseid) -> Response:
 
 
 @alerts_blueprint.route('/alerts/add', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alerts_add_route(caseid) -> Response:
     """
     Add a new alert to the database
@@ -219,7 +219,7 @@ def alerts_add_route(caseid) -> Response:
 
 
 @alerts_blueprint.route('/alerts/<int:alert_id>', methods=['GET'])
-@ac_api_requires(Permissions.alerts_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_read, no_cid_required=True)
 def alerts_get_route(caseid, alert_id) -> Response:
     """
     Get an alert from the database
@@ -254,7 +254,7 @@ def alerts_get_route(caseid, alert_id) -> Response:
 
 
 @alerts_blueprint.route('/alerts/similarities/<int:alert_id>', methods=['GET'])
-@ac_api_requires(Permissions.alerts_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_read, no_cid_required=True)
 def alerts_similarities_route(caseid, alert_id) -> Response:
     """
     Get an alert and similarities from the database
@@ -299,7 +299,7 @@ def alerts_similarities_route(caseid, alert_id) -> Response:
 
 
 @alerts_blueprint.route('/alerts/update/<int:alert_id>', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alerts_update_route(alert_id, caseid) -> Response:
     """
     Update an alert in the database
@@ -385,7 +385,7 @@ def alerts_update_route(alert_id, caseid) -> Response:
 
 
 @alerts_blueprint.route('/alerts/batch/update', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alerts_batch_update_route(caseid: int) -> Response:
     """
     Update multiple alerts in the database
@@ -452,7 +452,7 @@ def alerts_batch_update_route(caseid: int) -> Response:
 
 
 @alerts_blueprint.route('/alerts/batch/delete', methods=['POST'])
-@ac_api_requires(Permissions.alerts_delete, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_delete, no_cid_required=True)
 def alerts_batch_delete_route(caseid: int) -> Response:
     """
     Delete multiple alerts from the database
@@ -497,7 +497,7 @@ def alerts_batch_delete_route(caseid: int) -> Response:
 
 
 @alerts_blueprint.route('/alerts/delete/<int:alert_id>', methods=['POST'])
-@ac_api_requires(Permissions.alerts_delete, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_delete, no_cid_required=True)
 def alerts_delete_route(alert_id, caseid) -> Response:
     """
     Delete an alert from the database
@@ -540,7 +540,7 @@ def alerts_delete_route(alert_id, caseid) -> Response:
 
 
 @alerts_blueprint.route('/alerts/escalate/<int:alert_id>', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alerts_escalate_route(alert_id, caseid) -> Response:
     """
     Escalate an alert
@@ -611,7 +611,7 @@ def alerts_escalate_route(alert_id, caseid) -> Response:
 
 
 @alerts_blueprint.route('/alerts/merge/<int:alert_id>', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alerts_merge_route(alert_id, caseid) -> Response:
     """
     Merge an alert into a case
@@ -679,7 +679,7 @@ def alerts_merge_route(alert_id, caseid) -> Response:
 
 
 @alerts_blueprint.route('/alerts/unmerge/<int:alert_id>', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alerts_unmerge_route(alert_id, caseid) -> Response:
     """
     Unmerge an alert from a case
@@ -735,7 +735,7 @@ def alerts_unmerge_route(alert_id, caseid) -> Response:
 
 
 @alerts_blueprint.route('/alerts/batch/merge', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alerts_batch_merge_route(caseid) -> Response:
     """
     Merge multiple alerts into a case
@@ -814,7 +814,7 @@ def alerts_batch_merge_route(caseid) -> Response:
 
 
 @alerts_blueprint.route('/alerts/batch/escalate', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alerts_batch_escalate_route(caseid) -> Response:
     """
     Escalate multiple alerts into a case
@@ -938,7 +938,7 @@ def alert_comment_modal(cur_id, caseid, url_redir):
 
 
 @alerts_blueprint.route('/alerts/<int:alert_id>/comments/list', methods=['GET'])
-@ac_api_requires(Permissions.alerts_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_read, no_cid_required=True)
 def alert_comments_get(alert_id, caseid):
     """
     Get the comments for an alert
@@ -966,7 +966,7 @@ def alert_comments_get(alert_id, caseid):
 
 
 @alerts_blueprint.route('/alerts/<int:alert_id>/comments/<int:com_id>/delete', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alert_comment_delete(alert_id, com_id, caseid):
     """
     Delete a comment for an alert
@@ -999,7 +999,7 @@ def alert_comment_delete(alert_id, com_id, caseid):
 
 
 @alerts_blueprint.route('/alerts/<int:alert_id>/comments/<int:com_id>', methods=['GET'])
-@ac_api_requires(Permissions.alerts_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_read, no_cid_required=True)
 def alert_comment_get(alert_id, com_id, caseid):
     """
     Get a comment for an alert
@@ -1028,7 +1028,7 @@ def alert_comment_get(alert_id, com_id, caseid):
 
 
 @alerts_blueprint.route('/alerts/<int:alert_id>/comments/<int:com_id>/edit', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def alert_comment_edit(alert_id, com_id, caseid):
     """
     Edit a comment for an alert
@@ -1052,7 +1052,7 @@ def alert_comment_edit(alert_id, com_id, caseid):
 
 
 @alerts_blueprint.route('/alerts/<int:alert_id>/comments/add', methods=['POST'])
-@ac_api_requires(Permissions.alerts_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.alerts_write, no_cid_required=True)
 def case_comment_add(alert_id, caseid):
     """
     Add a comment to an alert

--- a/source/app/blueprints/api/api_routes.py
+++ b/source/app/blueprints/api/api_routes.py
@@ -19,7 +19,7 @@
 from flask import Blueprint, jsonify, render_template
 
 from app import app
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import response_success
 
 api_blueprint = Blueprint(
@@ -31,13 +31,13 @@ api_blueprint = Blueprint(
 
 # CONTENT ------------------------------------------------
 @api_blueprint.route('/api/ping', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def api_ping(caseid):
     return response_success("pong")
 
 
 @api_blueprint.route('/api/versions', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def api_version(caseid):
     versions = {
         "iris_current": app.config.get('IRIS_VERSION'),

--- a/source/app/blueprints/api/api_routes.py
+++ b/source/app/blueprints/api/api_routes.py
@@ -16,10 +16,10 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from flask import Blueprint, jsonify, render_template
+from flask import Blueprint
 
 from app import app
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import response_success
 
 api_blueprint = Blueprint(
@@ -31,14 +31,14 @@ api_blueprint = Blueprint(
 
 # CONTENT ------------------------------------------------
 @api_blueprint.route('/api/ping', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def api_ping(caseid):
+@ac_api_requires()
+def api_ping():
     return response_success("pong")
 
 
 @api_blueprint.route('/api/versions', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def api_version(caseid):
+@ac_api_requires()
+def api_version():
     versions = {
         "iris_current": app.config.get('IRIS_VERSION'),
         "api_min": app.config.get('API_MIN_VERSION'),

--- a/source/app/blueprints/api/api_routes.py
+++ b/source/app/blueprints/api/api_routes.py
@@ -31,13 +31,13 @@ api_blueprint = Blueprint(
 
 # CONTENT ------------------------------------------------
 @api_blueprint.route('/api/ping', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def api_ping(caseid):
     return response_success("pong")
 
 
 @api_blueprint.route('/api/versions', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def api_version(caseid):
     versions = {
         "iris_current": app.config.get('IRIS_VERSION'),

--- a/source/app/blueprints/context/context.py
+++ b/source/app/blueprints/context/context.py
@@ -17,7 +17,6 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from flask import Blueprint
-# IMPORTS ------------------------------------------------
 from flask import redirect
 from flask import request
 from flask_login import current_user
@@ -25,16 +24,14 @@ from flask_login import current_user
 from app import app
 from app import cache
 from app import db
-from app.datamgmt.context.context_db import ctx_get_user_cases
 from app.datamgmt.context.context_db import ctx_search_user_cases
 from app.models.authorization import Permissions
 from app.models.cases import Cases
 from app.models.models import Client
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import not_authenticated_redirection_url
 from app.util import response_success
 
-# CONTENT ------------------------------------------------
 ctx_blueprint = Blueprint(
     'context',
     __name__,
@@ -80,8 +77,8 @@ def has_updates():
 
 
 @ctx_blueprint.route('/context/search-cases', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def cases_context_search(caseid):
+@ac_api_requires()
+def cases_context_search():
     search = request.args.get('q')
 
     # Get all investigations not closed

--- a/source/app/blueprints/context/context.py
+++ b/source/app/blueprints/context/context.py
@@ -30,7 +30,7 @@ from app.datamgmt.context.context_db import ctx_search_user_cases
 from app.models.authorization import Permissions
 from app.models.cases import Cases
 from app.models.models import Client
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import not_authenticated_redirection_url
 from app.util import response_success
 
@@ -80,7 +80,7 @@ def has_updates():
 
 
 @ctx_blueprint.route('/context/search-cases', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def cases_context_search(caseid):
     search = request.args.get('q')
 

--- a/source/app/blueprints/dashboard/dashboard_routes.py
+++ b/source/app/blueprints/dashboard/dashboard_routes.py
@@ -49,7 +49,7 @@ from app.models.models import TaskStatus
 from app.models.models import UserActivity
 from app.schema.marshables import CaseTaskSchema, CaseSchema, CaseDetailsSchema
 from app.schema.marshables import GlobalTasksSchema
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import not_authenticated_redirection_url
 from app.util import response_error
@@ -82,7 +82,7 @@ def logout():
 
 
 @dashboard_blueprint.route('/dashboard/case_charts', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_cases_charts(caseid):
     """
     Get case charts
@@ -146,7 +146,7 @@ def index(caseid, url_redir):
 
 
 @dashboard_blueprint.route('/global/tasks/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_gtasks(caseid):
 
     tasks_list = list_global_tasks()
@@ -165,7 +165,7 @@ def get_gtasks(caseid):
 
 
 @dashboard_blueprint.route('/user/cases/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_own_cases(caseid):
 
     cases = list_user_cases(
@@ -176,7 +176,7 @@ def list_own_cases(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/<int:cur_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def view_gtask(cur_id, caseid):
 
     task = get_global_task(task_id=cur_id)
@@ -187,7 +187,7 @@ def view_gtask(cur_id, caseid):
 
 
 @dashboard_blueprint.route('/user/tasks/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_utasks(caseid):
 
     ct = list_user_tasks()
@@ -206,7 +206,7 @@ def get_utasks(caseid):
 
 
 @dashboard_blueprint.route('/user/reviews/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_reviews(caseid):
 
     ct = list_user_reviews()
@@ -221,7 +221,7 @@ def get_reviews(caseid):
 
 
 @dashboard_blueprint.route('/user/tasks/status/update', methods=['POST'])
-@ac_api_requires()
+@ac_api_requires_deprecated()
 def utask_statusupdate(caseid):
     jsdata = request.get_json()
     if not jsdata:
@@ -255,7 +255,7 @@ def utask_statusupdate(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/add/modal', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def add_gtask_modal(caseid):
     task = GlobalTasks()
 
@@ -268,7 +268,7 @@ def add_gtask_modal(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/add', methods=['POST'])
-@ac_api_requires()
+@ac_api_requires_deprecated()
 def add_gtask(caseid):
 
     try:
@@ -302,7 +302,7 @@ def add_gtask(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/update/<int:cur_id>/modal', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def edit_gtask_modal(cur_id, caseid):
     form = CaseGlobalTaskForm()
     task = GlobalTasks.query.filter(GlobalTasks.id == cur_id).first()
@@ -320,7 +320,7 @@ def edit_gtask_modal(cur_id, caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires()
+@ac_api_requires_deprecated()
 def edit_gtask(cur_id, caseid):
 
     form = CaseGlobalTaskForm()
@@ -354,7 +354,7 @@ def edit_gtask(cur_id, caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires()
+@ac_api_requires_deprecated()
 def gtask_delete(cur_id, caseid):
 
     call_modules_hook('on_preload_global_task_delete', data=cur_id, caseid=caseid)

--- a/source/app/blueprints/dashboard/dashboard_routes.py
+++ b/source/app/blueprints/dashboard/dashboard_routes.py
@@ -82,7 +82,7 @@ def logout():
 
 
 @dashboard_blueprint.route('/dashboard/case_charts', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def get_cases_charts(caseid):
     """
     Get case charts
@@ -146,7 +146,7 @@ def index(caseid, url_redir):
 
 
 @dashboard_blueprint.route('/global/tasks/list', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def get_gtasks(caseid):
 
     tasks_list = list_global_tasks()
@@ -165,7 +165,7 @@ def get_gtasks(caseid):
 
 
 @dashboard_blueprint.route('/user/cases/list', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def list_own_cases(caseid):
 
     cases = list_user_cases(
@@ -176,7 +176,7 @@ def list_own_cases(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/<int:cur_id>', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def view_gtask(cur_id, caseid):
 
     task = get_global_task(task_id=cur_id)
@@ -187,7 +187,7 @@ def view_gtask(cur_id, caseid):
 
 
 @dashboard_blueprint.route('/user/tasks/list', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def get_utasks(caseid):
 
     ct = list_user_tasks()
@@ -206,7 +206,7 @@ def get_utasks(caseid):
 
 
 @dashboard_blueprint.route('/user/reviews/list', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def get_reviews(caseid):
 
     ct = list_user_reviews()
@@ -255,7 +255,7 @@ def utask_statusupdate(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/add/modal', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def add_gtask_modal(caseid):
     task = GlobalTasks()
 
@@ -302,7 +302,7 @@ def add_gtask(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/update/<int:cur_id>/modal', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def edit_gtask_modal(cur_id, caseid):
     form = CaseGlobalTaskForm()
     task = GlobalTasks.query.filter(GlobalTasks.id == cur_id).first()

--- a/source/app/blueprints/dashboard/dashboard_routes.py
+++ b/source/app/blueprints/dashboard/dashboard_routes.py
@@ -17,9 +17,9 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import marshmallow
-# IMPORTS ------------------------------------------------
 from datetime import datetime
 from datetime import timedelta
+
 from flask import Blueprint
 from flask import redirect
 from flask import render_template
@@ -29,7 +29,6 @@ from flask import url_for
 from flask_login import current_user
 from flask_login import logout_user
 from flask_wtf import FlaskForm
-from sqlalchemy import distinct
 
 from app import app
 from app import db
@@ -46,10 +45,10 @@ from app.models.cases import Cases
 from app.models.models import CaseTasks
 from app.models.models import GlobalTasks
 from app.models.models import TaskStatus
-from app.models.models import UserActivity
-from app.schema.marshables import CaseTaskSchema, CaseSchema, CaseDetailsSchema
+from app.schema.marshables import CaseTaskSchema, CaseDetailsSchema
 from app.schema.marshables import GlobalTasksSchema
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
+from app.util import ac_requires_case_identifier
 from app.util import ac_requires
 from app.util import not_authenticated_redirection_url
 from app.util import response_error
@@ -82,8 +81,8 @@ def logout():
 
 
 @dashboard_blueprint.route('/dashboard/case_charts', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_cases_charts(caseid):
+@ac_api_requires()
+def get_cases_charts():
     """
     Get case charts
     :return: JSON
@@ -146,8 +145,8 @@ def index(caseid, url_redir):
 
 
 @dashboard_blueprint.route('/global/tasks/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_gtasks(caseid):
+@ac_api_requires()
+def get_gtasks():
 
     tasks_list = list_global_tasks()
 
@@ -165,8 +164,8 @@ def get_gtasks(caseid):
 
 
 @dashboard_blueprint.route('/user/cases/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_own_cases(caseid):
+@ac_api_requires()
+def list_own_cases():
 
     cases = list_user_cases(
         request.args.get('show_closed', 'false', type=str).lower() == 'true'
@@ -176,8 +175,8 @@ def list_own_cases(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def view_gtask(cur_id, caseid):
+@ac_api_requires()
+def view_gtask(cur_id):
 
     task = get_global_task(task_id=cur_id)
     if not task:
@@ -187,8 +186,8 @@ def view_gtask(cur_id, caseid):
 
 
 @dashboard_blueprint.route('/user/tasks/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_utasks(caseid):
+@ac_api_requires()
+def get_utasks():
 
     ct = list_user_tasks()
 
@@ -206,8 +205,8 @@ def get_utasks(caseid):
 
 
 @dashboard_blueprint.route('/user/reviews/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_reviews(caseid):
+@ac_api_requires()
+def get_reviews():
 
     ct = list_user_reviews()
 
@@ -221,7 +220,8 @@ def get_reviews(caseid):
 
 
 @dashboard_blueprint.route('/user/tasks/status/update', methods=['POST'])
-@ac_api_requires_deprecated()
+@ac_api_requires()
+@ac_requires_case_identifier()
 def utask_statusupdate(caseid):
     jsdata = request.get_json()
     if not jsdata:
@@ -255,8 +255,8 @@ def utask_statusupdate(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/add/modal', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def add_gtask_modal(caseid):
+@ac_api_requires()
+def add_gtask_modal():
     task = GlobalTasks()
 
     form = CaseGlobalTaskForm()
@@ -268,7 +268,8 @@ def add_gtask_modal(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/add', methods=['POST'])
-@ac_api_requires_deprecated()
+@ac_api_requires()
+@ac_requires_case_identifier()
 def add_gtask(caseid):
 
     try:
@@ -302,8 +303,8 @@ def add_gtask(caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/update/<int:cur_id>/modal', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def edit_gtask_modal(cur_id, caseid):
+@ac_api_requires()
+def edit_gtask_modal(cur_id):
     form = CaseGlobalTaskForm()
     task = GlobalTasks.query.filter(GlobalTasks.id == cur_id).first()
     form.task_assignee_id.choices = [(user.id, user.name) for user in
@@ -320,7 +321,8 @@ def edit_gtask_modal(cur_id, caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated()
+@ac_api_requires()
+@ac_requires_case_identifier()
 def edit_gtask(cur_id, caseid):
 
     form = CaseGlobalTaskForm()
@@ -354,7 +356,8 @@ def edit_gtask(cur_id, caseid):
 
 
 @dashboard_blueprint.route('/global/tasks/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated()
+@ac_api_requires()
+@ac_requires_case_identifier()
 def gtask_delete(cur_id, caseid):
 
     call_modules_hook('on_preload_global_task_delete', data=cur_id, caseid=caseid)

--- a/source/app/blueprints/dim_tasks/dim_tasks.py
+++ b/source/app/blueprints/dim_tasks/dim_tasks.py
@@ -16,7 +16,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-# IMPORTS ------------------------------------------------
 import json
 import os
 import pickle
@@ -46,7 +45,7 @@ from app.models.alerts import Alert
 from app.models.authorization import CaseAccessLevel
 from app.models.authorization import Permissions
 from app.util import ac_api_case_requires
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_case_requires
 from app.util import ac_requires
 from app.util import response_error
@@ -75,8 +74,8 @@ def dim_index(caseid: int, url_redir):
 
 
 @dim_tasks_blueprint.route('/dim/hooks/options/<hook_type>/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_dim_hook_options_ioc(hook_type, caseid):
+@ac_api_requires()
+def list_dim_hook_options_ioc(hook_type):
     mods_options = (IrisModuleHook.query.with_entities(
         IrisModuleHook.manual_hook_ui_name,
         IrisHook.hook_name,
@@ -201,8 +200,8 @@ def dim_hooks_call(caseid):
 
 
 @dim_tasks_blueprint.route('/dim/tasks/list/<int:count>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_dim_tasks(count, caseid):
+@ac_api_requires()
+def list_dim_tasks(count):
     tasks = CeleryTaskMeta.query.filter(
         ~ CeleryTaskMeta.name.like('app.iris_engine.updater.updater.%')
     ).order_by(desc(CeleryTaskMeta.date_done)).limit(count).all()

--- a/source/app/blueprints/dim_tasks/dim_tasks.py
+++ b/source/app/blueprints/dim_tasks/dim_tasks.py
@@ -46,7 +46,7 @@ from app.models.alerts import Alert
 from app.models.authorization import CaseAccessLevel
 from app.models.authorization import Permissions
 from app.util import ac_api_case_requires
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_case_requires
 from app.util import ac_requires
 from app.util import response_error
@@ -75,7 +75,7 @@ def dim_index(caseid: int, url_redir):
 
 
 @dim_tasks_blueprint.route('/dim/hooks/options/<hook_type>/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_dim_hook_options_ioc(hook_type, caseid):
     mods_options = (IrisModuleHook.query.with_entities(
         IrisModuleHook.manual_hook_ui_name,
@@ -201,7 +201,7 @@ def dim_hooks_call(caseid):
 
 
 @dim_tasks_blueprint.route('/dim/tasks/list/<int:count>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_dim_tasks(count, caseid):
     tasks = CeleryTaskMeta.query.filter(
         ~ CeleryTaskMeta.name.like('app.iris_engine.updater.updater.%')

--- a/source/app/blueprints/dim_tasks/dim_tasks.py
+++ b/source/app/blueprints/dim_tasks/dim_tasks.py
@@ -75,7 +75,7 @@ def dim_index(caseid: int, url_redir):
 
 
 @dim_tasks_blueprint.route('/dim/hooks/options/<hook_type>/list', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def list_dim_hook_options_ioc(hook_type, caseid):
     mods_options = (IrisModuleHook.query.with_entities(
         IrisModuleHook.manual_hook_ui_name,
@@ -201,7 +201,7 @@ def dim_hooks_call(caseid):
 
 
 @dim_tasks_blueprint.route('/dim/tasks/list/<int:count>', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def list_dim_tasks(count, caseid):
     tasks = CeleryTaskMeta.query.filter(
         ~ CeleryTaskMeta.name.like('app.iris_engine.updater.updater.%')

--- a/source/app/blueprints/filters/filters_routes.py
+++ b/source/app/blueprints/filters/filters_routes.py
@@ -23,14 +23,14 @@ from app import db
 from app.datamgmt.filters.filters_db import get_filter_by_id, list_filters_by_type
 from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import SavedFilterSchema
-from app.util import ac_api_requires, response_success, response_error
+from app.util import ac_api_requires_deprecated, response_success, response_error
 
 saved_filters_blueprint = Blueprint('saved_filters', __name__,
                                     template_folder='templates')
 
 
 @saved_filters_blueprint.route('/filters/add', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def filters_add_route(caseid) -> Response:
     """
     Add a new saved filter
@@ -63,7 +63,7 @@ def filters_add_route(caseid) -> Response:
 
 
 @saved_filters_blueprint.route('/filters/update/<int:filter_id>', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def filters_update_route(filter_id, caseid) -> Response:
     """
     Update a saved filter
@@ -96,7 +96,7 @@ def filters_update_route(filter_id, caseid) -> Response:
 
 
 @saved_filters_blueprint.route('/filters/delete/<int:filter_id>', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def filters_delete_route(filter_id, caseid) -> Response:
     """
     Delete a saved filter
@@ -125,7 +125,7 @@ def filters_delete_route(filter_id, caseid) -> Response:
 
 
 @saved_filters_blueprint.route('/filters/<int:filter_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def filters_get_route(filter_id, caseid) -> Response:
     """
     Get a saved filter
@@ -151,7 +151,7 @@ def filters_get_route(filter_id, caseid) -> Response:
 
 
 @saved_filters_blueprint.route('/filters/<string:filter_type>/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def filters_list_route(filter_type, caseid) -> Response:
     """
     List saved filters

--- a/source/app/blueprints/filters/filters_routes.py
+++ b/source/app/blueprints/filters/filters_routes.py
@@ -20,18 +20,21 @@ from flask_login import current_user
 from werkzeug import Response
 
 from app import db
-from app.datamgmt.filters.filters_db import get_filter_by_id, list_filters_by_type
+from app.datamgmt.filters.filters_db import get_filter_by_id
+from app.datamgmt.filters.filters_db import list_filters_by_type
 from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import SavedFilterSchema
-from app.util import ac_api_requires_deprecated, response_success, response_error
+from app.util import ac_api_requires
+from app.util import response_success
+from app.util import response_error
 
 saved_filters_blueprint = Blueprint('saved_filters', __name__,
                                     template_folder='templates')
 
 
 @saved_filters_blueprint.route('/filters/add', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def filters_add_route(caseid) -> Response:
+@ac_api_requires()
+def filters_add_route() -> Response:
     """
     Add a new saved filter
 
@@ -63,8 +66,8 @@ def filters_add_route(caseid) -> Response:
 
 
 @saved_filters_blueprint.route('/filters/update/<int:filter_id>', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def filters_update_route(filter_id, caseid) -> Response:
+@ac_api_requires()
+def filters_update_route(filter_id) -> Response:
     """
     Update a saved filter
 
@@ -96,8 +99,8 @@ def filters_update_route(filter_id, caseid) -> Response:
 
 
 @saved_filters_blueprint.route('/filters/delete/<int:filter_id>', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def filters_delete_route(filter_id, caseid) -> Response:
+@ac_api_requires()
+def filters_delete_route(filter_id) -> Response:
     """
     Delete a saved filter
 
@@ -125,8 +128,8 @@ def filters_delete_route(filter_id, caseid) -> Response:
 
 
 @saved_filters_blueprint.route('/filters/<int:filter_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def filters_get_route(filter_id, caseid) -> Response:
+@ac_api_requires()
+def filters_get_route(filter_id) -> Response:
     """
     Get a saved filter
 
@@ -151,8 +154,8 @@ def filters_get_route(filter_id, caseid) -> Response:
 
 
 @saved_filters_blueprint.route('/filters/<string:filter_type>/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def filters_list_route(filter_type, caseid) -> Response:
+@ac_api_requires()
+def filters_list_route(filter_type) -> Response:
     """
     List saved filters
 

--- a/source/app/blueprints/manage/manage_access_control.py
+++ b/source/app/blueprints/manage/manage_access_control.py
@@ -25,7 +25,7 @@ from app.iris_engine.access_control.utils import ac_recompute_effective_ac
 from app.iris_engine.access_control.utils import ac_trace_effective_user_permissions
 from app.iris_engine.access_control.utils import ac_trace_user_effective_cases_access_2
 from app.models.authorization import Permissions
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_success
 
@@ -48,7 +48,7 @@ def manage_ac_index(caseid, url_redir):
 
 
 @manage_ac_blueprint.route('/manage/access-control/recompute-effective-users-ac', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_ac_compute_effective_all_ac(caseid):
 
     ac_recompute_all_users_effective_ac()
@@ -57,7 +57,7 @@ def manage_ac_compute_effective_all_ac(caseid):
 
 
 @manage_ac_blueprint.route('/manage/access-control/recompute-effective-user-ac/<int:cur_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_ac_compute_effective_ac(cur_id, caseid):
 
     ac_recompute_effective_ac(cur_id)
@@ -66,7 +66,7 @@ def manage_ac_compute_effective_ac(cur_id, caseid):
 
 
 @manage_ac_blueprint.route('/manage/access-control/audit/users/<int:cur_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_ac_audit_user(cur_id, caseid):
     user_audit = {
         'access_audit': ac_trace_user_effective_cases_access_2(cur_id),
@@ -77,7 +77,7 @@ def manage_ac_audit_user(cur_id, caseid):
 
 
 @manage_ac_blueprint.route('/manage/access-control/audit/users/<int:cur_id>/modal', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_ac_audit_user_modal(cur_id, caseid):
     access_audit = ac_trace_user_effective_cases_access_2(cur_id)
     permissions_audit = ac_trace_effective_user_permissions(cur_id)

--- a/source/app/blueprints/manage/manage_access_control.py
+++ b/source/app/blueprints/manage/manage_access_control.py
@@ -48,7 +48,7 @@ def manage_ac_index(caseid, url_redir):
 
 
 @manage_ac_blueprint.route('/manage/access-control/recompute-effective-users-ac', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator)
+@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
 def manage_ac_compute_effective_all_ac(caseid):
 
     ac_recompute_all_users_effective_ac()
@@ -57,7 +57,7 @@ def manage_ac_compute_effective_all_ac(caseid):
 
 
 @manage_ac_blueprint.route('/manage/access-control/recompute-effective-user-ac/<int:cur_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator)
+@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
 def manage_ac_compute_effective_ac(cur_id, caseid):
 
     ac_recompute_effective_ac(cur_id)
@@ -66,7 +66,7 @@ def manage_ac_compute_effective_ac(cur_id, caseid):
 
 
 @manage_ac_blueprint.route('/manage/access-control/audit/users/<int:cur_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator)
+@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
 def manage_ac_audit_user(cur_id, caseid):
     user_audit = {
         'access_audit': ac_trace_user_effective_cases_access_2(cur_id),
@@ -77,7 +77,7 @@ def manage_ac_audit_user(cur_id, caseid):
 
 
 @manage_ac_blueprint.route('/manage/access-control/audit/users/<int:cur_id>/modal', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator)
+@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
 def manage_ac_audit_user_modal(cur_id, caseid):
     access_audit = ac_trace_user_effective_cases_access_2(cur_id)
     permissions_audit = ac_trace_effective_user_permissions(cur_id)

--- a/source/app/blueprints/manage/manage_access_control.py
+++ b/source/app/blueprints/manage/manage_access_control.py
@@ -25,7 +25,7 @@ from app.iris_engine.access_control.utils import ac_recompute_effective_ac
 from app.iris_engine.access_control.utils import ac_trace_effective_user_permissions
 from app.iris_engine.access_control.utils import ac_trace_user_effective_cases_access_2
 from app.models.authorization import Permissions
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_success
 
@@ -48,8 +48,8 @@ def manage_ac_index(caseid, url_redir):
 
 
 @manage_ac_blueprint.route('/manage/access-control/recompute-effective-users-ac', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_ac_compute_effective_all_ac(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_ac_compute_effective_all_ac():
 
     ac_recompute_all_users_effective_ac()
 
@@ -57,8 +57,8 @@ def manage_ac_compute_effective_all_ac(caseid):
 
 
 @manage_ac_blueprint.route('/manage/access-control/recompute-effective-user-ac/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_ac_compute_effective_ac(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_ac_compute_effective_ac(cur_id):
 
     ac_recompute_effective_ac(cur_id)
 
@@ -66,8 +66,8 @@ def manage_ac_compute_effective_ac(cur_id, caseid):
 
 
 @manage_ac_blueprint.route('/manage/access-control/audit/users/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_ac_audit_user(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_ac_audit_user(cur_id):
     user_audit = {
         'access_audit': ac_trace_user_effective_cases_access_2(cur_id),
         'permissions_audit': ac_trace_effective_user_permissions(cur_id)
@@ -77,8 +77,8 @@ def manage_ac_audit_user(cur_id, caseid):
 
 
 @manage_ac_blueprint.route('/manage/access-control/audit/users/<int:cur_id>/modal', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_ac_audit_user_modal(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_ac_audit_user_modal(cur_id):
     access_audit = ac_trace_user_effective_cases_access_2(cur_id)
     permissions_audit = ac_trace_effective_user_permissions(cur_id)
 
@@ -91,5 +91,3 @@ def manage_ac_audit_users_page(caseid, url_redir):
     form = FlaskForm()
 
     return render_template("manage_user_audit.html", form=form)
-
-

--- a/source/app/blueprints/manage/manage_alerts_status_routes.py
+++ b/source/app/blueprints/manage/manage_alerts_status_routes.py
@@ -20,7 +20,7 @@ from flask import Blueprint, Response, request
 from app.datamgmt.alerts.alerts_db import get_alert_status_list, get_alert_status_by_id, search_alert_status_by_name, \
     get_alert_resolution_by_id, get_alert_resolution_list, search_alert_resolution_by_name
 from app.schema.marshables import AlertStatusSchema, AlertResolutionSchema
-from app.util import ac_api_requires, response_error
+from app.util import ac_api_requires_deprecated, response_error
 from app.util import response_success
 
 manage_alerts_status_blueprint = Blueprint('manage_alerts_status',
@@ -30,7 +30,7 @@ manage_alerts_status_blueprint = Blueprint('manage_alerts_status',
 
 # CONTENT ------------------------------------------------
 @manage_alerts_status_blueprint.route('/manage/alert-status/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_alert_status(caseid: int) -> Response:
     """
     Get the list of alert status
@@ -48,7 +48,7 @@ def list_alert_status(caseid: int) -> Response:
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-status/<int:classification_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_case_alert_status(classification_id: int, caseid: int) -> Response:
     """
     Get the alert status
@@ -64,7 +64,7 @@ def get_case_alert_status(classification_id: int, caseid: int) -> Response:
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-status/search', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def search_alert_status(caseid):
     if not request.is_json:
         return response_error("Invalid request")
@@ -86,7 +86,7 @@ def search_alert_status(caseid):
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-resolutions/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_alert_resolution(caseid: int) -> Response:
     """
     Get the list of alert resolution
@@ -104,7 +104,7 @@ def list_alert_resolution(caseid: int) -> Response:
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-resolutions/<int:resolution_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_case_alert_resolution(resolution_id: int, caseid: int) -> Response:
     """
     Get the alert resolution
@@ -120,7 +120,7 @@ def get_case_alert_resolution(resolution_id: int, caseid: int) -> Response:
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-resolutions/search', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def search_alert_resolution(caseid):
     if not request.is_json:
         return response_error("Invalid request")

--- a/source/app/blueprints/manage/manage_alerts_status_routes.py
+++ b/source/app/blueprints/manage/manage_alerts_status_routes.py
@@ -17,10 +17,16 @@
 
 from flask import Blueprint, Response, request
 
-from app.datamgmt.alerts.alerts_db import get_alert_status_list, get_alert_status_by_id, search_alert_status_by_name, \
-    get_alert_resolution_by_id, get_alert_resolution_list, search_alert_resolution_by_name
-from app.schema.marshables import AlertStatusSchema, AlertResolutionSchema
-from app.util import ac_api_requires_deprecated, response_error
+from app.datamgmt.alerts.alerts_db import get_alert_status_list
+from app.datamgmt.alerts.alerts_db import get_alert_status_by_id
+from app.datamgmt.alerts.alerts_db import search_alert_status_by_name
+from app.datamgmt.alerts.alerts_db import get_alert_resolution_by_id
+from app.datamgmt.alerts.alerts_db import get_alert_resolution_list
+from app.datamgmt.alerts.alerts_db import search_alert_resolution_by_name
+from app.schema.marshables import AlertStatusSchema
+from app.schema.marshables import AlertResolutionSchema
+from app.util import ac_api_requires
+from app.util import response_error
 from app.util import response_success
 
 manage_alerts_status_blueprint = Blueprint('manage_alerts_status',
@@ -30,8 +36,8 @@ manage_alerts_status_blueprint = Blueprint('manage_alerts_status',
 
 # CONTENT ------------------------------------------------
 @manage_alerts_status_blueprint.route('/manage/alert-status/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_alert_status(caseid: int) -> Response:
+@ac_api_requires()
+def list_alert_status() -> Response:
     """
     Get the list of alert status
 
@@ -48,8 +54,8 @@ def list_alert_status(caseid: int) -> Response:
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-status/<int:classification_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_case_alert_status(classification_id: int, caseid: int) -> Response:
+@ac_api_requires()
+def get_case_alert_status(classification_id: int) -> Response:
     """
     Get the alert status
 
@@ -64,8 +70,8 @@ def get_case_alert_status(classification_id: int, caseid: int) -> Response:
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-status/search', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def search_alert_status(caseid):
+@ac_api_requires()
+def search_alert_status():
     if not request.is_json:
         return response_error("Invalid request")
 
@@ -86,8 +92,8 @@ def search_alert_status(caseid):
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-resolutions/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_alert_resolution(caseid: int) -> Response:
+@ac_api_requires()
+def list_alert_resolution() -> Response:
     """
     Get the list of alert resolution
 
@@ -104,8 +110,8 @@ def list_alert_resolution(caseid: int) -> Response:
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-resolutions/<int:resolution_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_case_alert_resolution(resolution_id: int, caseid: int) -> Response:
+@ac_api_requires()
+def get_case_alert_resolution(resolution_id: int) -> Response:
     """
     Get the alert resolution
 
@@ -120,8 +126,8 @@ def get_case_alert_resolution(resolution_id: int, caseid: int) -> Response:
 
 
 @manage_alerts_status_blueprint.route('/manage/alert-resolutions/search', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def search_alert_resolution(caseid):
+@ac_api_requires()
+def search_alert_resolution():
     if not request.is_json:
         return response_error("Invalid request")
 

--- a/source/app/blueprints/manage/manage_analysis_status_routes.py
+++ b/source/app/blueprints/manage/manage_analysis_status_routes.py
@@ -23,7 +23,7 @@ from app.datamgmt.case.case_assets_db import get_compromise_status_dict, get_cas
 from app.datamgmt.manage.manage_case_objs import search_analysis_status_by_name
 from app.models.models import AnalysisStatus
 from app.schema.marshables import AnalysisStatusSchema
-from app.util import api_login_required, ac_api_requires
+from app.util import api_login_required, ac_api_requires_deprecated
 from app.util import response_error
 from app.util import response_success
 
@@ -34,7 +34,7 @@ manage_anastatus_blueprint = Blueprint('manage_anastatus',
 
 # CONTENT ------------------------------------------------
 @manage_anastatus_blueprint.route('/manage/analysis-status/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_anastatus(caseid):
     lstatus = AnalysisStatus.query.with_entities(
         AnalysisStatus.id,
@@ -47,7 +47,7 @@ def list_anastatus(caseid):
 
 
 @manage_anastatus_blueprint.route('/manage/compromise-status/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_compr_status(caseid):
     compro_status = get_compromise_status_dict()
 
@@ -55,7 +55,7 @@ def list_compr_status(caseid):
 
 
 @manage_anastatus_blueprint.route('/manage/outcome-status/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_outcome_status(caseid) -> Response:
     """ Returns a list of outcome status
 
@@ -72,7 +72,7 @@ def list_outcome_status(caseid) -> Response:
 
 
 @manage_anastatus_blueprint.route('/manage/analysis-status/<int:cur_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def view_anastatus(cur_id, caseid):
     lstatus = AnalysisStatus.query.with_entities(
         AnalysisStatus.id,
@@ -88,7 +88,7 @@ def view_anastatus(cur_id, caseid):
 
 
 @manage_anastatus_blueprint.route('/manage/analysis-status/search', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def search_analysis_status(caseid):
     if not request.is_json:
         return response_error("Invalid request")

--- a/source/app/blueprints/manage/manage_analysis_status_routes.py
+++ b/source/app/blueprints/manage/manage_analysis_status_routes.py
@@ -19,23 +19,22 @@
 from flask import Blueprint, request
 from werkzeug import Response
 
-from app.datamgmt.case.case_assets_db import get_compromise_status_dict, get_case_outcome_status_dict
+from app.datamgmt.case.case_assets_db import get_compromise_status_dict
+from app.datamgmt.case.case_assets_db import get_case_outcome_status_dict
 from app.datamgmt.manage.manage_case_objs import search_analysis_status_by_name
 from app.models.models import AnalysisStatus
 from app.schema.marshables import AnalysisStatusSchema
-from app.util import api_login_required, ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 
-manage_anastatus_blueprint = Blueprint('manage_anastatus',
-                                    __name__,
-                                    template_folder='templates')
+manage_anastatus_blueprint = Blueprint('manage_anastatus', __name__, template_folder='templates')
 
 
 # CONTENT ------------------------------------------------
 @manage_anastatus_blueprint.route('/manage/analysis-status/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_anastatus(caseid):
+@ac_api_requires()
+def list_anastatus():
     lstatus = AnalysisStatus.query.with_entities(
         AnalysisStatus.id,
         AnalysisStatus.name
@@ -47,16 +46,16 @@ def list_anastatus(caseid):
 
 
 @manage_anastatus_blueprint.route('/manage/compromise-status/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_compr_status(caseid):
+@ac_api_requires()
+def list_compr_status():
     compro_status = get_compromise_status_dict()
 
     return response_success("", data=compro_status)
 
 
 @manage_anastatus_blueprint.route('/manage/outcome-status/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_outcome_status(caseid) -> Response:
+@ac_api_requires()
+def list_outcome_status() -> Response:
     """ Returns a list of outcome status
 
     Args:
@@ -72,8 +71,8 @@ def list_outcome_status(caseid) -> Response:
 
 
 @manage_anastatus_blueprint.route('/manage/analysis-status/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def view_anastatus(cur_id, caseid):
+@ac_api_requires()
+def view_anastatus(cur_id):
     lstatus = AnalysisStatus.query.with_entities(
         AnalysisStatus.id,
         AnalysisStatus.name
@@ -88,8 +87,8 @@ def view_anastatus(cur_id, caseid):
 
 
 @manage_anastatus_blueprint.route('/manage/analysis-status/search', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def search_analysis_status(caseid):
+@ac_api_requires()
+def search_analysis_status():
     if not request.is_json:
         return response_error("Invalid request")
 

--- a/source/app/blueprints/manage/manage_assets.py
+++ b/source/app/blueprints/manage/manage_assets.py
@@ -72,7 +72,7 @@ from app.models.authorization import Permissions
 from app.models.models import Client, ReviewStatusList
 from app.schema.marshables import CaseSchema, CaseDetailsSchema, CaseAssetsSchema
 from app.util import ac_api_case_requires, add_obj_history_entry
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_api_return_access_denied
 from app.util import ac_case_requires
 from app.util import ac_requires
@@ -85,7 +85,7 @@ manage_assets_blueprint = Blueprint('manage_assets',
 
 
 @manage_assets_blueprint.route('/manage/assets/filter', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def manage_assets_filter(caseid) -> Response:
     """ Returns a list of assets, filtered by the given parameters.
     """

--- a/source/app/blueprints/manage/manage_assets.py
+++ b/source/app/blueprints/manage/manage_assets.py
@@ -14,69 +14,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-from typing import Union
 
-import logging as log
-# IMPORTS ------------------------------------------------
-import os
-import traceback
-import urllib.parse
-
-import marshmallow
 from flask import Blueprint
-from flask import redirect
-from flask import render_template
 from flask import request
-from flask import url_for
-from flask_login import current_user
-from flask_wtf import FlaskForm
 from werkzeug import Response
 
-import app
-from app import db
-from app.datamgmt.alerts.alerts_db import get_alert_status_by_name
-from app.datamgmt.case.case_db import get_case, get_review_id_from_name
-from app.datamgmt.case.case_db import register_case_protagonists
-from app.datamgmt.case.case_db import save_case_tags
-from app.datamgmt.client.client_db import get_client_list
-from app.datamgmt.iris_engine.modules_db import get_pipelines_args_from_name
-from app.datamgmt.iris_engine.modules_db import iris_module_exists
 from app.datamgmt.manage.manage_assets_db import get_filtered_assets
-from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
-from app.datamgmt.manage.manage_case_classifications_db import get_case_classifications_list
-from app.datamgmt.manage.manage_case_state_db import get_case_states_list, get_case_state_by_name
-from app.datamgmt.manage.manage_case_templates_db import get_case_templates_list, case_template_pre_modifier, \
-    case_template_post_modifier
-from app.datamgmt.manage.manage_cases_db import close_case, map_alert_resolution_to_case_status, get_filtered_cases
-from app.datamgmt.manage.manage_cases_db import delete_case
-from app.datamgmt.manage.manage_cases_db import get_case_details_rt
-from app.datamgmt.manage.manage_cases_db import get_case_protagonists
-from app.datamgmt.manage.manage_cases_db import list_cases_dict
-from app.datamgmt.manage.manage_cases_db import reopen_case
-from app.datamgmt.manage.manage_common import get_severities_list
-from app.datamgmt.manage.manage_users_db import get_user_organisations
-from app.forms import AddCaseForm
-from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access, \
-    ac_current_user_has_permission
-from app.iris_engine.access_control.utils import ac_fast_check_user_has_case_access
-from app.iris_engine.access_control.utils import ac_set_new_case_access
-from app.iris_engine.module_handler.module_handler import call_modules_hook
-from app.iris_engine.module_handler.module_handler import configure_module_on_init
-from app.iris_engine.module_handler.module_handler import instantiate_module_from_name
-from app.iris_engine.tasker.tasks import task_case_update
-from app.iris_engine.utils.common import build_upload_path
-from app.iris_engine.utils.tracker import track_activity
-from app.models.alerts import AlertStatus
+from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.models.authorization import CaseAccessLevel
-from app.models.authorization import Permissions
-from app.models.models import Client, ReviewStatusList
-from app.schema.marshables import CaseSchema, CaseDetailsSchema, CaseAssetsSchema
-from app.util import ac_api_case_requires, add_obj_history_entry
-from app.util import ac_api_requires_deprecated
+from app.schema.marshables import CaseAssetsSchema
+from app.util import ac_api_requires
 from app.util import ac_api_return_access_denied
-from app.util import ac_case_requires
-from app.util import ac_requires
-from app.util import response_error
 from app.util import response_success
 
 manage_assets_blueprint = Blueprint('manage_assets',
@@ -85,8 +33,8 @@ manage_assets_blueprint = Blueprint('manage_assets',
 
 
 @manage_assets_blueprint.route('/manage/assets/filter', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def manage_assets_filter(caseid) -> Response:
+@ac_api_requires()
+def manage_assets_filter() -> Response:
     """ Returns a list of assets, filtered by the given parameters.
     """
     page = request.args.get('page', 1, type=int)

--- a/source/app/blueprints/manage/manage_assets_type_routes.py
+++ b/source/app/blueprints/manage/manage_assets_type_routes.py
@@ -16,10 +16,10 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-# IMPORTS ------------------------------------------------
 import logging
 import marshmallow
 import os
+
 from flask import Blueprint
 from flask import redirect
 from flask import render_template
@@ -35,7 +35,7 @@ from app.models.authorization import Permissions
 from app.models.models import AssetsType
 from app.models.models import CaseAssets
 from app.schema.marshables import AssetTypeSchema
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -46,8 +46,8 @@ manage_assets_type_blueprint = Blueprint('manage_assets_type',
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/list')
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_assets(caseid):
+@ac_api_requires()
+def list_assets():
     # Get all assets
     assets = AssetsType.query.with_entities(
         AssetsType.asset_name,
@@ -70,8 +70,8 @@ def list_assets(caseid):
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def view_asset_api(cur_id, caseid):
+@ac_api_requires()
+def view_asset_api(cur_id):
     # Get all assets
     asset_type = AssetsType.query.with_entities(
         AssetsType.asset_name,
@@ -110,8 +110,8 @@ def view_assets_modal(cur_id, caseid, url_redir):
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def view_assets(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def view_assets(cur_id):
     asset_type = AssetsType.query.filter(AssetsType.asset_id == cur_id).first()
     if not asset_type:
         return response_error("Invalid asset type ID")
@@ -131,7 +131,7 @@ def view_assets(cur_id, caseid):
             asset_sc.asset_icon_compromised = fpath_c
 
         if asset_sc:
-            track_activity("updated asset type {}".format(asset_sc.asset_name), caseid=caseid)
+            track_activity("updated asset type {}".format(asset_sc.asset_name))
             return response_success("Asset type updated", asset_sc)
 
     except marshmallow.exceptions.ValidationError as e:
@@ -151,8 +151,8 @@ def add_assets_modal(caseid, url_redir):
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def add_assets(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def add_assets():
 
     asset_schema = AssetTypeSchema()
     try:
@@ -172,7 +172,7 @@ def add_assets(caseid):
             db.session.add(asset_sc)
             db.session.commit()
 
-            track_activity("updated asset type {}".format(asset_sc.asset_name), caseid=caseid)
+            track_activity("updated asset type {}".format(asset_sc.asset_name))
             return response_success("Asset type updated", asset_sc)
 
     except marshmallow.exceptions.ValidationError as e:
@@ -182,8 +182,8 @@ def add_assets(caseid):
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def delete_assets(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def delete_assets(cur_id):
     asset = AssetsType.query.filter(AssetsType.asset_id == cur_id).first()
     if not asset:
         return response_error("Invalid asset ID")
@@ -207,14 +207,14 @@ def delete_assets(cur_id, caseid):
     
     db.session.delete(asset)
 
-    track_activity("Deleted asset type ID {asset_id}".format(asset_id=cur_id), caseid=caseid, ctx_less=True)
+    track_activity("Deleted asset type ID {asset_id}".format(asset_id=cur_id), ctx_less=True)
 
     return response_success("Deleted asset type ID {cur_id} successfully".format(cur_id=cur_id))
 
 
 @manage_assets_type_blueprint.route('/manage/asset-types/search', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def search_assets_type(caseid):
+@ac_api_requires()
+def search_assets_type():
     """Searches for assets types in the database.
 
     This function searches for assets types in the database with a name that contains the specified search term.
@@ -244,4 +244,3 @@ def search_assets_type(caseid):
     # Serialize the assets types and return them in a JSON response
     assetst_schema = AssetTypeSchema(many=True)
     return response_success("", data=assetst_schema.dump(assets_type))
-

--- a/source/app/blueprints/manage/manage_assets_type_routes.py
+++ b/source/app/blueprints/manage/manage_assets_type_routes.py
@@ -35,7 +35,7 @@ from app.models.authorization import Permissions
 from app.models.models import AssetsType
 from app.models.models import CaseAssets
 from app.schema.marshables import AssetTypeSchema
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -46,7 +46,7 @@ manage_assets_type_blueprint = Blueprint('manage_assets_type',
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/list')
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_assets(caseid):
     # Get all assets
     assets = AssetsType.query.with_entities(
@@ -70,7 +70,7 @@ def list_assets(caseid):
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/<int:cur_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def view_asset_api(cur_id, caseid):
     # Get all assets
     asset_type = AssetsType.query.with_entities(
@@ -110,7 +110,7 @@ def view_assets_modal(cur_id, caseid, url_redir):
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def view_assets(cur_id, caseid):
     asset_type = AssetsType.query.filter(AssetsType.asset_id == cur_id).first()
     if not asset_type:
@@ -151,7 +151,7 @@ def add_assets_modal(caseid, url_redir):
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/add', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def add_assets(caseid):
 
     asset_schema = AssetTypeSchema()
@@ -182,7 +182,7 @@ def add_assets(caseid):
 
 
 @manage_assets_type_blueprint.route('/manage/asset-type/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def delete_assets(cur_id, caseid):
     asset = AssetsType.query.filter(AssetsType.asset_id == cur_id).first()
     if not asset:
@@ -213,7 +213,7 @@ def delete_assets(cur_id, caseid):
 
 
 @manage_assets_type_blueprint.route('/manage/asset-types/search', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def search_assets_type(caseid):
     """Searches for assets types in the database.
 

--- a/source/app/blueprints/manage/manage_attributes_routes.py
+++ b/source/app/blueprints/manage/manage_attributes_routes.py
@@ -31,7 +31,7 @@ from app.forms import AddAssetForm
 from app.forms import AttributeForm
 from app.models.authorization import Permissions
 from app.models.models import CustomAttribute
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -54,7 +54,7 @@ def manage_attributes(caseid, url_redir):
 
 
 @manage_attributes_blueprint.route('/manage/attributes/list')
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def list_attributes(caseid):
     # Get all attributes
     attributes = CustomAttribute.query.with_entities(
@@ -113,7 +113,7 @@ def attributes_preview(caseid, url_redir):
 
 
 @manage_attributes_blueprint.route('/manage/attributes/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def update_attribute(cur_id, caseid):
     if not request.is_json:
         return response_error("Invalid request")

--- a/source/app/blueprints/manage/manage_attributes_routes.py
+++ b/source/app/blueprints/manage/manage_attributes_routes.py
@@ -16,7 +16,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-# IMPORTS ------------------------------------------------
 import json
 from flask import Blueprint
 from flask import redirect
@@ -31,14 +30,12 @@ from app.forms import AddAssetForm
 from app.forms import AttributeForm
 from app.models.authorization import Permissions
 from app.models.models import CustomAttribute
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
 
-manage_attributes_blueprint = Blueprint('manage_attributes',
-                                          __name__,
-                                          template_folder='templates')
+manage_attributes_blueprint = Blueprint('manage_attributes', __name__, template_folder='templates')
 
 
 # CONTENT ------------------------------------------------
@@ -54,8 +51,8 @@ def manage_attributes(caseid, url_redir):
 
 
 @manage_attributes_blueprint.route('/manage/attributes/list')
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def list_attributes(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def list_attributes():
     # Get all attributes
     attributes = CustomAttribute.query.with_entities(
         CustomAttribute.attribute_id,
@@ -113,8 +110,8 @@ def attributes_preview(caseid, url_redir):
 
 
 @manage_attributes_blueprint.route('/manage/attributes/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def update_attribute(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def update_attribute(cur_id):
     if not request.is_json:
         return response_error("Invalid request")
 

--- a/source/app/blueprints/manage/manage_case_classifications.py
+++ b/source/app/blueprints/manage/manage_case_classifications.py
@@ -27,7 +27,7 @@ from app.forms import CaseClassificationForm
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseClassificationSchema
-from app.util import ac_api_requires, response_error, ac_requires
+from app.util import ac_api_requires_deprecated, response_error, ac_requires
 from app.util import response_success
 
 manage_case_classification_blueprint = Blueprint('manage_case_classifications',
@@ -37,7 +37,7 @@ manage_case_classification_blueprint = Blueprint('manage_case_classifications',
 
 # CONTENT ------------------------------------------------
 @manage_case_classification_blueprint.route('/manage/case-classifications/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_case_classifications(caseid: int) -> Response:
     """Get the list of case classifications
 
@@ -54,7 +54,7 @@ def list_case_classifications(caseid: int) -> Response:
 
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/<int:classification_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_case_classification(classification_id: int, caseid: int) -> Response:
     """Get a case classification
 
@@ -107,7 +107,7 @@ def update_case_classification_modal(classification_id: int, caseid: int, url_re
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/update/<int:classification_id>',
                                             methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def update_case_classification(classification_id: int, caseid: int) -> Response:
     """Update a case classification
 
@@ -163,7 +163,7 @@ def add_case_classification_modal(caseid: int, url_redir: bool) -> Union[str, Re
 
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/add', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def add_case_classification(caseid: int) -> Response:
     """Add a case classification
 
@@ -197,7 +197,7 @@ def add_case_classification(caseid: int) -> Response:
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/delete/<int:classification_id>',
                                             methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def delete_case_classification(classification_id: int, caseid: int) -> Response:
     """Delete a case classification
 
@@ -220,7 +220,7 @@ def delete_case_classification(classification_id: int, caseid: int) -> Response:
 
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/search', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def search_alert_status(caseid):
     if not request.is_json:
         return response_error("Invalid request")

--- a/source/app/blueprints/manage/manage_case_classifications.py
+++ b/source/app/blueprints/manage/manage_case_classifications.py
@@ -17,17 +17,24 @@
 import marshmallow
 from typing import Union
 
-from flask import Blueprint, Response, url_for, render_template, request
+from flask import Blueprint
+from flask import Response
+from flask import url_for
+from flask import render_template
+from flask import request
 from werkzeug.utils import redirect
 
 from app import db
-from app.datamgmt.manage.manage_case_classifications_db import get_case_classifications_list, \
-    get_case_classification_by_id, search_classification_by_name
+from app.datamgmt.manage.manage_case_classifications_db import get_case_classifications_list
+from app.datamgmt.manage.manage_case_classifications_db import get_case_classification_by_id
+from app.datamgmt.manage.manage_case_classifications_db import search_classification_by_name
 from app.forms import CaseClassificationForm
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseClassificationSchema
-from app.util import ac_api_requires_deprecated, response_error, ac_requires
+from app.util import ac_api_requires
+from app.util import response_error
+from app.util import ac_requires
 from app.util import response_success
 
 manage_case_classification_blueprint = Blueprint('manage_case_classifications',
@@ -35,10 +42,9 @@ manage_case_classification_blueprint = Blueprint('manage_case_classifications',
                                                  template_folder='templates')
 
 
-# CONTENT ------------------------------------------------
 @manage_case_classification_blueprint.route('/manage/case-classifications/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_case_classifications(caseid: int) -> Response:
+@ac_api_requires()
+def list_case_classifications() -> Response:
     """Get the list of case classifications
 
     Args:
@@ -54,8 +60,8 @@ def list_case_classifications(caseid: int) -> Response:
 
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/<int:classification_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_case_classification(classification_id: int, caseid: int) -> Response:
+@ac_api_requires()
+def get_case_classification(classification_id: int) -> Response:
     """Get a case classification
 
     Args:
@@ -107,8 +113,8 @@ def update_case_classification_modal(classification_id: int, caseid: int, url_re
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/update/<int:classification_id>',
                                             methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def update_case_classification(classification_id: int, caseid: int) -> Response:
+@ac_api_requires(Permissions.server_administrator)
+def update_case_classification(classification_id: int) -> Response:
     """Update a case classification
 
     Args:
@@ -132,7 +138,7 @@ def update_case_classification(classification_id: int, caseid: int) -> Response:
         ccls = ccl.load(request.get_json(), instance=case_classification)
 
         if ccls:
-            track_activity(f"updated case classification {ccls.id}", caseid=caseid)
+            track_activity(f"updated case classification {ccls.id}")
             return response_success("Case classification updated", ccl.dump(ccls))
 
     except marshmallow.exceptions.ValidationError as e:
@@ -163,8 +169,8 @@ def add_case_classification_modal(caseid: int, url_redir: bool) -> Union[str, Re
 
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def add_case_classification(caseid: int) -> Response:
+@ac_api_requires(Permissions.server_administrator)
+def add_case_classification() -> Response:
     """Add a case classification
 
     Args:
@@ -186,7 +192,7 @@ def add_case_classification(caseid: int) -> Response:
             db.session.add(ccls)
             db.session.commit()
 
-            track_activity(f"added case classification {ccls.name}", caseid=caseid)
+            track_activity(f"added case classification {ccls.name}")
             return response_success("Case classification added", ccl.dump(ccls))
 
     except marshmallow.exceptions.ValidationError as e:
@@ -197,8 +203,8 @@ def add_case_classification(caseid: int) -> Response:
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/delete/<int:classification_id>',
                                             methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def delete_case_classification(classification_id: int, caseid: int) -> Response:
+@ac_api_requires(Permissions.server_administrator)
+def delete_case_classification(classification_id: int) -> Response:
     """Delete a case classification
 
     Args:
@@ -215,13 +221,13 @@ def delete_case_classification(classification_id: int, caseid: int) -> Response:
     db.session.delete(case_classification)
     db.session.commit()
 
-    track_activity(f"deleted case classification {case_classification.name}", caseid=caseid)
+    track_activity(f"deleted case classification {case_classification.name}")
     return response_success("Case classification deleted")
 
 
 @manage_case_classification_blueprint.route('/manage/case-classifications/search', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def search_alert_status(caseid):
+@ac_api_requires()
+def search_alert_status():
     if not request.is_json:
         return response_error("Invalid request")
 

--- a/source/app/blueprints/manage/manage_case_state.py
+++ b/source/app/blueprints/manage/manage_case_state.py
@@ -17,32 +17,36 @@
 import marshmallow
 from typing import Union
 
-from flask import Blueprint, Response, url_for, render_template, request
+from flask import Blueprint
+from flask import Response
+from flask import url_for
+from flask import render_template
+from flask import request
 from werkzeug.utils import redirect
 
 from app import db
-from app.datamgmt.manage.manage_case_state_db import get_case_states_list, \
-    get_case_state_by_id, get_cases_using_state
+from app.datamgmt.manage.manage_case_state_db import get_case_states_list
+from app.datamgmt.manage.manage_case_state_db import get_case_state_by_id
+from app.datamgmt.manage.manage_case_state_db import get_cases_using_state
 from app.forms import CaseStateForm
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseStateSchema
-from app.util import ac_api_requires_deprecated, response_error, ac_requires
+from app.util import ac_api_requires
+from app.util import response_error
+from app.util import ac_requires
 from app.util import response_success
 
 manage_case_state_blueprint = Blueprint('manage_case_state',
-                                         __name__,
-                                         template_folder='templates')
+                                        __name__,
+                                        template_folder='templates')
 
 
 # CONTENT ------------------------------------------------
 @manage_case_state_blueprint.route('/manage/case-states/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_case_state(caseid: int) -> Response:
+@ac_api_requires()
+def list_case_state() -> Response:
     """Get the list of case state
-
-    Args:
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -54,13 +58,12 @@ def list_case_state(caseid: int) -> Response:
 
 
 @manage_case_state_blueprint.route('/manage/case-states/<int:state_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_case_state(state_id: int, caseid: int) -> Response:
+@ac_api_requires()
+def get_case_state(state_id: int) -> Response:
     """Get a case state
 
     Args:
         state_id (int): case state id
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -106,13 +109,12 @@ def update_case_state_modal(state_id: int, caseid: int, url_redir: bool) -> Unio
 
 @manage_case_state_blueprint.route('/manage/case-states/update/<int:state_id>',
                                             methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def update_case_state(state_id: int, caseid: int) -> Response:
+@ac_api_requires(Permissions.server_administrator)
+def update_case_state(state_id: int) -> Response:
     """Update a case state
 
     Args:
         state_id (int): case state id
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -134,7 +136,7 @@ def update_case_state(state_id: int, caseid: int) -> Response:
         ccls = ccl.load(request.get_json(), instance=case_state)
 
         if ccls:
-            track_activity(f"updated case state {ccls.state_id}", caseid=caseid)
+            track_activity(f"updated case state {ccls.state_id}")
             return response_success("Case state updated", ccl.dump(ccls))
 
     except marshmallow.exceptions.ValidationError as e:
@@ -165,12 +167,9 @@ def add_case_state_modal(caseid: int, url_redir: bool) -> Union[str, Response]:
 
 
 @manage_case_state_blueprint.route('/manage/case-states/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def add_case_state(caseid: int) -> Response:
+@ac_api_requires(Permissions.server_administrator)
+def add_case_state() -> Response:
     """Add a case state
-
-    Args:
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -188,7 +187,7 @@ def add_case_state(caseid: int) -> Response:
             db.session.add(ccls)
             db.session.commit()
 
-            track_activity(f"added case state {ccls.state_name}", caseid=caseid)
+            track_activity(f"added case state {ccls.state_name}")
             return response_success("Case state added", ccl.dump(ccls))
 
     except marshmallow.exceptions.ValidationError as e:
@@ -197,15 +196,13 @@ def add_case_state(caseid: int) -> Response:
     return response_error("Unexpected error server-side. Nothing added", data=None)
 
 
-@manage_case_state_blueprint.route('/manage/case-states/delete/<int:state_id>',
-                                            methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def delete_case_state(state_id: int, caseid: int) -> Response:
+@manage_case_state_blueprint.route('/manage/case-states/delete/<int:state_id>', methods=['POST'])
+@ac_api_requires(Permissions.server_administrator)
+def delete_case_state(state_id: int) -> Response:
     """Delete a case state
 
     Args:
         state_id (int): case state id
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -225,5 +222,5 @@ def delete_case_state(state_id: int, caseid: int) -> Response:
     db.session.delete(case_state)
     db.session.commit()
 
-    track_activity(f"deleted case state {case_state.state_name}", caseid=caseid)
+    track_activity(f"deleted case state {case_state.state_name}")
     return response_success("Case state deleted")

--- a/source/app/blueprints/manage/manage_case_state.py
+++ b/source/app/blueprints/manage/manage_case_state.py
@@ -27,7 +27,7 @@ from app.forms import CaseStateForm
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseStateSchema
-from app.util import ac_api_requires, response_error, ac_requires
+from app.util import ac_api_requires_deprecated, response_error, ac_requires
 from app.util import response_success
 
 manage_case_state_blueprint = Blueprint('manage_case_state',
@@ -37,7 +37,7 @@ manage_case_state_blueprint = Blueprint('manage_case_state',
 
 # CONTENT ------------------------------------------------
 @manage_case_state_blueprint.route('/manage/case-states/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_case_state(caseid: int) -> Response:
     """Get the list of case state
 
@@ -54,7 +54,7 @@ def list_case_state(caseid: int) -> Response:
 
 
 @manage_case_state_blueprint.route('/manage/case-states/<int:state_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_case_state(state_id: int, caseid: int) -> Response:
     """Get a case state
 
@@ -106,7 +106,7 @@ def update_case_state_modal(state_id: int, caseid: int, url_redir: bool) -> Unio
 
 @manage_case_state_blueprint.route('/manage/case-states/update/<int:state_id>',
                                             methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def update_case_state(state_id: int, caseid: int) -> Response:
     """Update a case state
 
@@ -165,7 +165,7 @@ def add_case_state_modal(caseid: int, url_redir: bool) -> Union[str, Response]:
 
 
 @manage_case_state_blueprint.route('/manage/case-states/add', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def add_case_state(caseid: int) -> Response:
     """Add a case state
 
@@ -199,7 +199,7 @@ def add_case_state(caseid: int) -> Response:
 
 @manage_case_state_blueprint.route('/manage/case-states/delete/<int:state_id>',
                                             methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def delete_case_state(state_id: int, caseid: int) -> Response:
     """Delete a case state
 

--- a/source/app/blueprints/manage/manage_case_templates_routes.py
+++ b/source/app/blueprints/manage/manage_case_templates_routes.py
@@ -35,7 +35,7 @@ from app.models import CaseTemplate
 from app.models.authorization import Permissions
 from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import CaseTemplateSchema
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -58,7 +58,7 @@ def manage_case_templates(caseid, url_redir):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_case_templates(caseid):
     """Show a list of case templates
 
@@ -112,7 +112,7 @@ def case_template_modal(cur_id, caseid, url_redir):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/add/modal', methods=['GET'])
-@ac_api_requires(Permissions.case_templates_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.case_templates_write, no_cid_required=True)
 def add_template_modal(caseid):
     case_template = CaseTemplate()
     form = CaseTemplateForm()
@@ -149,13 +149,13 @@ def add_template_modal(caseid):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/upload/modal', methods=['GET'])
-@ac_api_requires(Permissions.case_templates_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.case_templates_write, no_cid_required=True)
 def upload_template_modal(caseid):
     return render_template("modal_upload_case_template.html")
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/add', methods=['POST'])
-@ac_api_requires(Permissions.case_templates_write)
+@ac_api_requires_deprecated(Permissions.case_templates_write)
 def add_case_template(caseid):
     data = request.get_json()
     if not data:
@@ -192,7 +192,7 @@ def add_case_template(caseid):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.case_templates_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.case_templates_write, no_cid_required=True)
 def update_case_template(cur_id, caseid):
     if not request.is_json:
         return response_error("Invalid request")
@@ -234,7 +234,7 @@ def update_case_template(cur_id, caseid):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/delete/<int:case_template_id>', methods=['POST'])
-@ac_api_requires(Permissions.case_templates_write)
+@ac_api_requires_deprecated(Permissions.case_templates_write)
 def delete_case_template(case_template_id, caseid):
     case_template = get_case_template_by_id(case_template_id)
     if case_template is None:

--- a/source/app/blueprints/manage/manage_case_templates_routes.py
+++ b/source/app/blueprints/manage/manage_case_templates_routes.py
@@ -35,7 +35,8 @@ from app.models import CaseTemplate
 from app.models.authorization import Permissions
 from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import CaseTemplateSchema
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
+from app.util import ac_requires_case_identifier
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -58,8 +59,8 @@ def manage_case_templates(caseid, url_redir):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_case_templates(caseid):
+@ac_api_requires()
+def list_case_templates():
     """Show a list of case templates
 
     Returns:
@@ -112,8 +113,8 @@ def case_template_modal(cur_id, caseid, url_redir):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/add/modal', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.case_templates_write, no_cid_required=True)
-def add_template_modal(caseid):
+@ac_api_requires(Permissions.case_templates_write)
+def add_template_modal():
     case_template = CaseTemplate()
     form = CaseTemplateForm()
     form.case_template_json.data = {
@@ -149,13 +150,14 @@ def add_template_modal(caseid):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/upload/modal', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.case_templates_write, no_cid_required=True)
-def upload_template_modal(caseid):
+@ac_api_requires(Permissions.case_templates_write)
+def upload_template_modal():
     return render_template("modal_upload_case_template.html")
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.case_templates_write)
+@ac_api_requires(Permissions.case_templates_write)
+@ac_requires_case_identifier()
 def add_case_template(caseid):
     data = request.get_json()
     if not data:
@@ -192,8 +194,8 @@ def add_case_template(caseid):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.case_templates_write, no_cid_required=True)
-def update_case_template(cur_id, caseid):
+@ac_api_requires(Permissions.case_templates_write)
+def update_case_template(cur_id):
     if not request.is_json:
         return response_error("Invalid request")
 
@@ -234,7 +236,8 @@ def update_case_template(cur_id, caseid):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/delete/<int:case_template_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.case_templates_write)
+@ac_api_requires(Permissions.case_templates_write)
+@ac_requires_case_identifier()
 def delete_case_template(case_template_id, caseid):
     case_template = get_case_template_by_id(case_template_id)
     if case_template is None:

--- a/source/app/blueprints/manage/manage_case_templates_routes.py
+++ b/source/app/blueprints/manage/manage_case_templates_routes.py
@@ -58,7 +58,7 @@ def manage_case_templates(caseid, url_redir):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/list', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def list_case_templates(caseid):
     """Show a list of case templates
 
@@ -112,7 +112,7 @@ def case_template_modal(cur_id, caseid, url_redir):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/add/modal', methods=['GET'])
-@ac_api_requires(Permissions.case_templates_write)
+@ac_api_requires(Permissions.case_templates_write, no_cid_required=True)
 def add_template_modal(caseid):
     case_template = CaseTemplate()
     form = CaseTemplateForm()
@@ -149,7 +149,7 @@ def add_template_modal(caseid):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/upload/modal', methods=['GET'])
-@ac_api_requires(Permissions.case_templates_write)
+@ac_api_requires(Permissions.case_templates_write, no_cid_required=True)
 def upload_template_modal(caseid):
     return render_template("modal_upload_case_template.html")
 
@@ -192,7 +192,7 @@ def add_case_template(caseid):
 
 
 @manage_case_templates_blueprint.route('/manage/case-templates/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.case_templates_write)
+@ac_api_requires(Permissions.case_templates_write, no_cid_required=True)
 def update_case_template(cur_id, caseid):
     if not request.is_json:
         return response_error("Invalid request")

--- a/source/app/blueprints/manage/manage_cases_routes.py
+++ b/source/app/blueprints/manage/manage_cases_routes.py
@@ -61,7 +61,7 @@ from app.models.authorization import CaseAccessLevel
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseSchema, CaseDetailsSchema
 from app.util import add_obj_history_entry
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_api_return_access_denied
 from app.util import ac_requires
 from app.util import response_error
@@ -141,7 +141,7 @@ def manage_details_case(cur_id: int, caseid: int, url_redir: bool) -> Union[Resp
 
 
 @manage_cases_blueprint.route('/manage/cases/<int:cur_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_case_api(cur_id, caseid):
     if not ac_fast_check_current_user_has_case_access(cur_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=cur_id)
@@ -154,7 +154,7 @@ def get_case_api(cur_id, caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/filter', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def manage_case_filter(caseid) -> Response:
 
     page = request.args.get('page', 1, type=int)
@@ -228,7 +228,7 @@ def manage_case_filter(caseid) -> Response:
 
 
 @manage_cases_blueprint.route('/manage/cases/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.standard_user, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
 def api_delete_case(cur_id, caseid):
     try:
         delete(cur_id)
@@ -240,7 +240,7 @@ def api_delete_case(cur_id, caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/reopen/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.standard_user, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
 def api_reopen_case(cur_id, caseid):
     if not ac_fast_check_current_user_has_case_access(cur_id, [CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=cur_id)
@@ -277,7 +277,7 @@ def api_reopen_case(cur_id, caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/close/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.standard_user, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
 def api_case_close(cur_id, caseid):
     if not ac_fast_check_current_user_has_case_access(cur_id, [CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=cur_id)
@@ -322,7 +322,7 @@ def api_case_close(cur_id, caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/add/modal', methods=['GET'])
-@ac_api_requires(Permissions.standard_user, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
 def add_case_modal(caseid):
 
     form = AddCaseForm()
@@ -342,7 +342,7 @@ def add_case_modal(caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/add', methods=['POST'])
-@ac_api_requires(Permissions.standard_user, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
 def api_add_case(caseid):
     case_schema = CaseSchema()
 
@@ -354,7 +354,7 @@ def api_add_case(caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/list', methods=['GET'])
-@ac_api_requires(Permissions.standard_user, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
 def api_list_case(caseid):
     data = list_cases_dict(current_user.id)
 
@@ -362,7 +362,7 @@ def api_list_case(caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.standard_user, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
 def update_case_info(cur_id, caseid):
     case_schema = CaseSchema()
     try:
@@ -373,7 +373,7 @@ def update_case_info(cur_id, caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/trigger-pipeline', methods=['POST'])
-@ac_api_requires(Permissions.standard_user)
+@ac_api_requires_deprecated(Permissions.standard_user)
 def update_case_files(caseid):
     if not ac_fast_check_current_user_has_case_access(caseid, [CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=caseid)
@@ -434,7 +434,7 @@ def update_case_files(caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/upload_files', methods=['POST'])
-@ac_api_requires(Permissions.standard_user)
+@ac_api_requires_deprecated(Permissions.standard_user)
 def manage_cases_uploadfiles(caseid):
     """
     Handles the entire the case management, i.e creation, update, list and files imports

--- a/source/app/blueprints/manage/manage_cases_routes.py
+++ b/source/app/blueprints/manage/manage_cases_routes.py
@@ -15,9 +15,7 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 from typing import Union
-
 import logging as log
-# IMPORTS ------------------------------------------------
 import os
 import traceback
 import urllib.parse
@@ -59,9 +57,11 @@ from app.iris_engine.utils.common import build_upload_path
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
 from app.models.authorization import Permissions
-from app.schema.marshables import CaseSchema, CaseDetailsSchema
+from app.schema.marshables import CaseSchema
+from app.schema.marshables import CaseDetailsSchema
 from app.util import add_obj_history_entry
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
+from app.util import ac_requires_case_identifier
 from app.util import ac_api_return_access_denied
 from app.util import ac_requires
 from app.util import response_error
@@ -141,8 +141,8 @@ def manage_details_case(cur_id: int, caseid: int, url_redir: bool) -> Union[Resp
 
 
 @manage_cases_blueprint.route('/manage/cases/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_case_api(cur_id, caseid):
+@ac_api_requires()
+def get_case_api(cur_id):
     if not ac_fast_check_current_user_has_case_access(cur_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=cur_id)
 
@@ -154,8 +154,8 @@ def get_case_api(cur_id, caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/filter', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def manage_case_filter(caseid) -> Response:
+@ac_api_requires()
+def manage_case_filter() -> Response:
 
     page = request.args.get('page', 1, type=int)
     per_page = request.args.get('per_page', 10, type=int)
@@ -228,8 +228,8 @@ def manage_case_filter(caseid) -> Response:
 
 
 @manage_cases_blueprint.route('/manage/cases/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
-def api_delete_case(cur_id, caseid):
+@ac_api_requires(Permissions.standard_user)
+def api_delete_case(cur_id):
     try:
         delete(cur_id)
         return response_success('Case successfully deleted')
@@ -240,8 +240,8 @@ def api_delete_case(cur_id, caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/reopen/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
-def api_reopen_case(cur_id, caseid):
+@ac_api_requires(Permissions.standard_user)
+def api_reopen_case(cur_id):
     if not ac_fast_check_current_user_has_case_access(cur_id, [CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=cur_id)
 
@@ -262,23 +262,23 @@ def api_reopen_case(cur_id, caseid):
         for alert in case.alerts:
             if alert.alert_status_id != merged_status.status_id:
                 alert.alert_status_id = merged_status.status_id
-                track_activity(f"alert ID {alert.alert_id} status updated to merged due to case #{caseid} being reopen",
-                               caseid=caseid, ctx_less=False)
+                track_activity(f"alert ID {alert.alert_id} status updated to merged due to case #{cur_id} being reopen",
+                               caseid=cur_id, ctx_less=False)
 
                 db.session.add(alert)
     
-    case = call_modules_hook('on_postload_case_update', data=case, caseid=caseid)
+    case = call_modules_hook('on_postload_case_update', data=case, caseid=cur_id)
 
     add_obj_history_entry(case, 'case reopen')
-    track_activity("reopen case ID {}".format(cur_id), caseid=caseid)
+    track_activity("reopen case ID {}".format(cur_id), caseid=cur_id)
     case_schema = CaseSchema()
 
     return response_success("Case reopen successfully", data=case_schema.dump(res))
 
 
 @manage_cases_blueprint.route('/manage/cases/close/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
-def api_case_close(cur_id, caseid):
+@ac_api_requires(Permissions.standard_user)
+def api_case_close(cur_id):
     if not ac_fast_check_current_user_has_case_access(cur_id, [CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=cur_id)
 
@@ -301,29 +301,29 @@ def api_case_close(cur_id, caseid):
         for alert in case.alerts:
             if alert.alert_status_id != close_status.status_id:
                 alert.alert_status_id = close_status.status_id
-                alert = call_modules_hook('on_postload_alert_update', data=alert, caseid=caseid)
+                alert = call_modules_hook('on_postload_alert_update', data=alert, caseid=cur_id)
 
             if alert.alert_resolution_status_id != case_status_id_mapped:
                 alert.alert_resolution_status_id = case_status_id_mapped
-                alert = call_modules_hook('on_postload_alert_resolution_update', data=alert, caseid=caseid)
+                alert = call_modules_hook('on_postload_alert_resolution_update', data=alert, caseid=cur_id)
 
-                track_activity(f"closing alert ID {alert.alert_id} due to case #{caseid} being closed",
-                               caseid=caseid, ctx_less=False)
+                track_activity(f"closing alert ID {alert.alert_id} due to case #{cur_id} being closed",
+                               caseid=cur_id, ctx_less=False)
 
                 db.session.add(alert)
     
-    case = call_modules_hook('on_postload_case_update', data=case, caseid=caseid)
+    case = call_modules_hook('on_postload_case_update', data=case, caseid=cur_id)
 
     add_obj_history_entry(case, 'case closed')
-    track_activity("closed case ID {}".format(cur_id), caseid=caseid, ctx_less=False)
+    track_activity("closed case ID {}".format(cur_id), caseid=cur_id, ctx_less=False)
     case_schema = CaseSchema()
 
     return response_success("Case closed successfully", data=case_schema.dump(res))
 
 
 @manage_cases_blueprint.route('/manage/cases/add/modal', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
-def add_case_modal(caseid):
+@ac_api_requires(Permissions.standard_user)
+def add_case_modal():
 
     form = AddCaseForm()
     # Show only clients that the user has access to
@@ -342,8 +342,8 @@ def add_case_modal(caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
-def api_add_case(caseid):
+@ac_api_requires(Permissions.standard_user)
+def api_add_case():
     case_schema = CaseSchema()
 
     try:
@@ -354,16 +354,16 @@ def api_add_case(caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/list', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
-def api_list_case(caseid):
+@ac_api_requires(Permissions.standard_user)
+def api_list_case():
     data = list_cases_dict(current_user.id)
 
     return response_success("", data=data)
 
 
 @manage_cases_blueprint.route('/manage/cases/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.standard_user, no_cid_required=True)
-def update_case_info(cur_id, caseid):
+@ac_api_requires(Permissions.standard_user)
+def update_case_info(cur_id):
     case_schema = CaseSchema()
     try:
         case, msg = update(cur_id, request.get_json())
@@ -373,7 +373,8 @@ def update_case_info(cur_id, caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/trigger-pipeline', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.standard_user)
+@ac_api_requires(Permissions.standard_user)
+@ac_requires_case_identifier()
 def update_case_files(caseid):
     if not ac_fast_check_current_user_has_case_access(caseid, [CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=caseid)
@@ -434,7 +435,8 @@ def update_case_files(caseid):
 
 
 @manage_cases_blueprint.route('/manage/cases/upload_files', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.standard_user)
+@ac_api_requires(Permissions.standard_user)
+@ac_requires_case_identifier()
 def manage_cases_uploadfiles(caseid):
     """
     Handles the entire the case management, i.e creation, update, list and files imports

--- a/source/app/blueprints/manage/manage_customers_routes.py
+++ b/source/app/blueprints/manage/manage_customers_routes.py
@@ -16,7 +16,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-# IMPORTS ------------------------------------------------
 import datetime
 
 import traceback
@@ -44,7 +43,6 @@ from app.datamgmt.client.client_db import update_client
 from app.datamgmt.client.client_db import update_contact
 from app.datamgmt.exceptions.ElementExceptions import ElementInUseException
 from app.datamgmt.exceptions.ElementExceptions import ElementNotFoundException
-from app.datamgmt.manage.manage_access_control_db import get_user_clients_id, user_has_client_access
 from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
 from app.forms import AddCustomerForm
 from app.forms import ContactForm
@@ -52,7 +50,9 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import ContactSchema
 from app.schema.marshables import CustomerSchema
-from app.util import ac_api_requires_deprecated, ac_api_requires_client_access, ac_requires_client_access
+from app.util import ac_api_requires
+from app.util import ac_api_requires_client_access
+from app.util import ac_requires_client_access
 from app.util import ac_requires
 from app.util import page_not_found
 from app.util import response_error
@@ -79,8 +79,8 @@ def manage_customers(caseid, url_redir):
 
 
 @manage_customers_blueprint.route('/manage/customers/list')
-@ac_api_requires_deprecated(Permissions.customers_read, no_cid_required=True)
-def list_customers(caseid):
+@ac_api_requires(Permissions.customers_read)
+def list_customers():
     user_is_server_administrator = ac_current_user_has_permission(Permissions.server_administrator)
     client_list = get_client_list(current_user_id=current_user.id,
                                   is_server_administrator=user_is_server_administrator)
@@ -89,9 +89,9 @@ def list_customers(caseid):
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.customers_read, no_cid_required=True)
+@ac_api_requires(Permissions.customers_read)
 @ac_api_requires_client_access()
-def view_customer(client_id, caseid):
+def view_customer(client_id):
 
     customer = get_client_api(client_id)
 
@@ -153,9 +153,9 @@ def customer_edit_contact_modal(client_id, contact_id, caseid, url_redir):
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>/contacts/<int:contact_id>/update', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires(Permissions.customers_write)
 @ac_api_requires_client_access()
-def customer_update_contact(client_id, contact_id, caseid):
+def customer_update_contact(client_id, contact_id):
 
     if not request.is_json:
         return response_error("Invalid request")
@@ -174,7 +174,7 @@ def customer_update_contact(client_id, contact_id, caseid):
         print(traceback.format_exc())
         return response_error(f'An error occurred during contact update. {e}')
 
-    track_activity(f"Updated contact {contact.contact_name}", caseid=caseid, ctx_less=True)
+    track_activity(f"Updated contact {contact.contact_name}", ctx_less=True)
 
     # Return the customer
     contact_schema = ContactSchema()
@@ -182,9 +182,9 @@ def customer_update_contact(client_id, contact_id, caseid):
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>/contacts/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires(Permissions.customers_write)
 @ac_api_requires_client_access()
-def customer_add_contact(client_id, caseid):
+def customer_add_contact(client_id):
 
     if not request.is_json:
         return response_error("Invalid request")
@@ -203,7 +203,7 @@ def customer_add_contact(client_id, caseid):
         print(traceback.format_exc())
         return response_error(f'An error occurred during contact addition. {e}')
 
-    track_activity(f"Added contact {contact.contact_name}", caseid=caseid, ctx_less=True)
+    track_activity(f"Added contact {contact.contact_name}", ctx_less=True)
 
     # Return the customer
     contact_schema = ContactSchema()
@@ -211,9 +211,9 @@ def customer_add_contact(client_id, caseid):
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>/cases', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.customers_read, no_cid_required=True)
+@ac_api_requires(Permissions.customers_read)
 @ac_api_requires_client_access()
-def get_customer_case_stats(client_id, caseid):
+def get_customer_case_stats(client_id):
 
     cases = get_client_cases(client_id)
     cases_list = []
@@ -315,9 +315,9 @@ def view_customer_modal(client_id, caseid, url_redir):
 
 
 @manage_customers_blueprint.route('/manage/customers/update/<int:client_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires(Permissions.customers_write)
 @ac_api_requires_client_access()
-def view_customers(client_id, caseid):
+def view_customers(client_id):
     if not request.is_json:
         return response_error("Invalid request")
 
@@ -350,9 +350,9 @@ def add_customers_modal(caseid, url_redir):
 
 
 @manage_customers_blueprint.route('/manage/customers/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires(Permissions.customers_write)
 @ac_api_requires_client_access()
-def add_customers(caseid):
+def add_customers():
     if not request.is_json:
         return response_error("Invalid request")
 
@@ -364,7 +364,7 @@ def add_customers(caseid):
         print(traceback.format_exc())
         return response_error(f'An error occurred during customer addition. {e}')
 
-    track_activity(f"Added customer {client.name}", caseid=caseid, ctx_less=True)
+    track_activity(f"Added customer {client.name}", ctx_less=True)
 
     # Return the customer
     client_schema = CustomerSchema()
@@ -372,9 +372,9 @@ def add_customers(caseid):
 
 
 @manage_customers_blueprint.route('/manage/customers/delete/<int:client_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires(Permissions.customers_write)
 @ac_api_requires_client_access()
-def delete_customers(client_id, caseid):
+def delete_customers(client_id):
     try:
 
         delete_client(client_id)
@@ -388,15 +388,15 @@ def delete_customers(client_id, caseid):
     except Exception:
         return response_error('An error occurred during customer deletion')
 
-    track_activity(f"Deleted Customer with ID {client_id}", caseid=caseid, ctx_less=True)
+    track_activity(f"Deleted Customer with ID {client_id}", ctx_less=True)
 
     return response_success("Deleted successfully")
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>/contacts/<int:contact_id>/delete', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires(Permissions.customers_write)
 @ac_api_requires_client_access()
-def delete_contact_route(client_id, contact_id, caseid):
+def delete_contact_route(client_id, contact_id):
     try:
 
         delete_contact(contact_id)
@@ -410,6 +410,6 @@ def delete_contact_route(client_id, contact_id, caseid):
     except Exception:
         return response_error('An error occurred during contact deletion')
 
-    track_activity(f"Deleted Customer with ID {contact_id}", caseid=caseid, ctx_less=True)
+    track_activity(f"Deleted Customer with ID {contact_id}", ctx_less=True)
 
     return response_success("Deleted successfully")

--- a/source/app/blueprints/manage/manage_customers_routes.py
+++ b/source/app/blueprints/manage/manage_customers_routes.py
@@ -52,7 +52,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import ContactSchema
 from app.schema.marshables import CustomerSchema
-from app.util import ac_api_requires, ac_api_requires_client_access, ac_requires_client_access
+from app.util import ac_api_requires_deprecated, ac_api_requires_client_access, ac_requires_client_access
 from app.util import ac_requires
 from app.util import page_not_found
 from app.util import response_error
@@ -79,7 +79,7 @@ def manage_customers(caseid, url_redir):
 
 
 @manage_customers_blueprint.route('/manage/customers/list')
-@ac_api_requires(Permissions.customers_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.customers_read, no_cid_required=True)
 def list_customers(caseid):
     user_is_server_administrator = ac_current_user_has_permission(Permissions.server_administrator)
     client_list = get_client_list(current_user_id=current_user.id,
@@ -89,7 +89,7 @@ def list_customers(caseid):
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>', methods=['GET'])
-@ac_api_requires(Permissions.customers_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.customers_read, no_cid_required=True)
 @ac_api_requires_client_access()
 def view_customer(client_id, caseid):
 
@@ -153,7 +153,7 @@ def customer_edit_contact_modal(client_id, contact_id, caseid, url_redir):
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>/contacts/<int:contact_id>/update', methods=['POST'])
-@ac_api_requires(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
 @ac_api_requires_client_access()
 def customer_update_contact(client_id, contact_id, caseid):
 
@@ -182,7 +182,7 @@ def customer_update_contact(client_id, contact_id, caseid):
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>/contacts/add', methods=['POST'])
-@ac_api_requires(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
 @ac_api_requires_client_access()
 def customer_add_contact(client_id, caseid):
 
@@ -211,7 +211,7 @@ def customer_add_contact(client_id, caseid):
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>/cases', methods=['GET'])
-@ac_api_requires(Permissions.customers_read, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.customers_read, no_cid_required=True)
 @ac_api_requires_client_access()
 def get_customer_case_stats(client_id, caseid):
 
@@ -315,7 +315,7 @@ def view_customer_modal(client_id, caseid, url_redir):
 
 
 @manage_customers_blueprint.route('/manage/customers/update/<int:client_id>', methods=['POST'])
-@ac_api_requires(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
 @ac_api_requires_client_access()
 def view_customers(client_id, caseid):
     if not request.is_json:
@@ -350,7 +350,7 @@ def add_customers_modal(caseid, url_redir):
 
 
 @manage_customers_blueprint.route('/manage/customers/add', methods=['POST'])
-@ac_api_requires(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
 @ac_api_requires_client_access()
 def add_customers(caseid):
     if not request.is_json:
@@ -372,7 +372,7 @@ def add_customers(caseid):
 
 
 @manage_customers_blueprint.route('/manage/customers/delete/<int:client_id>', methods=['POST'])
-@ac_api_requires(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
 @ac_api_requires_client_access()
 def delete_customers(client_id, caseid):
     try:
@@ -394,7 +394,7 @@ def delete_customers(client_id, caseid):
 
 
 @manage_customers_blueprint.route('/manage/customers/<int:client_id>/contacts/<int:contact_id>/delete', methods=['POST'])
-@ac_api_requires(Permissions.customers_write, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.customers_write, no_cid_required=True)
 @ac_api_requires_client_access()
 def delete_contact_route(client_id, contact_id, caseid):
     try:

--- a/source/app/blueprints/manage/manage_event_categories_routes.py
+++ b/source/app/blueprints/manage/manage_event_categories_routes.py
@@ -21,7 +21,7 @@ from flask import Blueprint, request
 from app.datamgmt.manage.manage_case_objs import search_event_category_by_name
 from app.models.models import EventCategory
 from app.schema.marshables import EventCategorySchema
-from app.util import api_login_required, ac_api_requires
+from app.util import api_login_required, ac_api_requires_deprecated
 from app.util import response_error
 from app.util import response_success
 
@@ -32,7 +32,7 @@ manage_event_cat_blueprint = Blueprint('manage_event_cat',
 
 # CONTENT ------------------------------------------------
 @manage_event_cat_blueprint.route('/manage/event-categories/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_event_categories(caseid):
     lcat= EventCategory.query.with_entities(
         EventCategory.id,
@@ -45,7 +45,7 @@ def list_event_categories(caseid):
 
 
 @manage_event_cat_blueprint.route('/manage/event-categories/<int:cur_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_event_category(cur_id, caseid):
     lcat = EventCategory.query.with_entities(
         EventCategory.id,
@@ -63,7 +63,7 @@ def get_event_category(cur_id, caseid):
 
 
 @manage_event_cat_blueprint.route('/manage/event-categories/search', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def search_event_category(caseid):
     if not request.is_json:
         return response_error("Invalid request")

--- a/source/app/blueprints/manage/manage_event_categories_routes.py
+++ b/source/app/blueprints/manage/manage_event_categories_routes.py
@@ -21,19 +21,19 @@ from flask import Blueprint, request
 from app.datamgmt.manage.manage_case_objs import search_event_category_by_name
 from app.models.models import EventCategory
 from app.schema.marshables import EventCategorySchema
-from app.util import api_login_required, ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 
 manage_event_cat_blueprint = Blueprint('manage_event_cat',
-                                        __name__,
-                                        template_folder='templates')
+                                       __name__,
+                                       template_folder='templates')
 
 
 # CONTENT ------------------------------------------------
 @manage_event_cat_blueprint.route('/manage/event-categories/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_event_categories(caseid):
+@ac_api_requires()
+def list_event_categories():
     lcat= EventCategory.query.with_entities(
         EventCategory.id,
         EventCategory.name
@@ -45,8 +45,8 @@ def list_event_categories(caseid):
 
 
 @manage_event_cat_blueprint.route('/manage/event-categories/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_event_category(cur_id, caseid):
+@ac_api_requires()
+def get_event_category(cur_id):
     lcat = EventCategory.query.with_entities(
         EventCategory.id,
         EventCategory.name
@@ -63,8 +63,8 @@ def get_event_category(cur_id, caseid):
 
 
 @manage_event_cat_blueprint.route('/manage/event-categories/search', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def search_event_category(caseid):
+@ac_api_requires()
+def search_event_category():
     if not request.is_json:
         return response_error("Invalid request")
 

--- a/source/app/blueprints/manage/manage_evidence_types_route.py
+++ b/source/app/blueprints/manage/manage_evidence_types_route.py
@@ -28,7 +28,7 @@ from app.forms import CaseClassificationForm, EvidenceTypeForm
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseClassificationSchema, EvidenceTypeSchema
-from app.util import ac_api_requires, response_error, ac_requires
+from app.util import ac_api_requires_deprecated, response_error, ac_requires
 from app.util import response_success
 
 manage_evidence_types_blueprint = Blueprint('manage_evidence_types',
@@ -38,7 +38,7 @@ manage_evidence_types_blueprint = Blueprint('manage_evidence_types',
 
 # CONTENT ------------------------------------------------
 @manage_evidence_types_blueprint.route('/manage/evidence-types/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_evidence_types(caseid: int) -> Response:
     """Get the list of evidence types
 
@@ -55,7 +55,7 @@ def list_evidence_types(caseid: int) -> Response:
 
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/<int:evidence_type_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_evidence_type(evidence_type_id: int, caseid: int) -> Response:
     """Get an evidence type
 
@@ -107,7 +107,7 @@ def update_evidence_type_modal(evidence_type_id: int, caseid: int, url_redir: bo
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/update/<int:evidence_type_id>',
                                        methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def update_case_classification(evidence_type_id: int, caseid: int) -> Response:
     """Update an evidence type
 
@@ -163,7 +163,7 @@ def add_evidence_type_modal(caseid: int, url_redir: bool) -> Union[str, Response
 
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/add', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def add_evidence_type(caseid: int) -> Response:
     """Add an evidence type
 
@@ -197,7 +197,7 @@ def add_evidence_type(caseid: int) -> Response:
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/delete/<int:evidence_type_id>',
                                        methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def delete_evidence_type(evidence_type_id: int, caseid: int) -> Response:
     """Delete an evidence type
 
@@ -223,7 +223,7 @@ def delete_evidence_type(evidence_type_id: int, caseid: int) -> Response:
 
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/search', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def search_evidence_type(caseid):
     if not request.is_json:
         return response_error("Invalid request")

--- a/source/app/blueprints/manage/manage_evidence_types_route.py
+++ b/source/app/blueprints/manage/manage_evidence_types_route.py
@@ -17,18 +17,24 @@
 import marshmallow
 from typing import Union
 
-from flask import Blueprint, Response, url_for, render_template, request
+from flask import Blueprint
+from flask import Response
+from flask import url_for
+from flask import render_template
+from flask import request
 from werkzeug.utils import redirect
 
 from app import db
-from app.datamgmt.manage.manage_evidence_types_db import get_evidence_types_list, \
-    get_evidence_type_by_id, \
-    get_evidence_type_by_name, verify_evidence_type_in_use
-from app.forms import CaseClassificationForm, EvidenceTypeForm
+from app.datamgmt.manage.manage_evidence_types_db import get_evidence_types_list
+from app.datamgmt.manage.manage_evidence_types_db import get_evidence_type_by_id
+from app.datamgmt.manage.manage_evidence_types_db import verify_evidence_type_in_use
+from app.forms import EvidenceTypeForm
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
-from app.schema.marshables import CaseClassificationSchema, EvidenceTypeSchema
-from app.util import ac_api_requires_deprecated, response_error, ac_requires
+from app.schema.marshables import EvidenceTypeSchema
+from app.util import ac_api_requires
+from app.util import response_error
+from app.util import ac_requires
 from app.util import response_success
 
 manage_evidence_types_blueprint = Blueprint('manage_evidence_types',
@@ -38,12 +44,9 @@ manage_evidence_types_blueprint = Blueprint('manage_evidence_types',
 
 # CONTENT ------------------------------------------------
 @manage_evidence_types_blueprint.route('/manage/evidence-types/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_evidence_types(caseid: int) -> Response:
+@ac_api_requires()
+def list_evidence_types() -> Response:
     """Get the list of evidence types
-
-    Args:
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -55,8 +58,8 @@ def list_evidence_types(caseid: int) -> Response:
 
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/<int:evidence_type_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_evidence_type(evidence_type_id: int, caseid: int) -> Response:
+@ac_api_requires()
+def get_evidence_type(evidence_type_id: int) -> Response:
     """Get an evidence type
 
     Args:
@@ -107,13 +110,12 @@ def update_evidence_type_modal(evidence_type_id: int, caseid: int, url_redir: bo
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/update/<int:evidence_type_id>',
                                        methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def update_case_classification(evidence_type_id: int, caseid: int) -> Response:
+@ac_api_requires(Permissions.server_administrator)
+def update_case_classification(evidence_type_id: int) -> Response:
     """Update an evidence type
 
     Args:
         evidence_type_id (int): evidence type id
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -132,7 +134,7 @@ def update_case_classification(evidence_type_id: int, caseid: int) -> Response:
         ccls = ccl.load(request.get_json(), instance=evidence_type)
 
         if ccls:
-            track_activity(f"updated evidence type {ccls.id}", caseid=caseid)
+            track_activity(f"updated evidence type {ccls.id}")
             return response_success("Evidence type updated", ccl.dump(ccls))
 
     except marshmallow.exceptions.ValidationError as e:
@@ -163,12 +165,9 @@ def add_evidence_type_modal(caseid: int, url_redir: bool) -> Union[str, Response
 
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def add_evidence_type(caseid: int) -> Response:
+@ac_api_requires(Permissions.server_administrator)
+def add_evidence_type() -> Response:
     """Add an evidence type
-
-    Args:
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -186,7 +185,7 @@ def add_evidence_type(caseid: int) -> Response:
             db.session.add(ccls)
             db.session.commit()
 
-            track_activity(f"added evidence type {ccls.name}", caseid=caseid)
+            track_activity(f"added evidence type {ccls.name}")
             return response_success("Evidence type added", ccl.dump(ccls))
 
     except marshmallow.exceptions.ValidationError as e:
@@ -197,13 +196,12 @@ def add_evidence_type(caseid: int) -> Response:
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/delete/<int:evidence_type_id>',
                                        methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def delete_evidence_type(evidence_type_id: int, caseid: int) -> Response:
+@ac_api_requires(Permissions.server_administrator)
+def delete_evidence_type(evidence_type_id: int) -> Response:
     """Delete an evidence type
 
     Args:
         evidence_type_id (int): evidence type id
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -218,13 +216,13 @@ def delete_evidence_type(evidence_type_id: int, caseid: int) -> Response:
     db.session.delete(evidence_type)
     db.session.commit()
 
-    track_activity(f"deleted evidence type {evidence_type.name}", caseid=caseid)
+    track_activity(f"deleted evidence type {evidence_type.name}")
     return response_success("Evidence type deleted")
 
 
 @manage_evidence_types_blueprint.route('/manage/evidence-types/search', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def search_evidence_type(caseid):
+@ac_api_requires()
+def search_evidence_type():
     if not request.is_json:
         return response_error("Invalid request")
 

--- a/source/app/blueprints/manage/manage_groups.py
+++ b/source/app/blueprints/manage/manage_groups.py
@@ -24,7 +24,8 @@ from flask import url_for
 from flask_login import current_user
 from werkzeug.utils import redirect
 
-from app import db, app
+from app import db
+from app import app
 from app.datamgmt.manage.manage_cases_db import list_cases_dict
 from app.datamgmt.manage.manage_groups_db import add_all_cases_access_to_group
 from app.datamgmt.manage.manage_groups_db import add_case_access_to_group
@@ -39,14 +40,16 @@ from app.datamgmt.manage.manage_groups_db import update_group_members
 from app.datamgmt.manage.manage_users_db import get_user
 from app.datamgmt.manage.manage_users_db import get_users_list_restricted
 from app.forms import AddGroupForm
-from app.iris_engine.access_control.utils import ac_get_all_access_level, ac_ldp_group_removal, ac_flag_match_mask, \
-    ac_ldp_group_update
+from app.iris_engine.access_control.utils import ac_get_all_access_level
+from app.iris_engine.access_control.utils import ac_ldp_group_removal
+from app.iris_engine.access_control.utils import ac_flag_match_mask
+from app.iris_engine.access_control.utils import ac_ldp_group_update
 from app.iris_engine.access_control.utils import ac_get_all_permissions
 from app.iris_engine.access_control.utils import ac_recompute_effective_ac_from_users_list
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import AuthorizationGroupSchema
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import ac_requires
 from app.util import response_error
@@ -64,8 +67,8 @@ log = app.logger
 
 
 @manage_groups_blueprint.route('/manage/groups/list', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_groups_index(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_groups_index():
     groups = get_groups_list_hr_perms()
 
     return response_success('', data=groups)
@@ -104,8 +107,8 @@ def manage_groups_add_modal(caseid, url_redir):
 
 
 @manage_groups_blueprint.route('/manage/groups/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_groups_add(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_groups_add():
 
     if not request.is_json:
         return response_error("Invalid request, expecting JSON")
@@ -127,14 +130,14 @@ def manage_groups_add(caseid):
     except marshmallow.exceptions.ValidationError as e:
         return response_error(msg="Data error", data=e.messages)
 
-    track_activity(message=f"added group {ags_c.group_name}", caseid=caseid, ctx_less=True)
+    track_activity(message=f"added group {ags_c.group_name}", ctx_less=True)
 
     return response_success('', data=ags.dump(ags_c))
 
 
 @manage_groups_blueprint.route('/manage/groups/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_groups_update(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_groups_update(cur_id):
 
     if not request.is_json:
         return response_error("Invalid request, expecting JSON")
@@ -148,7 +151,7 @@ def manage_groups_update(cur_id, caseid):
         return response_error("Invalid group ID")
 
     if protect_demo_mode_group(group):
-        return ac_api_return_access_denied(caseid=caseid)
+        return ac_api_return_access_denied()
 
     ags = AuthorizationGroupSchema()
 
@@ -174,15 +177,15 @@ def manage_groups_update(cur_id, caseid):
 
 
 @manage_groups_blueprint.route('/manage/groups/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_groups_delete(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_groups_delete(cur_id):
 
     group = get_group(cur_id)
     if not group:
         return response_error("Invalid group ID")
 
     if protect_demo_mode_group(group):
-        return ac_api_return_access_denied(caseid=caseid)
+        return ac_api_return_access_denied()
 
     if ac_ldp_group_removal(current_user.id, group_id=group.group_id):
         return response_error("I can't let you do that Dave", data="Removing this group will lock you out")
@@ -193,8 +196,8 @@ def manage_groups_delete(cur_id, caseid):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_groups_view(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_groups_view(cur_id):
 
     group = get_group_details(cur_id)
     if not group:
@@ -220,15 +223,15 @@ def manage_groups_members_modal(cur_id, caseid, url_redir):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>/members/update', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_groups_members_update(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_groups_members_update(cur_id):
 
     group = get_group_with_members(cur_id)
     if not group:
         return response_error("Invalid group ID")
 
     if protect_demo_mode_group(group):
-        return ac_api_return_access_denied(caseid=caseid)
+        return ac_api_return_access_denied()
 
     if not request.is_json:
         return response_error("Invalid request, expecting JSON")
@@ -247,15 +250,15 @@ def manage_groups_members_update(cur_id, caseid):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>/members/delete/<int:cur_id_2>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_groups_members_delete(cur_id, cur_id_2, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_groups_members_delete(cur_id, cur_id_2):
 
     group = get_group_with_members(cur_id)
     if not group:
         return response_error("Invalid group ID")
 
     if protect_demo_mode_group(group):
-        return ac_api_return_access_denied(caseid=caseid)
+        return ac_api_return_access_denied()
 
     user = get_user(cur_id_2)
     if not user:
@@ -298,8 +301,8 @@ def manage_groups_cac_modal(cur_id, caseid, url_redir):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>/cases-access/update', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_groups_cac_add_case(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_groups_cac_add_case(cur_id):
     if not request.is_json:
         return response_error("Invalid request, expecting JSON")
 
@@ -312,7 +315,7 @@ def manage_groups_cac_add_case(cur_id, caseid):
         return response_error("Invalid group ID")
 
     if protect_demo_mode_group(group):
-        return ac_api_return_access_denied(caseid=caseid)
+        return ac_api_return_access_denied()
 
     if not isinstance(data.get('access_level'), int):
         try:
@@ -344,15 +347,15 @@ def manage_groups_cac_add_case(cur_id, caseid):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>/cases-access/delete', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_groups_cac_delete_case(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_groups_cac_delete_case(cur_id):
 
     group = get_group_with_members(cur_id)
     if not group:
         return response_error("Invalid group ID")
 
     if protect_demo_mode_group(group):
-        return ac_api_return_access_denied(caseid=caseid)
+        return ac_api_return_access_denied()
 
     if not request.is_json:
         return response_error("Invalid request")

--- a/source/app/blueprints/manage/manage_groups.py
+++ b/source/app/blueprints/manage/manage_groups.py
@@ -46,7 +46,7 @@ from app.iris_engine.access_control.utils import ac_recompute_effective_ac_from_
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import AuthorizationGroupSchema
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_api_return_access_denied
 from app.util import ac_requires
 from app.util import response_error
@@ -64,7 +64,7 @@ log = app.logger
 
 
 @manage_groups_blueprint.route('/manage/groups/list', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_groups_index(caseid):
     groups = get_groups_list_hr_perms()
 
@@ -104,7 +104,7 @@ def manage_groups_add_modal(caseid, url_redir):
 
 
 @manage_groups_blueprint.route('/manage/groups/add', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_groups_add(caseid):
 
     if not request.is_json:
@@ -133,7 +133,7 @@ def manage_groups_add(caseid):
 
 
 @manage_groups_blueprint.route('/manage/groups/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_groups_update(cur_id, caseid):
 
     if not request.is_json:
@@ -174,7 +174,7 @@ def manage_groups_update(cur_id, caseid):
 
 
 @manage_groups_blueprint.route('/manage/groups/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_groups_delete(cur_id, caseid):
 
     group = get_group(cur_id)
@@ -193,7 +193,7 @@ def manage_groups_delete(cur_id, caseid):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_groups_view(cur_id, caseid):
 
     group = get_group_details(cur_id)
@@ -220,7 +220,7 @@ def manage_groups_members_modal(cur_id, caseid, url_redir):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>/members/update', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_groups_members_update(cur_id, caseid):
 
     group = get_group_with_members(cur_id)
@@ -247,7 +247,7 @@ def manage_groups_members_update(cur_id, caseid):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>/members/delete/<int:cur_id_2>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_groups_members_delete(cur_id, cur_id_2, caseid):
 
     group = get_group_with_members(cur_id)
@@ -298,7 +298,7 @@ def manage_groups_cac_modal(cur_id, caseid, url_redir):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>/cases-access/update', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_groups_cac_add_case(cur_id, caseid):
     if not request.is_json:
         return response_error("Invalid request, expecting JSON")
@@ -344,7 +344,7 @@ def manage_groups_cac_add_case(cur_id, caseid):
 
 
 @manage_groups_blueprint.route('/manage/groups/<int:cur_id>/cases-access/delete', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_groups_cac_delete_case(cur_id, caseid):
 
     group = get_group_with_members(cur_id)

--- a/source/app/blueprints/manage/manage_ioc_types_routes.py
+++ b/source/app/blueprints/manage/manage_ioc_types_routes.py
@@ -31,7 +31,7 @@ from app.models import Ioc
 from app.models import IocType
 from app.models.authorization import Permissions
 from app.schema.marshables import IocTypeSchema
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -43,16 +43,16 @@ manage_ioc_type_blueprint = Blueprint('manage_ioc_types',
 
 # CONTENT ------------------------------------------------
 @manage_ioc_type_blueprint.route('/manage/ioc-types/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_ioc_types(caseid):
+@ac_api_requires()
+def list_ioc_types():
     lstatus = get_ioc_types_list()
 
     return response_success("", data=lstatus)
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_ioc_type(cur_id, caseid):
+@ac_api_requires()
+def get_ioc_type(cur_id):
 
     ioc_type = IocType.query.filter(IocType.type_id == cur_id).first()
     if not ioc_type:
@@ -93,8 +93,8 @@ def add_ioc_modal(caseid, url_redir):
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def add_ioc_type_api(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def add_ioc_type_api():
     if not request.is_json:
         return response_error("Invalid request")
 
@@ -109,14 +109,14 @@ def add_ioc_type_api(caseid):
     except marshmallow.exceptions.ValidationError as e:
         return response_error(msg="Data error", data=e.messages)
 
-    track_activity("Added ioc type {ioc_type_name}".format(ioc_type_name=ioct_sc.type_name), caseid=caseid, ctx_less=True)
+    track_activity("Added ioc type {ioc_type_name}".format(ioc_type_name=ioct_sc.type_name), ctx_less=True)
     # Return the assets
     return response_success("Added successfully", data=ioct_sc)
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def remove_ioc_type(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def remove_ioc_type(cur_id):
 
     type_id = IocType.query.filter(
         IocType.type_id == cur_id
@@ -128,18 +128,17 @@ def remove_ioc_type(cur_id, caseid):
 
     if type_id:
         db.session.delete(type_id)
-        track_activity("Deleted ioc type ID {type_id}".format(type_id=cur_id), caseid=caseid, ctx_less=True)
+        track_activity("Deleted ioc type ID {type_id}".format(type_id=cur_id), ctx_less=True)
         return response_success("Deleted ioc type ID {type_id}".format(type_id=cur_id))
 
-    track_activity("Attempted to delete ioc type ID {type_id}, but was not found".format(type_id=cur_id),
-                    caseid=caseid, ctx_less=True)
+    track_activity(f'Attempted to delete ioc type ID {cur_id}, but was not found', ctx_less=True)
 
     return response_error("Attempted to delete ioc type ID {type_id}, but was not found".format(type_id=cur_id))
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def update_ioc(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def update_ioc(cur_id):
     if not request.is_json:
         return response_error("Invalid request")
 
@@ -154,7 +153,7 @@ def update_ioc(cur_id, caseid):
         ioct_sc = ioct_schema.load(request.get_json(), instance=ioc_type)
 
         if ioct_sc:
-            track_activity("updated ioc type type {}".format(ioct_sc.type_name), caseid=caseid)
+            track_activity("updated ioc type type {}".format(ioct_sc.type_name))
             return response_success("IOC type updated", ioct_sc)
 
     except marshmallow.exceptions.ValidationError as e:
@@ -164,15 +163,12 @@ def update_ioc(cur_id, caseid):
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/search', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def search_ioc_type(caseid):
+@ac_api_requires()
+def search_ioc_type():
     """Searches for IOC types in the database.
 
     This function searches for IOC types in the database with a name that contains the specified search term.
     It returns a JSON response containing the matching IOC types.
-
-    Args:
-        caseid: The ID of the case associated with the request.
 
     Returns:
         A JSON response containing the matching IOC types.

--- a/source/app/blueprints/manage/manage_ioc_types_routes.py
+++ b/source/app/blueprints/manage/manage_ioc_types_routes.py
@@ -31,7 +31,7 @@ from app.models import Ioc
 from app.models import IocType
 from app.models.authorization import Permissions
 from app.schema.marshables import IocTypeSchema
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -43,7 +43,7 @@ manage_ioc_type_blueprint = Blueprint('manage_ioc_types',
 
 # CONTENT ------------------------------------------------
 @manage_ioc_type_blueprint.route('/manage/ioc-types/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_ioc_types(caseid):
     lstatus = get_ioc_types_list()
 
@@ -51,7 +51,7 @@ def list_ioc_types(caseid):
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/<int:cur_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_ioc_type(cur_id, caseid):
 
     ioc_type = IocType.query.filter(IocType.type_id == cur_id).first()
@@ -93,7 +93,7 @@ def add_ioc_modal(caseid, url_redir):
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/add', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def add_ioc_type_api(caseid):
     if not request.is_json:
         return response_error("Invalid request")
@@ -115,7 +115,7 @@ def add_ioc_type_api(caseid):
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/delete/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def remove_ioc_type(cur_id, caseid):
 
     type_id = IocType.query.filter(
@@ -138,7 +138,7 @@ def remove_ioc_type(cur_id, caseid):
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def update_ioc(cur_id, caseid):
     if not request.is_json:
         return response_error("Invalid request")
@@ -164,7 +164,7 @@ def update_ioc(cur_id, caseid):
 
 
 @manage_ioc_type_blueprint.route('/manage/ioc-types/search', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def search_ioc_type(caseid):
     """Searches for IOC types in the database.
 

--- a/source/app/blueprints/manage/manage_modules_routes.py
+++ b/source/app/blueprints/manage/manage_modules_routes.py
@@ -16,7 +16,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-# IMPORTS ------------------------------------------------
 import json
 import logging as log
 import traceback
@@ -46,7 +45,7 @@ from app.iris_engine.module_handler.module_handler import iris_update_hooks
 from app.iris_engine.module_handler.module_handler import register_module
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -89,16 +88,16 @@ def manage_modules_index(caseid, url_redir):
 
 
 @manage_modules_blueprint.route('/manage/modules/list', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_modules_list(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_modules_list():
     output = iris_modules_list()
 
     return response_success('', data=output)
 
 
 @manage_modules_blueprint.route('/manage/modules/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def add_module(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def add_module():
     if request.json is None:
         return response_error('Invalid request')
 
@@ -122,11 +121,10 @@ def add_module(caseid):
         # Registers into Iris DB for further calls
         module, message = register_module(module_name)
         if module is None:
-            track_activity(f"addition of IRIS module {module_name} was attempted and failed",
-                           caseid=caseid, ctx_less=True)
+            track_activity(f"addition of IRIS module {module_name} was attempted and failed", ctx_less=True)
             return response_error(f'Unable to register module: {message}')
 
-        track_activity(f"IRIS module {module_name} was added", caseid=caseid, ctx_less=True)
+        track_activity(f"IRIS module {module_name} was added", ctx_less=True)
         module_schema = IrisModuleSchema()
         return response_success(message, data=module_schema.dump(module))
 
@@ -165,8 +163,8 @@ def getmodule_param(param_name, caseid, url_redir):
 
 
 @manage_modules_blueprint.route('/manage/modules/set-parameter/<param_name>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def update_module_param(param_name, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def update_module_param(param_name):
 
     if request.json is None:
         return response_error('Invalid request')
@@ -180,7 +178,7 @@ def update_module_param(param_name, caseid):
 
     if iris_module_save_parameter(mod_id, mod_config, parameter['param_name'], parameter_value):
         track_activity(f"parameter {parameter['param_name']} of mod ({mod_name})  #{mod_id} was updated",
-                       caseid=caseid, ctx_less=True)
+                       ctx_less=True)
 
         success, logs = iris_update_hooks(mod_iname, mod_id)
         if not success:
@@ -212,8 +210,8 @@ def view_module(mod_id, caseid, url_redir):
 
 
 @manage_modules_blueprint.route('/manage/modules/enable/<int:mod_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def enable_module(mod_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def enable_module(mod_id):
 
     module_name = iris_module_name_from_id(mod_id)
     if module_name is None:
@@ -226,32 +224,29 @@ def enable_module(mod_id, caseid):
     if not success:
         return response_error("Unable to update hooks when enabling module", data=logs)
 
-    track_activity(f"IRIS module ({module_name}) #{mod_id} enabled",
-                   caseid=caseid, ctx_less=True)
+    track_activity(f"IRIS module ({module_name}) #{mod_id} enabled", ctx_less=True)
 
     return response_success('Module enabled', data=logs)
 
 
 @manage_modules_blueprint.route('/manage/modules/disable/<int:module_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def disable_module(module_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def disable_module(module_id):
     if iris_module_disable_by_id(module_id):
 
-        track_activity(f"IRIS module #{module_id} disabled",
-                       caseid=caseid, ctx_less=True)
+        track_activity(f"IRIS module #{module_id} disabled", ctx_less=True)
         return response_success('Module disabled')
 
     return response_error('Unable to disable module')
 
 
 @manage_modules_blueprint.route('/manage/modules/remove/<int:module_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def view_delete_module(module_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def view_delete_module(module_id):
     try:
 
         delete_module_from_id(module_id=module_id)
-        track_activity(f"IRIS module #{module_id} deleted",
-                       caseid=caseid, ctx_less=True)
+        track_activity(f"IRIS module #{module_id} deleted", ctx_less=True)
         return response_success("Deleted")
 
     except Exception as e:
@@ -260,8 +255,8 @@ def view_delete_module(module_id, caseid):
 
 
 @manage_modules_blueprint.route('/manage/modules/export-config/<int:module_id>', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def export_mod_config(module_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def export_mod_config(module_id):
 
     mod_config, mod_name, _ = get_module_config_from_id(module_id)
     if mod_name:
@@ -275,8 +270,8 @@ def export_mod_config(module_id, caseid):
 
 
 @manage_modules_blueprint.route('/manage/modules/import-config/<int:module_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def import_mod_config(module_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def import_mod_config(module_id):
 
     mod_config, mod_name, _ = get_module_config_from_id(module_id)
     logs = []
@@ -296,8 +291,7 @@ def import_mod_config(module_id, caseid):
         if not iris_module_save_parameter(module_id, mod_config, param_name, parameter_value):
             logs.append(f'Unable to save parameter {param_name}')
 
-    track_activity(f"parameters of mod #{module_id} were updated from config file",
-                   caseid=caseid, ctx_less=True)
+    track_activity(f"parameters of mod #{module_id} were updated from config file", ctx_less=True)
 
     if len(logs) == 0:
         msg = "Successfully imported data."
@@ -308,8 +302,8 @@ def import_mod_config(module_id, caseid):
 
 
 @manage_modules_blueprint.route('/manage/modules/hooks/list', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def view_modules_hook(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def view_modules_hook():
     output = module_list_hooks_view()
     data = [item._asdict() for item in output]
 

--- a/source/app/blueprints/manage/manage_modules_routes.py
+++ b/source/app/blueprints/manage/manage_modules_routes.py
@@ -46,7 +46,7 @@ from app.iris_engine.module_handler.module_handler import iris_update_hooks
 from app.iris_engine.module_handler.module_handler import register_module
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -89,7 +89,7 @@ def manage_modules_index(caseid, url_redir):
 
 
 @manage_modules_blueprint.route('/manage/modules/list', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_modules_list(caseid):
     output = iris_modules_list()
 
@@ -97,7 +97,7 @@ def manage_modules_list(caseid):
 
 
 @manage_modules_blueprint.route('/manage/modules/add', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def add_module(caseid):
     if request.json is None:
         return response_error('Invalid request')
@@ -165,7 +165,7 @@ def getmodule_param(param_name, caseid, url_redir):
 
 
 @manage_modules_blueprint.route('/manage/modules/set-parameter/<param_name>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def update_module_param(param_name, caseid):
 
     if request.json is None:
@@ -212,7 +212,7 @@ def view_module(mod_id, caseid, url_redir):
 
 
 @manage_modules_blueprint.route('/manage/modules/enable/<int:mod_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def enable_module(mod_id, caseid):
 
     module_name = iris_module_name_from_id(mod_id)
@@ -233,7 +233,7 @@ def enable_module(mod_id, caseid):
 
 
 @manage_modules_blueprint.route('/manage/modules/disable/<int:module_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def disable_module(module_id, caseid):
     if iris_module_disable_by_id(module_id):
 
@@ -245,7 +245,7 @@ def disable_module(module_id, caseid):
 
 
 @manage_modules_blueprint.route('/manage/modules/remove/<int:module_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def view_delete_module(module_id, caseid):
     try:
 
@@ -260,7 +260,7 @@ def view_delete_module(module_id, caseid):
 
 
 @manage_modules_blueprint.route('/manage/modules/export-config/<int:module_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def export_mod_config(module_id, caseid):
 
     mod_config, mod_name, _ = get_module_config_from_id(module_id)
@@ -275,7 +275,7 @@ def export_mod_config(module_id, caseid):
 
 
 @manage_modules_blueprint.route('/manage/modules/import-config/<int:module_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def import_mod_config(module_id, caseid):
 
     mod_config, mod_name, _ = get_module_config_from_id(module_id)
@@ -308,7 +308,7 @@ def import_mod_config(module_id, caseid):
 
 
 @manage_modules_blueprint.route('/manage/modules/hooks/list', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def view_modules_hook(caseid):
     output = module_list_hooks_view()
     data = [item._asdict() for item in output]

--- a/source/app/blueprints/manage/manage_severities_routes.py
+++ b/source/app/blueprints/manage/manage_severities_routes.py
@@ -19,7 +19,7 @@ from flask import Blueprint, Response, request
 
 from app.datamgmt.manage.manage_common import get_severity_by_id, get_severities_list, search_severity_by_name
 from app.schema.marshables import SeveritySchema
-from app.util import ac_api_requires, response_error
+from app.util import ac_api_requires_deprecated, response_error
 from app.util import response_success
 
 manage_severities_blueprint = Blueprint('manage_severities',
@@ -29,7 +29,7 @@ manage_severities_blueprint = Blueprint('manage_severities',
 
 # CONTENT ------------------------------------------------
 @manage_severities_blueprint.route('/manage/severities/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_severities(caseid: int) -> Response:
     """
     Get the list of severities
@@ -47,7 +47,7 @@ def list_severities(caseid: int) -> Response:
 
 
 @manage_severities_blueprint.route('/manage/severities/<int:severity_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_case_alert_status(severity_id: int, caseid: int) -> Response:
     """
     Get the alert status
@@ -63,7 +63,7 @@ def get_case_alert_status(severity_id: int, caseid: int) -> Response:
 
 
 @manage_severities_blueprint.route('/manage/severities/search', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def search_analysis_status(caseid):
     if not request.is_json:
         return response_error("Invalid request")

--- a/source/app/blueprints/manage/manage_severities_routes.py
+++ b/source/app/blueprints/manage/manage_severities_routes.py
@@ -15,11 +15,16 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from flask import Blueprint, Response, request
+from flask import Blueprint
+from flask import Response
+from flask import request
 
-from app.datamgmt.manage.manage_common import get_severity_by_id, get_severities_list, search_severity_by_name
+from app.datamgmt.manage.manage_common import get_severity_by_id
+from app.datamgmt.manage.manage_common import get_severities_list
+from app.datamgmt.manage.manage_common import search_severity_by_name
 from app.schema.marshables import SeveritySchema
-from app.util import ac_api_requires_deprecated, response_error
+from app.util import ac_api_requires
+from app.util import response_error
 from app.util import response_success
 
 manage_severities_blueprint = Blueprint('manage_severities',
@@ -27,15 +32,11 @@ manage_severities_blueprint = Blueprint('manage_severities',
                                         template_folder='templates')
 
 
-# CONTENT ------------------------------------------------
 @manage_severities_blueprint.route('/manage/severities/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_severities(caseid: int) -> Response:
+@ac_api_requires()
+def list_severities() -> Response:
     """
     Get the list of severities
-
-    Args:
-        caseid (int): case id
 
     Returns:
         Flask Response object
@@ -47,14 +48,13 @@ def list_severities(caseid: int) -> Response:
 
 
 @manage_severities_blueprint.route('/manage/severities/<int:severity_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_case_alert_status(severity_id: int, caseid: int) -> Response:
+@ac_api_requires()
+def get_case_alert_status(severity_id: int) -> Response:
     """
     Get the alert status
 
     Args:
         severity_id (int): severity id
-        caseid (int): case id
     """
     cl = get_severity_by_id(severity_id)
     schema = SeveritySchema()
@@ -63,8 +63,8 @@ def get_case_alert_status(severity_id: int, caseid: int) -> Response:
 
 
 @manage_severities_blueprint.route('/manage/severities/search', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def search_analysis_status(caseid):
+@ac_api_requires()
+def search_analysis_status():
     if not request.is_json:
         return response_error("Invalid request")
 

--- a/source/app/blueprints/manage/manage_srv_settings_routes.py
+++ b/source/app/blueprints/manage/manage_srv_settings_routes.py
@@ -39,7 +39,7 @@ from app.iris_engine.updater.updater import setup_periodic_update_checks
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import ServerSettingsSchema
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -62,7 +62,7 @@ def manage_update(caseid, url_redir):
 
 
 @manage_srv_settings_blueprint.route('/manage/server/backups/make-db', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_make_db_backup(caseid):
 
     has_error, logs = backup_iris_db()
@@ -111,7 +111,7 @@ def manage_settings(caseid, url_redir):
 
 
 @manage_srv_settings_blueprint.route('/manage/settings/update', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_update_settings(caseid):
     if not request.is_json:
         return response_error('Invalid request')

--- a/source/app/blueprints/manage/manage_srv_settings_routes.py
+++ b/source/app/blueprints/manage/manage_srv_settings_routes.py
@@ -16,8 +16,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-# IMPORTS ------------------------------------------------
-
 import marshmallow
 from flask import Blueprint
 from flask import render_template
@@ -32,14 +30,13 @@ from app import db
 from app.datamgmt.manage.manage_srv_settings_db import get_alembic_revision
 from app.datamgmt.manage.manage_srv_settings_db import get_srv_settings
 from app.iris_engine.backup.backup import backup_iris_db
-from app.iris_engine.updater.updater import inner_init_server_update
 from app.iris_engine.updater.updater import is_updates_available
 from app.iris_engine.updater.updater import remove_periodic_update_checks
 from app.iris_engine.updater.updater import setup_periodic_update_checks
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import ServerSettingsSchema
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -62,8 +59,8 @@ def manage_update(caseid, url_redir):
 
 
 @manage_srv_settings_blueprint.route('/manage/server/backups/make-db', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_make_db_backup(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_make_db_backup():
 
     has_error, logs = backup_iris_db()
     if has_error:
@@ -111,8 +108,8 @@ def manage_settings(caseid, url_redir):
 
 
 @manage_srv_settings_blueprint.route('/manage/settings/update', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_update_settings(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_update_settings():
     if not request.is_json:
         return response_error('Invalid request')
 
@@ -132,7 +129,7 @@ def manage_update_settings(caseid):
                 remove_periodic_update_checks()
 
         if srv_settings_sc:
-            track_activity("Server settings updated", caseid=caseid)
+            track_activity("Server settings updated")
             return response_success("Server settings updated", srv_settings_sc)
 
     except marshmallow.exceptions.ValidationError as e:

--- a/source/app/blueprints/manage/manage_tags.py
+++ b/source/app/blueprints/manage/manage_tags.py
@@ -15,9 +15,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import json
-
-# IMPORTS ------------------------------------------------
-
 from flask import Blueprint
 from flask import request
 from werkzeug import Response
@@ -25,7 +22,8 @@ from werkzeug import Response
 from app import app
 from app.datamgmt.manage.manage_tags_db import get_filtered_tags
 from app.schema.marshables import TagsSchema
-from app.util import ac_api_requires_deprecated, AlchemyEncoder
+from app.util import ac_api_requires
+from app.util import AlchemyEncoder
 from app.util import response_success
 
 manage_tags_blueprint = Blueprint('manage_tags',
@@ -34,8 +32,8 @@ manage_tags_blueprint = Blueprint('manage_tags',
 
 
 @manage_tags_blueprint.route('/manage/tags/filter', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def manage_tags_filter(caseid) -> Response:
+@ac_api_requires()
+def manage_tags_filter() -> Response:
     """ Returns a list of tags, filtered by the given parameters.
 
     :param caseid: Case ID - Unused
@@ -77,8 +75,8 @@ def manage_tags_filter(caseid) -> Response:
 
 
 @manage_tags_blueprint.route('/manage/tags/suggest', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def manage_tags_suggest(caseid) -> Response:
+@ac_api_requires()
+def manage_tags_suggest() -> Response:
     tag_title = request.args.get('term', None, type=str)
     filtered_tags = get_filtered_tags(tag_title=tag_title,
                                       tag_namespace=None,

--- a/source/app/blueprints/manage/manage_tags.py
+++ b/source/app/blueprints/manage/manage_tags.py
@@ -25,7 +25,7 @@ from werkzeug import Response
 from app import app
 from app.datamgmt.manage.manage_tags_db import get_filtered_tags
 from app.schema.marshables import TagsSchema
-from app.util import ac_api_requires, AlchemyEncoder
+from app.util import ac_api_requires_deprecated, AlchemyEncoder
 from app.util import response_success
 
 manage_tags_blueprint = Blueprint('manage_tags',
@@ -34,7 +34,7 @@ manage_tags_blueprint = Blueprint('manage_tags',
 
 
 @manage_tags_blueprint.route('/manage/tags/filter', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def manage_tags_filter(caseid) -> Response:
     """ Returns a list of tags, filtered by the given parameters.
 
@@ -77,7 +77,7 @@ def manage_tags_filter(caseid) -> Response:
 
 
 @manage_tags_blueprint.route('/manage/tags/suggest', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def manage_tags_suggest(caseid) -> Response:
     tag_title = request.args.get('term', None, type=str)
     filtered_tags = get_filtered_tags(tag_title=tag_title,

--- a/source/app/blueprints/manage/manage_task_status_routes.py
+++ b/source/app/blueprints/manage/manage_task_status_routes.py
@@ -19,7 +19,7 @@
 from flask import Blueprint
 
 from app.models.models import TaskStatus
-from app.util import api_login_required, ac_api_requires
+from app.util import api_login_required, ac_api_requires_deprecated
 from app.util import response_error
 from app.util import response_success
 
@@ -30,7 +30,7 @@ manage_task_status_blueprint = Blueprint('manage_task_status',
 
 # CONTENT ------------------------------------------------
 @manage_task_status_blueprint.route('/manage/task-status/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_task_status(caseid):
     lstatus = TaskStatus.query.with_entities(
         TaskStatus.id,
@@ -46,7 +46,7 @@ def list_task_status(caseid):
 
 # CONTENT ------------------------------------------------
 @manage_task_status_blueprint.route('/manage/task-status/<int:cur_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def view_task_status(cur_id, caseid):
     lstatus = TaskStatus.query.with_entities(
         TaskStatus.id,

--- a/source/app/blueprints/manage/manage_task_status_routes.py
+++ b/source/app/blueprints/manage/manage_task_status_routes.py
@@ -19,19 +19,16 @@
 from flask import Blueprint
 
 from app.models.models import TaskStatus
-from app.util import api_login_required, ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 
-manage_task_status_blueprint = Blueprint('manage_task_status',
-                                       __name__,
-                                       template_folder='templates')
+manage_task_status_blueprint = Blueprint('manage_task_status', __name__, template_folder='templates')
 
 
-# CONTENT ------------------------------------------------
 @manage_task_status_blueprint.route('/manage/task-status/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_task_status(caseid):
+@ac_api_requires()
+def list_task_status():
     lstatus = TaskStatus.query.with_entities(
         TaskStatus.id,
         TaskStatus.status_name,
@@ -46,8 +43,8 @@ def list_task_status(caseid):
 
 # CONTENT ------------------------------------------------
 @manage_task_status_blueprint.route('/manage/task-status/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def view_task_status(cur_id, caseid):
+@ac_api_requires()
+def view_task_status(cur_id):
     lstatus = TaskStatus.query.with_entities(
         TaskStatus.id,
         TaskStatus.status_name,

--- a/source/app/blueprints/manage/manage_templates_routes.py
+++ b/source/app/blueprints/manage/manage_templates_routes.py
@@ -39,7 +39,7 @@ from app.models.authorization import User
 from app.models.models import CaseTemplateReport
 from app.models.models import Languages
 from app.models.models import ReportType
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -79,7 +79,7 @@ def manage_report_templates(caseid, url_redir):
 
 
 @manage_templates_blueprint.route('/manage/templates/list')
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def report_templates_list(caseid):
     # Get all templates
     templates = CaseTemplateReport.query.with_entities(
@@ -106,7 +106,7 @@ def report_templates_list(caseid):
 
 
 @manage_templates_blueprint.route('/manage/templates/add/modal', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def add_template_modal(caseid):
     report_template = CaseTemplateReport()
     form = AddReportTemplateForm()
@@ -117,7 +117,7 @@ def add_template_modal(caseid):
 
 
 @manage_templates_blueprint.route('/manage/templates/add', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def add_template(caseid):
 
     report_template = CaseTemplateReport()
@@ -169,7 +169,7 @@ def add_template(caseid):
 
 
 @manage_templates_blueprint.route('/manage/templates/download/<report_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def download_template(report_id, caseid):
     if report_id != 0:
         report_template = CaseTemplateReport.query.filter(CaseTemplateReport.id == report_id).first()
@@ -185,7 +185,7 @@ def download_template(report_id, caseid):
 
 
 @manage_templates_blueprint.route('/manage/templates/delete/<report_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def delete_template(report_id, caseid):
     error = None
 

--- a/source/app/blueprints/manage/manage_templates_routes.py
+++ b/source/app/blueprints/manage/manage_templates_routes.py
@@ -16,7 +16,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-# IMPORTS ------------------------------------------------
 import os
 import random
 import string
@@ -39,7 +38,7 @@ from app.models.authorization import User
 from app.models.models import CaseTemplateReport
 from app.models.models import Languages
 from app.models.models import ReportType
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_error
 from app.util import response_success
@@ -79,8 +78,8 @@ def manage_report_templates(caseid, url_redir):
 
 
 @manage_templates_blueprint.route('/manage/templates/list')
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def report_templates_list(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def report_templates_list():
     # Get all templates
     templates = CaseTemplateReport.query.with_entities(
         CaseTemplateReport.name,
@@ -106,8 +105,8 @@ def report_templates_list(caseid):
 
 
 @manage_templates_blueprint.route('/manage/templates/add/modal', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def add_template_modal(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def add_template_modal():
     report_template = CaseTemplateReport()
     form = AddReportTemplateForm()
     form.report_language.choices = [(c.id, c.name.capitalize()) for c in Languages.query.all()]
@@ -117,8 +116,8 @@ def add_template_modal(caseid):
 
 
 @manage_templates_blueprint.route('/manage/templates/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def add_template(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def add_template():
 
     report_template = CaseTemplateReport()
 
@@ -152,7 +151,7 @@ def add_template(caseid):
         db.session.add(report_template)
         db.session.commit()
 
-        track_activity(f"report template '{report_template.name}' added", caseid=caseid, ctx_less=True)
+        track_activity(f"report template '{report_template.name}' added", ctx_less=True)
 
         ret = {
             "report_id": report_template.id,
@@ -169,8 +168,8 @@ def add_template(caseid):
 
 
 @manage_templates_blueprint.route('/manage/templates/download/<report_id>', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def download_template(report_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def download_template(report_id):
     if report_id != 0:
         report_template = CaseTemplateReport.query.filter(CaseTemplateReport.id == report_id).first()
 
@@ -185,8 +184,8 @@ def download_template(report_id, caseid):
 
 
 @manage_templates_blueprint.route('/manage/templates/delete/<report_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def delete_template(report_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def delete_template(report_id):
     error = None
 
     report_template = CaseTemplateReport.query.filter(CaseTemplateReport.id == report_id).first()
@@ -209,5 +208,5 @@ def delete_template(report_id, caseid):
     if error:
         return response_error(error)
 
-    track_activity(f"report template '{report_name}' deleted", caseid=caseid, ctx_less=True)
+    track_activity(f"report template '{report_name}' deleted", ctx_less=True)
     return response_success("Deleted successfully", data=error)

--- a/source/app/blueprints/manage/manage_tlps_routes.py
+++ b/source/app/blueprints/manage/manage_tlps_routes.py
@@ -18,7 +18,7 @@
 from flask import Blueprint
 
 from app.models import Tlp
-from app.util import api_login_required, ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 
@@ -29,16 +29,16 @@ manage_tlp_type_blueprint = Blueprint('manage_tlp_types',
 
 # CONTENT ------------------------------------------------
 @manage_tlp_type_blueprint.route('/manage/tlp/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def list_tlp_types(caseid):
+@ac_api_requires()
+def list_tlp_types():
     lstatus = Tlp.query.all()
 
     return response_success("", data=lstatus)
 
 
 @manage_tlp_type_blueprint.route('/manage/tlp/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_tlp_type(cur_id, caseid):
+@ac_api_requires()
+def get_tlp_type(cur_id):
 
     tlp_type = Tlp.query.filter(Tlp.tlp_id == cur_id).first()
     if not tlp_type:

--- a/source/app/blueprints/manage/manage_tlps_routes.py
+++ b/source/app/blueprints/manage/manage_tlps_routes.py
@@ -18,7 +18,7 @@
 from flask import Blueprint
 
 from app.models import Tlp
-from app.util import api_login_required, ac_api_requires
+from app.util import api_login_required, ac_api_requires_deprecated
 from app.util import response_error
 from app.util import response_success
 
@@ -29,7 +29,7 @@ manage_tlp_type_blueprint = Blueprint('manage_tlp_types',
 
 # CONTENT ------------------------------------------------
 @manage_tlp_type_blueprint.route('/manage/tlp/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def list_tlp_types(caseid):
     lstatus = Tlp.query.all()
 
@@ -37,7 +37,7 @@ def list_tlp_types(caseid):
 
 
 @manage_tlp_type_blueprint.route('/manage/tlp/<int:cur_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_tlp_type(cur_id, caseid):
 
     tlp_type = Tlp.query.filter(Tlp.tlp_id == cur_id).first()

--- a/source/app/blueprints/manage/manage_users.py
+++ b/source/app/blueprints/manage/manage_users.py
@@ -51,7 +51,7 @@ from app.iris_engine.access_control.utils import ac_get_all_access_level, ac_cur
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import UserSchema, BasicUserSchema, UserFullSchema
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_api_return_access_denied
 from app.util import ac_requires
 from app.util import is_authentication_local
@@ -69,7 +69,7 @@ log = app.logger
 
 
 @manage_users_blueprint.route('/manage/users/list', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_users_list(caseid):
 
     users = get_users_list()
@@ -78,7 +78,7 @@ def manage_users_list(caseid):
 
 
 @manage_users_blueprint.route('/manage/users/filter', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_users_filter(caseid):
 
     page = request.args.get('page', 1, type=int)
@@ -140,7 +140,7 @@ def add_user_modal(caseid, url_redir):
 
 
 @manage_users_blueprint.route('/manage/users/add', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def add_user(caseid):
     try:
 
@@ -172,7 +172,7 @@ def add_user(caseid):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def view_user(cur_id, caseid):
 
     user = get_user_details(user_id=cur_id)
@@ -224,7 +224,7 @@ def manage_user_group_modal(cur_id, caseid, url_redir):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/groups/update', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_user_group_(cur_id, caseid):
 
     if not request.is_json:
@@ -266,7 +266,7 @@ def manage_user_customers_modal(cur_id, caseid, url_redir):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/customers/update', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_user_customers_(cur_id, caseid):
 
     if not request.is_json:
@@ -319,7 +319,7 @@ def manage_user_cac_modal(cur_id, caseid, url_redir):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/cases-access/update', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_user_cac_add_case(cur_id, caseid):
 
     if not request.is_json:
@@ -355,7 +355,7 @@ def manage_user_cac_add_case(cur_id, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/cases-access/delete', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_user_cac_delete_cases(cur_id,  caseid):
 
     user = get_user(cur_id)
@@ -394,7 +394,7 @@ def manage_user_cac_delete_cases(cur_id,  caseid):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/case-access/delete', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def manage_user_cac_delete_case(cur_id,  caseid):
 
     user = get_user(cur_id)
@@ -433,7 +433,7 @@ def manage_user_cac_delete_case(cur_id,  caseid):
 
 
 @manage_users_blueprint.route('/manage/users/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def update_user_api(cur_id, caseid):
 
     try:
@@ -464,7 +464,7 @@ def update_user_api(cur_id, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/deactivate/<int:cur_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def deactivate_user_api(cur_id, caseid):
 
     user = get_user(cur_id)
@@ -486,7 +486,7 @@ def deactivate_user_api(cur_id, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/activate/<int:cur_id>', methods=['GET'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def activate_user_api(cur_id, caseid):
 
     user = get_user(cur_id)
@@ -505,7 +505,7 @@ def activate_user_api(cur_id, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/renew-api-key/<int:cur_id>', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
 def renew_user_api_key(cur_id, caseid):
 
     user = get_user(cur_id)
@@ -526,7 +526,7 @@ def renew_user_api_key(cur_id, caseid):
 
 if is_authentication_local():
     @manage_users_blueprint.route('/manage/users/delete/<int:cur_id>', methods=['POST'])
-    @ac_api_requires(Permissions.server_administrator, no_cid_required=True)
+    @ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
     def view_delete_user(cur_id, caseid):
 
         try:
@@ -555,7 +555,7 @@ if is_authentication_local():
 
 # Unrestricted section - non admin available
 @manage_users_blueprint.route('/manage/users/lookup/id/<int:cur_id>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def exists_user_restricted(cur_id, caseid):
 
     user = get_user(cur_id)
@@ -572,7 +572,7 @@ def exists_user_restricted(cur_id, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/lookup/login/<string:login>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def lookup_name_restricted(login, caseid):
     user = get_user_by_username(login)
     if not user:
@@ -591,7 +591,7 @@ def lookup_name_restricted(login, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/restricted/list', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def manage_users_list_restricted(caseid):
 
     users = get_users_list_restricted()

--- a/source/app/blueprints/manage/manage_users.py
+++ b/source/app/blueprints/manage/manage_users.py
@@ -16,9 +16,7 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import secrets
-
 import marshmallow
-# IMPORTS ------------------------------------------------
 import traceback
 from flask import Blueprint
 from flask import redirect
@@ -33,7 +31,9 @@ from app.datamgmt.client.client_db import get_client_list
 from app.datamgmt.manage.manage_cases_db import list_cases_dict
 from app.datamgmt.manage.manage_groups_db import get_groups_list
 from app.datamgmt.manage.manage_srv_settings_db import get_srv_settings
-from app.datamgmt.manage.manage_users_db import add_case_access_to_user, update_user_customers, get_filtered_users
+from app.datamgmt.manage.manage_users_db import add_case_access_to_user
+from app.datamgmt.manage.manage_users_db import update_user_customers
+from app.datamgmt.manage.manage_users_db import get_filtered_users
 from app.datamgmt.manage.manage_users_db import create_user
 from app.datamgmt.manage.manage_users_db import delete_user
 from app.datamgmt.manage.manage_users_db import get_user
@@ -47,11 +47,14 @@ from app.datamgmt.manage.manage_users_db import remove_cases_access_from_user
 from app.datamgmt.manage.manage_users_db import update_user
 from app.datamgmt.manage.manage_users_db import update_user_groups
 from app.forms import AddUserForm
-from app.iris_engine.access_control.utils import ac_get_all_access_level, ac_current_user_has_permission
+from app.iris_engine.access_control.utils import ac_get_all_access_level
+from app.iris_engine.access_control.utils import ac_current_user_has_permission
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
-from app.schema.marshables import UserSchema, BasicUserSchema, UserFullSchema
-from app.util import ac_api_requires_deprecated
+from app.schema.marshables import UserSchema
+from app.schema.marshables import BasicUserSchema
+from app.schema.marshables import UserFullSchema
+from app.util import ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import ac_requires
 from app.util import is_authentication_local
@@ -59,18 +62,14 @@ from app.util import response_error
 from app.util import response_success
 from app.iris_engine.demo_builder import protect_demo_mode_user
 
-manage_users_blueprint = Blueprint(
-    'manage_users',
-    __name__,
-    template_folder='templates'
-)
+manage_users_blueprint = Blueprint('manage_users', __name__, template_folder='templates')
 
 log = app.logger
 
 
 @manage_users_blueprint.route('/manage/users/list', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_users_list(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_users_list():
 
     users = get_users_list()
 
@@ -78,8 +77,8 @@ def manage_users_list(caseid):
 
 
 @manage_users_blueprint.route('/manage/users/filter', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_users_filter(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_users_filter():
 
     page = request.args.get('page', 1, type=int)
     per_page = request.args.get('per_page', 10, type=int)
@@ -140,8 +139,8 @@ def add_user_modal(caseid, url_redir):
 
 
 @manage_users_blueprint.route('/manage/users/add', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def add_user(caseid):
+@ac_api_requires(Permissions.server_administrator)
+def add_user():
     try:
 
         # validate before saving
@@ -162,7 +161,7 @@ def add_user(caseid):
         del udata['user_password']
 
         if cuser:
-            track_activity("created user {}".format(user.user), caseid=caseid,  ctx_less=True)
+            track_activity("created user {}".format(user.user),  ctx_less=True)
             return response_success("user created", data=udata)
 
         return response_error("Unable to create user for internal reasons")
@@ -172,8 +171,8 @@ def add_user(caseid):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def view_user(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def view_user(cur_id):
 
     user = get_user_details(user_id=cur_id)
 
@@ -224,8 +223,8 @@ def manage_user_group_modal(cur_id, caseid, url_redir):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/groups/update', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_user_group_(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_user_group_(cur_id):
 
     if not request.is_json:
         return response_error("Invalid request")
@@ -243,7 +242,7 @@ def manage_user_group_(cur_id, caseid):
     update_user_groups(user_id=cur_id,
                        groups=request.json.get('groups_membership'))
 
-    track_activity(f"groups membership of user {cur_id} updated", caseid=caseid,  ctx_less=True)
+    track_activity(f"groups membership of user {cur_id} updated", ctx_less=True)
 
     return response_success("User groups updated", data=user)
 
@@ -266,8 +265,8 @@ def manage_user_customers_modal(cur_id, caseid, url_redir):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/customers/update', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_user_customers_(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_user_customers_(cur_id):
 
     if not request.is_json:
         return response_error("Invalid request")
@@ -280,12 +279,11 @@ def manage_user_customers_(cur_id, caseid):
 
     user = get_user_details(cur_id)
     if not user:
-        return response_error("Invalid user ID")
+        return response_error('Invalid user ID')
 
-    update_user_customers(user_id=cur_id,
-                          customers=request.json.get('customers_membership'))
+    update_user_customers(user_id=cur_id, customers=request.json.get('customers_membership'))
 
-    track_activity(f"customers membership of user {cur_id} updated", caseid=caseid,  ctx_less=True)
+    track_activity(f"customers membership of user {cur_id} updated", ctx_less=True)
 
     return response_success("User customers updated", data=user)
 
@@ -319,8 +317,8 @@ def manage_user_cac_modal(cur_id, caseid, url_redir):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/cases-access/update', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_user_cac_add_case(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_user_cac_add_case(cur_id):
 
     if not request.is_json:
         return response_error("Invalid request, expecting JSON")
@@ -347,7 +345,7 @@ def manage_user_cac_add_case(cur_id, caseid):
         return response_error(msg=logs)
 
     track_activity(f"case access level {data.get('access_level')} for case(s) {data.get('cases_list')} "
-                   f"set for user {user.user}", caseid=caseid,  ctx_less=True)
+                   f"set for user {user.user}", ctx_less=True)
 
     group = get_user_details(cur_id)
 
@@ -355,8 +353,8 @@ def manage_user_cac_add_case(cur_id, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/cases-access/delete', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_user_cac_delete_cases(cur_id,  caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_user_cac_delete_cases(cur_id):
 
     user = get_user(cur_id)
     if not user:
@@ -383,7 +381,7 @@ def manage_user_cac_delete_cases(cur_id,  caseid):
         return response_error(msg=str(e))
 
     if success:
-        track_activity(f"cases access for case(s) {data.get('cases')} deleted for user {user.user}", caseid=caseid,
+        track_activity(f"cases access for case(s) {data.get('cases')} deleted for user {user.user}",
                        ctx_less=True)
 
         user = get_user_details(cur_id)
@@ -394,8 +392,8 @@ def manage_user_cac_delete_cases(cur_id,  caseid):
 
 
 @manage_users_blueprint.route('/manage/users/<int:cur_id>/case-access/delete', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def manage_user_cac_delete_case(cur_id,  caseid):
+@ac_api_requires(Permissions.server_administrator)
+def manage_user_cac_delete_case(cur_id):
 
     user = get_user(cur_id)
     if not user:
@@ -422,8 +420,7 @@ def manage_user_cac_delete_case(cur_id,  caseid):
         return response_error(msg=str(e))
 
     if success:
-        track_activity(f"case access for case {data.get('case')} deleted for user {user.user}", caseid=caseid,
-                       ctx_less=True)
+        track_activity(f"case access for case {data.get('case')} deleted for user {user.user}", ctx_less=True)
 
         user = get_user_details(cur_id)
 
@@ -433,8 +430,8 @@ def manage_user_cac_delete_case(cur_id,  caseid):
 
 
 @manage_users_blueprint.route('/manage/users/update/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def update_user_api(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def update_user_api(cur_id):
 
     try:
         user = get_user(cur_id)
@@ -442,7 +439,7 @@ def update_user_api(cur_id, caseid):
             return response_error("Invalid user ID for this case")
 
         if protect_demo_mode_user(user):
-            return ac_api_return_access_denied(caseid=caseid)
+            return ac_api_return_access_denied()
 
         # validate before saving
         user_schema = UserSchema()
@@ -454,7 +451,7 @@ def update_user_api(cur_id, caseid):
         db.session.commit()
 
         if cuser:
-            track_activity("updated user {}".format(user.user), caseid=caseid, ctx_less=True)
+            track_activity("updated user {}".format(user.user), ctx_less=True)
             return response_success("User updated", data=user_schema.dump(user))
 
         return response_error("Unable to update user for internal reasons")
@@ -464,15 +461,15 @@ def update_user_api(cur_id, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/deactivate/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def deactivate_user_api(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def deactivate_user_api(cur_id):
 
     user = get_user(cur_id)
     if not user:
         return response_error("Invalid user ID for this case")
 
     if protect_demo_mode_user(user):
-        return ac_api_return_access_denied(caseid=caseid)
+        return ac_api_return_access_denied()
 
     if current_user.id == cur_id:
         return response_error('We do not recommend deactivating yourself for obvious reasons')
@@ -481,53 +478,53 @@ def deactivate_user_api(cur_id, caseid):
     db.session.commit()
     user_schema = UserSchema()
 
-    track_activity(f"user {user.user} deactivated", caseid=caseid,  ctx_less=True)
+    track_activity(f"user {user.user} deactivated", ctx_less=True)
     return response_success("User deactivated", data=user_schema.dump(user))
 
 
 @manage_users_blueprint.route('/manage/users/activate/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def activate_user_api(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def activate_user_api(cur_id):
 
     user = get_user(cur_id)
     if not user:
         return response_error("Invalid user ID for this case")
 
     if protect_demo_mode_user(user):
-        return ac_api_return_access_denied(caseid=caseid)
+        return ac_api_return_access_denied()
 
     user.active = True
     db.session.commit()
     user_schema = UserSchema()
 
-    track_activity(f"user {user.user} activated", caseid=caseid, ctx_less=True)
+    track_activity(f"user {user.user} activated", ctx_less=True)
     return response_success("User activated", data=user_schema.dump(user))
 
 
 @manage_users_blueprint.route('/manage/users/renew-api-key/<int:cur_id>', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-def renew_user_api_key(cur_id, caseid):
+@ac_api_requires(Permissions.server_administrator)
+def renew_user_api_key(cur_id):
 
     user = get_user(cur_id)
     if not user:
         return response_error("Invalid user ID for this case")
 
     if protect_demo_mode_user(user):
-        return ac_api_return_access_denied(caseid=caseid)
+        return ac_api_return_access_denied()
 
     user.api_key = secrets.token_urlsafe(nbytes=64)
     db.session.commit()
 
     user_schema = UserFullSchema()
 
-    track_activity(f"API key of user {user.user} renewed", caseid=caseid, ctx_less=True)
+    track_activity(f"API key of user {user.user} renewed", ctx_less=True)
     return response_success(f"API key of user {user.user} renewed", data=user_schema.dump(user))
 
 
 if is_authentication_local():
     @manage_users_blueprint.route('/manage/users/delete/<int:cur_id>', methods=['POST'])
-    @ac_api_requires_deprecated(Permissions.server_administrator, no_cid_required=True)
-    def view_delete_user(cur_id, caseid):
+    @ac_api_requires(Permissions.server_administrator)
+    def view_delete_user(cur_id):
 
         try:
 
@@ -536,27 +533,27 @@ if is_authentication_local():
                 return response_error("Invalid user ID")
 
             if protect_demo_mode_user(user):
-                return ac_api_return_access_denied(caseid=caseid)
+                return ac_api_return_access_denied()
 
             if user.active is True:
-                track_activity(message="tried to delete active user ID {}".format(cur_id), caseid=caseid, ctx_less=True)
+                track_activity(message="tried to delete active user ID {}".format(cur_id), ctx_less=True)
                 return response_error("Cannot delete active user")
 
             delete_user(user.id)
 
-            track_activity(message="deleted user ID {}".format(cur_id), caseid=caseid, ctx_less=True)
+            track_activity(message="deleted user ID {}".format(cur_id), ctx_less=True)
             return response_success("Deleted user ID {}".format(cur_id))
 
         except Exception:
             db.session.rollback()
-            track_activity(message="tried to delete active user ID {}".format(cur_id), caseid=caseid,  ctx_less=True)
+            track_activity(message="tried to delete active user ID {}".format(cur_id), ctx_less=True)
             return response_error("Cannot delete active user")
 
 
 # Unrestricted section - non admin available
 @manage_users_blueprint.route('/manage/users/lookup/id/<int:cur_id>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def exists_user_restricted(cur_id, caseid):
+@ac_api_requires()
+def exists_user_restricted(cur_id):
 
     user = get_user(cur_id)
     if not user:
@@ -572,8 +569,8 @@ def exists_user_restricted(cur_id, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/lookup/login/<string:login>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def lookup_name_restricted(login, caseid):
+@ac_api_requires()
+def lookup_name_restricted(login):
     user = get_user_by_username(login)
     if not user:
         return response_error("Invalid login")
@@ -591,8 +588,8 @@ def lookup_name_restricted(login, caseid):
 
 
 @manage_users_blueprint.route('/manage/users/restricted/list', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def manage_users_list_restricted(caseid):
+@ac_api_requires()
+def manage_users_list_restricted():
 
     users = get_users_list_restricted()
 

--- a/source/app/blueprints/overview/overview_routes.py
+++ b/source/app/blueprints/overview/overview_routes.py
@@ -24,7 +24,7 @@ from flask_wtf import FlaskForm
 from werkzeug.utils import redirect
 
 from app.datamgmt.overview.overview_db import get_overview_db
-from app.util import ac_api_requires_deprecated
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_success
 
@@ -50,8 +50,8 @@ def get_overview(caseid, url_redir):
 
 
 @overview_blueprint.route('/overview/filter', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def get_overview_filter(caseid):
+@ac_api_requires()
+def get_overview_filter():
     """
     Return an overview of the cases
     """

--- a/source/app/blueprints/overview/overview_routes.py
+++ b/source/app/blueprints/overview/overview_routes.py
@@ -24,7 +24,7 @@ from flask_wtf import FlaskForm
 from werkzeug.utils import redirect
 
 from app.datamgmt.overview.overview_db import get_overview_db
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import response_success
 
@@ -50,7 +50,7 @@ def get_overview(caseid, url_redir):
 
 
 @overview_blueprint.route('/overview/filter', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def get_overview_filter(caseid):
     """
     Return an overview of the cases

--- a/source/app/blueprints/overview/overview_routes.py
+++ b/source/app/blueprints/overview/overview_routes.py
@@ -50,7 +50,7 @@ def get_overview(caseid, url_redir):
 
 
 @overview_blueprint.route('/overview/filter', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires(no_cid_required=True)
 def get_overview_filter(caseid):
     """
     Return an overview of the cases

--- a/source/app/blueprints/profile/profile_routes.py
+++ b/source/app/blueprints/profile/profile_routes.py
@@ -39,7 +39,7 @@ from app.iris_engine.access_control.utils import ac_recompute_effective_ac
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import UserSchema, BasicUserSchema
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires
 from app.util import endpoint_deprecated
 from app.util import response_error
@@ -61,7 +61,7 @@ def user_settings(caseid, url_redir):
 
 
 @profile_blueprint.route('/user/token/renew', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def user_renew_api(caseid):
 
     user = get_user(current_user.id)
@@ -79,7 +79,7 @@ def user_is_admin(caseid):
 
 
 @profile_blueprint.route('/user/has-permission', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def user_has_permission(caseid):
 
     req_js = request.json
@@ -116,7 +116,7 @@ def update_pwd_modal(caseid, url_redir):
 
 
 @profile_blueprint.route('/user/update', methods=['POST'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def update_user_view(caseid):
     try:
         user = get_user(current_user.id)
@@ -147,7 +147,7 @@ def update_user_view(caseid):
 
 
 @profile_blueprint.route('/user/theme/set/<string:theme>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def profile_set_theme(theme, caseid):
     if theme not in ['dark', 'light']:
         return response_error('Invalid data')
@@ -163,7 +163,7 @@ def profile_set_theme(theme, caseid):
 
 
 @profile_blueprint.route('/user/deletion-prompt/set/<string:val>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def profile_set_deletion_prompt(val, caseid):
     if val not in ['true', 'false']:
         return response_error('Invalid data')
@@ -179,7 +179,7 @@ def profile_set_deletion_prompt(val, caseid):
 
 
 @profile_blueprint.route('/user/mini-sidebar/set/<string:val>', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def profile_set_minisidebar(val, caseid):
     if val not in ['true', 'false']:
         return response_error('Invalid data')
@@ -195,7 +195,7 @@ def profile_set_minisidebar(val, caseid):
 
 
 @profile_blueprint.route('/user/refresh-permissions', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def profile_refresh_permissions_and_ac(caseid):
 
     user = get_user(current_user.id)
@@ -209,7 +209,7 @@ def profile_refresh_permissions_and_ac(caseid):
 
 
 @profile_blueprint.route('/user/whoami', methods=['GET'])
-@ac_api_requires(no_cid_required=True)
+@ac_api_requires_deprecated(no_cid_required=True)
 def profile_whoami(caseid):
     """
     Returns the current user's profile

--- a/source/app/blueprints/profile/profile_routes.py
+++ b/source/app/blueprints/profile/profile_routes.py
@@ -17,7 +17,6 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import marshmallow
-# IMPORTS ------------------------------------------------
 import secrets
 from flask import Blueprint
 from flask import redirect
@@ -38,8 +37,9 @@ from app.iris_engine.access_control.utils import ac_get_effective_permissions_of
 from app.iris_engine.access_control.utils import ac_recompute_effective_ac
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
-from app.schema.marshables import UserSchema, BasicUserSchema
-from app.util import ac_api_requires_deprecated
+from app.schema.marshables import UserSchema
+from app.schema.marshables import BasicUserSchema
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import endpoint_deprecated
 from app.util import response_error
@@ -61,8 +61,8 @@ def user_settings(caseid, url_redir):
 
 
 @profile_blueprint.route('/user/token/renew', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def user_renew_api(caseid):
+@ac_api_requires()
+def user_renew_api():
 
     user = get_user(current_user.id)
     user.api_key = secrets.token_urlsafe(nbytes=64)
@@ -79,8 +79,8 @@ def user_is_admin(caseid):
 
 
 @profile_blueprint.route('/user/has-permission', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def user_has_permission(caseid):
+@ac_api_requires()
+def user_has_permission():
 
     req_js = request.json
     if not req_js:
@@ -116,7 +116,7 @@ def update_pwd_modal(caseid, url_redir):
 
 
 @profile_blueprint.route('/user/update', methods=['POST'])
-@ac_api_requires_deprecated(no_cid_required=True)
+@ac_api_requires()
 def update_user_view(caseid):
     try:
         user = get_user(current_user.id)
@@ -147,8 +147,8 @@ def update_user_view(caseid):
 
 
 @profile_blueprint.route('/user/theme/set/<string:theme>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def profile_set_theme(theme, caseid):
+@ac_api_requires()
+def profile_set_theme(theme):
     if theme not in ['dark', 'light']:
         return response_error('Invalid data')
 
@@ -163,8 +163,8 @@ def profile_set_theme(theme, caseid):
 
 
 @profile_blueprint.route('/user/deletion-prompt/set/<string:val>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def profile_set_deletion_prompt(val, caseid):
+@ac_api_requires()
+def profile_set_deletion_prompt(val):
     if val not in ['true', 'false']:
         return response_error('Invalid data')
 
@@ -179,8 +179,8 @@ def profile_set_deletion_prompt(val, caseid):
 
 
 @profile_blueprint.route('/user/mini-sidebar/set/<string:val>', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def profile_set_minisidebar(val, caseid):
+@ac_api_requires()
+def profile_set_minisidebar(val):
     if val not in ['true', 'false']:
         return response_error('Invalid data')
 
@@ -195,8 +195,8 @@ def profile_set_minisidebar(val, caseid):
 
 
 @profile_blueprint.route('/user/refresh-permissions', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def profile_refresh_permissions_and_ac(caseid):
+@ac_api_requires()
+def profile_refresh_permissions_and_ac():
 
     user = get_user(current_user.id)
     if not user:
@@ -209,8 +209,8 @@ def profile_refresh_permissions_and_ac(caseid):
 
 
 @profile_blueprint.route('/user/whoami', methods=['GET'])
-@ac_api_requires_deprecated(no_cid_required=True)
-def profile_whoami(caseid):
+@ac_api_requires()
+def profile_whoami():
     """
     Returns the current user's profile
     """

--- a/source/app/blueprints/reports/reports_route.py
+++ b/source/app/blueprints/reports/reports_route.py
@@ -16,27 +16,18 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-# IMPORTS ------------------------------------------------
-
-# VARS ---------------------------------------------------
-
 import os
-# CONTENT ------------------------------------------------
 import tempfile
 
 from flask import Blueprint
-from flask import redirect
 from flask import request
 from flask import send_file
-from flask import url_for
-from flask_login import current_user
 
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.reporter.reporter import IrisMakeDocReport, IrisMakeMdReport
 from app.iris_engine.utils.tracker import track_activity
 from app.models import CaseTemplateReport
 from app.util import FileRemover, ac_api_requires
-from app.util import not_authenticated_redirection_url
 from app.util import response_error
 
 reports_blueprint = Blueprint('reports',
@@ -133,4 +124,3 @@ def _gen_report(report_id, caseid):
             return resp
 
     return response_error("Unknown report", status=404)
-

--- a/source/app/blueprints/reports/reports_route.py
+++ b/source/app/blueprints/reports/reports_route.py
@@ -24,21 +24,23 @@ from flask import request
 from flask import send_file
 
 from app.iris_engine.module_handler.module_handler import call_modules_hook
-from app.iris_engine.reporter.reporter import IrisMakeDocReport, IrisMakeMdReport
+from app.iris_engine.reporter.reporter import IrisMakeDocReport
+from app.iris_engine.reporter.reporter import IrisMakeMdReport
 from app.iris_engine.utils.tracker import track_activity
 from app.models import CaseTemplateReport
-from app.util import FileRemover, ac_api_requires_deprecated
+from app.util import FileRemover
+from app.util import ac_api_requires
+from app.util import ac_requires_case_identifier
 from app.util import response_error
 
-reports_blueprint = Blueprint('reports',
-                              __name__,
-                              template_folder='templates')
+reports_blueprint = Blueprint('reports', __name__, template_folder='templates')
 
 file_remover = FileRemover()
 
 
 @reports_blueprint.route('/case/report/generate-activities/<int:report_id>', methods=['GET'])
-@ac_api_requires_deprecated()
+@ac_api_requires()
+@ac_requires_case_identifier()
 def download_case_activity(report_id, caseid):
 
     call_modules_hook('on_preload_activities_report_create', data=report_id, caseid=caseid)
@@ -83,7 +85,8 @@ def download_case_activity(report_id, caseid):
 
 
 @reports_blueprint.route("/case/report/generate-investigation/<int:report_id>", methods=['GET'])
-@ac_api_requires_deprecated()
+@ac_api_requires()
+@ac_requires_case_identifier()
 def _gen_report(report_id, caseid):
 
     safe_mode = False

--- a/source/app/blueprints/reports/reports_route.py
+++ b/source/app/blueprints/reports/reports_route.py
@@ -27,7 +27,7 @@ from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.reporter.reporter import IrisMakeDocReport, IrisMakeMdReport
 from app.iris_engine.utils.tracker import track_activity
 from app.models import CaseTemplateReport
-from app.util import FileRemover, ac_api_requires
+from app.util import FileRemover, ac_api_requires_deprecated
 from app.util import response_error
 
 reports_blueprint = Blueprint('reports',
@@ -38,7 +38,7 @@ file_remover = FileRemover()
 
 
 @reports_blueprint.route('/case/report/generate-activities/<int:report_id>', methods=['GET'])
-@ac_api_requires()
+@ac_api_requires_deprecated()
 def download_case_activity(report_id, caseid):
 
     call_modules_hook('on_preload_activities_report_create', data=report_id, caseid=caseid)
@@ -83,7 +83,7 @@ def download_case_activity(report_id, caseid):
 
 
 @reports_blueprint.route("/case/report/generate-investigation/<int:report_id>", methods=['GET'])
-@ac_api_requires()
+@ac_api_requires_deprecated()
 def _gen_report(report_id, caseid):
 
     safe_mode = False

--- a/source/app/blueprints/search/search_routes.py
+++ b/source/app/blueprints/search/search_routes.py
@@ -36,6 +36,7 @@ from app.models.models import IocType
 from app.models.models import Notes
 from app.models.models import Tlp
 from app.util import ac_api_requires
+from app.util import ac_requires_case_identifier
 from app.util import ac_requires
 from app.util import response_success
 
@@ -46,7 +47,7 @@ search_blueprint = Blueprint('search',
 
 # CONTENT ------------------------------------------------
 @search_blueprint.route('/search', methods=['POST'])
-@ac_api_requires(Permissions.search_across_cases)
+@ac_api_requires(Permissions.search_across_cases, no_cid_required=True)
 def search_file_post(caseid: int):
 
     jsdata = request.get_json()

--- a/source/app/blueprints/search/search_routes.py
+++ b/source/app/blueprints/search/search_routes.py
@@ -35,7 +35,7 @@ from app.models.models import IocLink
 from app.models.models import IocType
 from app.models.models import Notes
 from app.models.models import Tlp
-from app.util import ac_api_requires
+from app.util import ac_api_requires_deprecated
 from app.util import ac_requires_case_identifier
 from app.util import ac_requires
 from app.util import response_success
@@ -47,7 +47,7 @@ search_blueprint = Blueprint('search',
 
 # CONTENT ------------------------------------------------
 @search_blueprint.route('/search', methods=['POST'])
-@ac_api_requires(Permissions.search_across_cases, no_cid_required=True)
+@ac_api_requires_deprecated(Permissions.search_across_cases, no_cid_required=True)
 def search_file_post(caseid: int):
 
     jsdata = request.get_json()

--- a/source/app/blueprints/search/search_routes.py
+++ b/source/app/blueprints/search/search_routes.py
@@ -35,8 +35,7 @@ from app.models.models import IocLink
 from app.models.models import IocType
 from app.models.models import Notes
 from app.models.models import Tlp
-from app.util import ac_api_requires_deprecated
-from app.util import ac_requires_case_identifier
+from app.util import ac_api_requires
 from app.util import ac_requires
 from app.util import response_success
 
@@ -45,10 +44,9 @@ search_blueprint = Blueprint('search',
                              template_folder='templates')
 
 
-# CONTENT ------------------------------------------------
 @search_blueprint.route('/search', methods=['POST'])
-@ac_api_requires_deprecated(Permissions.search_across_cases, no_cid_required=True)
-def search_file_post(caseid: int):
+@ac_api_requires(Permissions.search_across_cases)
+def search_file_post():
 
     jsdata = request.get_json()
     search_value = jsdata.get('search_value')

--- a/source/app/datamgmt/case/case_db.py
+++ b/source/app/datamgmt/case/case_db.py
@@ -47,7 +47,7 @@ def get_case_summary(caseid):
     return case_summary
 
 
-def get_case(caseid):
+def get_case(caseid) -> Cases:
     return Cases.query.filter(Cases.case_id == caseid).first()
 
 

--- a/source/app/iris_engine/module_handler/module_handler.py
+++ b/source/app/iris_engine/module_handler/module_handler.py
@@ -492,7 +492,7 @@ def task_hook_wrapper(self, module_name, hook_name, hook_ui_name, data, init_use
     return task_status
 
 
-def call_modules_hook(hook_name: str, data: any, caseid: int, hook_ui_name: str = None, module_name: str = None) -> any:
+def call_modules_hook(hook_name: str, data: any, caseid: int = None, hook_ui_name: str = None, module_name: str = None) -> any:
     """
     Calls modules which have registered the specified hook
 

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -211,7 +211,7 @@ class FileRemover(object):
         shutil.rmtree(filepath, ignore_errors=True)
 
 
-def get_caseid_from_request_data(request_data, no_cid_required):
+def _get_caseid_from_request_data(request_data, no_cid_required):
     caseid = request_data.args.get('cid', default=None, type=int)
     redir = False
     has_access = True
@@ -318,7 +318,7 @@ def update_denied_case(caseid, from_api):
 
 
 def get_case_access(request_data, access_level, from_api=False, no_cid_required=False):
-    redir, caseid, has_access = get_caseid_from_request_data(request_data, no_cid_required)
+    redir, caseid, has_access = _get_caseid_from_request_data(request_data, no_cid_required)
 
     redir, ctmp, has_access = handle_no_cid_required(request, no_cid_required)
     if ctmp is not None:

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -261,7 +261,7 @@ def log_exception_and_error(e):
     log.error(traceback.print_exc())
 
 
-def _handle_no_cid_required(request, no_cid_required):
+def _handle_no_cid_required(no_cid_required):
     if no_cid_required:
         js_d = request.get_json(silent=True)
         caseid = None
@@ -320,7 +320,7 @@ def update_denied_case(caseid, from_api):
 def get_case_access(request_data, access_level, from_api=False, no_cid_required=False):
     redir, caseid, has_access = _get_caseid_from_request_data(request_data, no_cid_required)
 
-    ctmp, has_access = _handle_no_cid_required(request, no_cid_required)
+    ctmp, has_access = _handle_no_cid_required(no_cid_required)
     redir = False
     if ctmp is not None:
         return redir, ctmp, has_access
@@ -585,7 +585,8 @@ def _user_has_required_permissions(permissions):
 
     for permission in permissions:
         # TODO do we really want to do this?
-        #      as it is coded now, as soon as the user has one of the required permission, the action is allowed
+        #      as it is coded now, as soon as the user has one of the required
+        #      permission, the action is allowed
         #      don't we rather want the user to have all required permissions?
         if session['permissions'] & permission.value:
             return True

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -276,11 +276,11 @@ def _handle_no_cid_required(request, no_cid_required):
                 request.json.pop('cid')
 
         except Exception:
-            return False, None, False
+            return None, False
 
-        return False, caseid, True
+        return caseid, True
 
-    return False, None, False
+    return None, False
 
 
 def update_session(caseid, eaccess_level, from_api):
@@ -320,7 +320,8 @@ def update_denied_case(caseid, from_api):
 def get_case_access(request_data, access_level, from_api=False, no_cid_required=False):
     redir, caseid, has_access = _get_caseid_from_request_data(request_data, no_cid_required)
 
-    redir, ctmp, has_access = _handle_no_cid_required(request, no_cid_required)
+    ctmp, has_access = _handle_no_cid_required(request, no_cid_required)
+    redir = False
     if ctmp is not None:
         return redir, ctmp, has_access
 

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -213,29 +213,29 @@ class FileRemover(object):
 
 def _get_caseid_from_request_data(request_data, no_cid_required):
     caseid = request_data.args.get('cid', default=None, type=int)
-    redir = False
-    has_access = True
+    if caseid:
+        return False, caseid, True
 
-    if not caseid and not no_cid_required:
+    if no_cid_required:
+        return False, caseid, True
 
-        try:
-            js_d = None
+    try:
+        js_d = None
 
-            if request_data.content_type == 'application/json':
-                js_d = request_data.get_json()
+        if request_data.content_type == 'application/json':
+            js_d = request_data.get_json()
 
-            if js_d:
-                caseid = js_d.get('cid')
-                request_data.json.pop('cid')
+        if not js_d:
+            return _set_caseid_from_current_user()
 
-            else:
-                redir, caseid, has_access = _set_caseid_from_current_user()
+        caseid = js_d.get('cid')
+        request_data.json.pop('cid')
 
-        except Exception as e:
-            print(request_data.url)
-            redir, caseid, has_access = _handle_exception(e, request_data)
+        return False, caseid, True
 
-    return redir, caseid, has_access
+    except Exception as e:
+        print(request_data.url)
+        return _handle_exception(e, request_data)
 
 
 def _set_caseid_from_current_user():

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -233,7 +233,7 @@ def _get_caseid_from_request_data(request_data, no_cid_required):
 
         except Exception as e:
             print(request_data.url)
-            redir, caseid, has_access = handle_exception(e, request_data)
+            redir, caseid, has_access = _handle_exception(e, request_data)
 
     return redir, caseid, has_access
 
@@ -247,7 +247,7 @@ def _set_caseid_from_current_user():
     return redir, caseid, True
 
 
-def handle_exception(e, request_data):
+def _handle_exception(e, request_data):
     cookie_session = request_data.cookies.get('session')
     if not cookie_session:
         return _set_caseid_from_current_user()

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -694,7 +694,7 @@ def ac_api_requires(*permissions, no_cid_required=False):
                 log.exception(e)
                 return response_error("Invalid data. Check server logs", status=500)
 
-            if not (caseid or redir) and not no_cid_required:
+            if not caseid and not redir and not no_cid_required:
                 return response_error("Invalid case ID", status=404)
 
             kwargs.update({"caseid": caseid})

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -215,11 +215,11 @@ def _get_caseid_from_request_data(request_data, no_cid_required):
     caseid = request_data.args.get('cid', default=None, type=int)
     redir = False
     has_access = True
-    js_d = None
 
     if not caseid and not no_cid_required:
 
         try:
+            js_d = None
 
             if request_data.content_type == 'application/json':
                 js_d = request_data.get_json()

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -682,27 +682,25 @@ def ac_requires_client_access():
     return inner_wrap
 
 
-def _decorate_with_requires_case_identifier(f):
-    @wraps(f)
-    def wrap(*args, **kwargs):
-        try:
-            redir, caseid, _ = get_case_access(request, [], from_api=True)
-        except Exception as e:
-            log.exception(e)
-            return response_error('Invalid data. Check server logs', status=500)
-
-        if not caseid and not redir:
-            return response_error('Invalid case ID', status=404)
-
-        kwargs.update({'caseid': caseid})
-
-        return f(*args, **kwargs)
-
-    return wrap
-
-
 def ac_requires_case_identifier():
-    return _decorate_with_requires_case_identifier
+    def decorate_with_requires_case_identifier(f):
+        @wraps(f)
+        def wrap(*args, **kwargs):
+            try:
+                redir, caseid, _ = get_case_access(request, [], from_api=True)
+            except Exception as e:
+                log.exception(e)
+                return response_error('Invalid data. Check server logs', status=500)
+
+            if not caseid and not redir:
+                return response_error('Invalid case ID', status=404)
+
+            kwargs.update({'caseid': caseid})
+
+            return f(*args, **kwargs)
+
+        return wrap
+    return decorate_with_requires_case_identifier
 
 
 def ac_api_requires(*permissions):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -732,41 +732,6 @@ def ac_api_requires(*permissions):
     return inner_wrap
 
 
-# Deprecated, transform into
-# when no_cid_required=False => ac_api_requires followed by ac_requires_case_identifier
-# when no_cid_required=True => ac_api_requires
-def ac_api_requires_deprecated(*permissions, no_cid_required=False):
-    def inner_wrap(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            if request.method == 'POST':
-                cookie_session = request.cookies.get('session')
-                if cookie_session:
-                    form = FlaskForm()
-                    if not form.validate():
-                        return response_error('Invalid CSRF token')
-                    elif request.is_json:
-                        request.json.pop('csrf_token')
-
-            if not is_user_authenticated(request):
-                return response_error("Authentication required", status=401)
-
-            if 'permissions' not in session:
-                session['permissions'] = ac_get_effective_permissions_of_user(current_user)
-
-            if not _user_has_required_permissions(permissions):
-                return response_error('Permission denied', status=403)
-
-            if not no_cid_required:
-                require_case_identifier_then_f = _decorate_with_requires_case_identifier(f)
-                return require_case_identifier_then_f(*args, **kwargs)
-
-            kwargs.update({'caseid': None})
-            return f(*args, **kwargs)
-        return wrap
-    return inner_wrap
-
-
 def decompress_7z(filename: Path, output_dir):
     """
     Decompress a 7z file in specified output directory

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -688,30 +688,29 @@ def ac_api_requires(*permissions, no_cid_required=False):
             if not is_user_authenticated(request):
                 return response_error("Authentication required", status=401)
 
-            else:
-                try:
-                    redir, caseid, _ = get_case_access(request, [], from_api=True, no_cid_required=no_cid_required)
-                except Exception as e:
-                    log.exception(e)
-                    return response_error("Invalid data. Check server logs", status=500)
+            try:
+                redir, caseid, _ = get_case_access(request, [], from_api=True, no_cid_required=no_cid_required)
+            except Exception as e:
+                log.exception(e)
+                return response_error("Invalid data. Check server logs", status=500)
 
-                if not (caseid or redir) and not no_cid_required:
-                    return response_error("Invalid case ID", status=404)
+            if not (caseid or redir) and not no_cid_required:
+                return response_error("Invalid case ID", status=404)
 
-                kwargs.update({"caseid": caseid})
+            kwargs.update({"caseid": caseid})
 
-                if 'permissions' not in session:
-                    session['permissions'] = ac_get_effective_permissions_of_user(current_user)
+            if 'permissions' not in session:
+                session['permissions'] = ac_get_effective_permissions_of_user(current_user)
 
-                if permissions:
+            if permissions:
 
-                    for permission in permissions:
-                        if session['permissions'] & permission.value:
-                            return f(*args, **kwargs)
+                for permission in permissions:
+                    if session['permissions'] & permission.value:
+                        return f(*args, **kwargs)
 
-                    return response_error("Permission denied", status=403)
+                return response_error("Permission denied", status=403)
 
-                return f(*args, **kwargs)
+            return f(*args, **kwargs)
         return wrap
     return inner_wrap
 

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -229,7 +229,7 @@ def _get_caseid_from_request_data(request_data, no_cid_required):
                 request_data.json.pop('cid')
 
             else:
-                redir, caseid, has_access = set_caseid_from_current_user()
+                redir, caseid, has_access = _set_caseid_from_current_user()
 
         except Exception as e:
             print(request_data.url)
@@ -238,7 +238,7 @@ def _get_caseid_from_request_data(request_data, no_cid_required):
     return redir, caseid, has_access
 
 
-def set_caseid_from_current_user():
+def _set_caseid_from_current_user():
     redir = False
     if current_user.ctx_case is None:
         redir = True
@@ -250,7 +250,7 @@ def set_caseid_from_current_user():
 def handle_exception(e, request_data):
     cookie_session = request_data.cookies.get('session')
     if not cookie_session:
-        return set_caseid_from_current_user()
+        return _set_caseid_from_current_user()
 
     log_exception_and_error(e)
     return True, 0, False

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -261,7 +261,7 @@ def log_exception_and_error(e):
     log.error(traceback.print_exc())
 
 
-def handle_no_cid_required(request, no_cid_required):
+def _handle_no_cid_required(request, no_cid_required):
     if no_cid_required:
         js_d = request.get_json(silent=True)
         caseid = None
@@ -320,7 +320,7 @@ def update_denied_case(caseid, from_api):
 def get_case_access(request_data, access_level, from_api=False, no_cid_required=False):
     redir, caseid, has_access = _get_caseid_from_request_data(request_data, no_cid_required)
 
-    redir, ctmp, has_access = handle_no_cid_required(request, no_cid_required)
+    redir, ctmp, has_access = _handle_no_cid_required(request, no_cid_required)
     if ctmp is not None:
         return redir, ctmp, has_access
 

--- a/tests/iris.py
+++ b/tests/iris.py
@@ -70,6 +70,15 @@ class Iris:
     def get_api_version(self):
         return self._api.get('api/versions')
 
+    def create_alert(self):
+        body = {
+            'alert_title': 'alert title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        return self._api.post('/alerts/add', body)
+
     def create_asset(self):
         body = {
             'asset_type_id': '9',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -549,3 +549,12 @@ class Tests(TestCase):
         }
         body = self._subject.execute_graphql_query(payload)
         self.assertEqual(ioc_value, body['data']['ioc']['iocValue'])
+
+    def test_filter_alerts_should_find_newly_created_alert(self):
+        response = self._subject.create_alert()
+        alert_identifier = response['data']['alert_id']
+        response = self._subject._api.get('/alerts/filter')
+        self.assertEqual('success', response['status'])
+        # should rather check that response['data']['alerts'] contains the alert
+        # alert_identifiers = self._get_alert_identifiers(response['data']['alerts'])
+        # self.assertIn(alert_identifier, alert_identifiers)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -551,8 +551,6 @@ class Tests(TestCase):
         self.assertEqual(ioc_value, body['data']['ioc']['iocValue'])
 
     def test_filter_alerts_should_find_newly_created_alert(self):
-        response = self._subject.create_alert()
-        alert_identifier = response['data']['alert_id']
         response = self._subject._api.get('/alerts/filter')
         self.assertEqual('success', response['status'])
         # should rather check that response['data']['alerts'] contains the alert

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -549,10 +549,3 @@ class Tests(TestCase):
         }
         body = self._subject.execute_graphql_query(payload)
         self.assertEqual(ioc_value, body['data']['ioc']['iocValue'])
-
-    def test_filter_alerts_should_find_newly_created_alert(self):
-        response = self._subject._api.get('/alerts/filter')
-        self.assertEqual('success', response['status'])
-        # should rather check that response['data']['alerts'] contains the alert
-        # alert_identifiers = self._get_alert_identifiers(response['data']['alerts'])
-        # self.assertIn(alert_identifier, alert_identifiers)


### PR DESCRIPTION
This is a proposition to split annotation `ac_api_requires` in two:

- `ac_api_requires` without option `no_cid_required` and which never requires a case identifier
- `ac_requires_case_identifier` which extracts the `caseid` parameter

That way, routes which do not require a case identifier use only ac_api_requires and do not have the `caseid` parameter. And routes which require a case identifier are annotated with the two annotations. The code is more decoupled and more elegant (there is no spurious unused parameter).

To write this PR, I had to put the code which extracts the case identifier after the final code block of `ac_api_requires` which checks for the permissions. In theory these two aspects are independent so swapping them should not have changed any behavior. Maybe you could check this point, if there is some doubt.
Also, some routes had `no_cid_required` set to `True`, but were still using the `caseid` (when calling `track_activity`, `call_module_hooks` and `ac_api_return_access_denied`). In these case, I still removed the `caseid`, as I believe it was potentially totally unrelated to the request. 
Lastly, I did not check whether the REST API documentation should be updated (to remove unnecessary occurrences of the `cid` query parameter). Maybe that's something which should be done?
