### PR TITLE
CI/CD: GraphQL documentation spectaql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,16 @@ jobs:
           source venv/bin/activate
           pip install -r requirements.txt
           PYTHONUNBUFFERED=true python -m unittest --verbose
+      - name: Documentation
+        working-directory: source/spectaql
+        run: |
+          npm install spectaql
+          docker compose up --detach
+          npx spectaql config.yml
+          docker compose down
+      - uses: actions/upload-artifact@v4
+        with:
+            name: GraphQL DFIR-IRIS documentation
+            path: source/spectaql/public
+            if-no-files-found: error
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
             name: GraphQL DFIR-IRIS documentation
-            path: source/spectaql/public
+            path: public
             if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           #      or maybe the docker building phase should also be part of the tests 
           #      and we should build different dockers according to the scenarios? This sounds like an issue to me...
           cp tests/data/basic.env .env
-          docker compose build
+          docker compose -f docker-compose.dev.yml build
       - name: Run tests
         working-directory: tests
         run: |
@@ -45,15 +45,12 @@ jobs:
           pip install -r requirements.txt
           PYTHONUNBUFFERED=true python -m unittest --verbose
       - name: Documentation
-        working-directory: source/spectaql
         run: |
-          npm install spectaql
-          docker compose up --detach
-          npx spectaql config.yml
+          docker compose -f docker-compose.dev.yml up --detach
+          npx --yes spectaql source/spectaql/config.yml
           docker compose down
       - uses: actions/upload-artifact@v4
         with:
             name: GraphQL DFIR-IRIS documentation
             path: source/spectaql/public
             if-no-files-found: error
-

--- a/source/spectaql/config.yml
+++ b/source/spectaql/config.yml
@@ -1,5 +1,5 @@
 spectaql:
-  logoFile: ../app/static/assets/img/logo-full-blue.png
+  logoFile: source/app/static/assets/img/logo-full-blue.png
 
 introspection:
   url: http://127.0.0.1:8000/graphql

--- a/source/spectaql/config.yml
+++ b/source/spectaql/config.yml
@@ -1,0 +1,21 @@
+spectaql:
+  logoFile: ../app/static/assets/img/logo-full-blue.png
+
+introspection:
+  url: http://127.0.0.1:8000/graphql
+  headers:
+    Authorization: Bearer B8BA5D730210B50F41C06941582D7965D57319D5685440587F98DFDC45A01594
+
+extensions:
+  graphqlScalarExamples: true
+
+info:
+  title: GraphQL DFIR-IRIS DOCUMENTATION
+  description: Welcome to DFIR-IRIS GraphQL Documentation.
+  x-introItems:
+    - title: IRIS API
+      description: To use these API endpoint, an API key is needed and can be found in every user profile under My settings > API Key.
+
+servers:
+  - url: https://v200.beta.dfir-iris.org/login
+    production: true

--- a/tests/docker_compose.py
+++ b/tests/docker_compose.py
@@ -23,14 +23,15 @@ _DOCKER_COMPOSE = ['docker', 'compose']
 
 class DockerCompose:
 
-    def __init__(self, docker_compose_path):
+    def __init__(self, docker_compose_path, docker_compose_file):
         self._docker_compose_path = docker_compose_path
+        self._docker_compose_file = docker_compose_file
 
     def start(self):
-        subprocess.check_call(_DOCKER_COMPOSE + ['-f', 'docker-compose.dev.yml', 'up', '--detach'], cwd=self._docker_compose_path)
+        subprocess.check_call(_DOCKER_COMPOSE + ['-f', self._docker_compose_file, 'up', '--detach'], cwd=self._docker_compose_path)
 
     def extract_all_logs(self):
-        return subprocess.check_output(_DOCKER_COMPOSE + ['-f', 'docker-compose.dev.yml', 'logs', '--no-color'], cwd=self._docker_compose_path, universal_newlines=True)
+        return subprocess.check_output(_DOCKER_COMPOSE + ['-f', self._docker_compose_file, 'logs', '--no-color'], cwd=self._docker_compose_path, universal_newlines=True)
 
     def stop(self):
-        subprocess.check_call(_DOCKER_COMPOSE + ['-f', 'docker-compose.dev.yml', 'down', '--volumes'], cwd=self._docker_compose_path)
+        subprocess.check_call(_DOCKER_COMPOSE + ['-f', self._docker_compose_file, 'down', '--volumes'], cwd=self._docker_compose_path)

--- a/tests/iris.py
+++ b/tests/iris.py
@@ -33,7 +33,7 @@ _TEST_DATA_PATH = Path('./data')
 class Iris:
 
     def __init__(self):
-        self._docker_compose = DockerCompose(_IRIS_PATH)
+        self._docker_compose = DockerCompose(_IRIS_PATH, 'docker-compose.dev.yml')
         self._api = RestApi(API_URL, _API_KEY)
         self._administrator = User(API_URL, _API_KEY)
 


### PR DESCRIPTION

Add GraphQL documentation in continuous integration.

You can now download the documentation named GraphQL DFIR-IRIS documentation after the execution of continuous integration.
