### PR TITLE
add-feature: add resources limits

### DIFF
--- a/deploy/kubernetes/charts/templates/iris_app.yaml
+++ b/deploy/kubernetes/charts/templates/iris_app.yaml
@@ -54,6 +54,17 @@ spec:
     spec:
       containers:
         - name: {{ .Values.irisapp.name }}
+          resources:
+            {{- if and .Values.irisapp.limits_memory .Values.irisapp.limits_cpu .Values.irisapp.requests_memory .Values.irisapp.requests_cpu -}}
+            limits:
+              memory: {{ .Values.irisapp.limits_memory }}
+              cpu: {{ .Values.irisapp.limits_cpu }}
+            requests:
+              memory: {{ .Values.irisapp.requests_memory }}
+              cpu: {{ .Values.irisapp.requests_cpu }}
+            {{- else -}}
+            {}
+            {{- end -}}
           image: "{{ .Values.irisapp.image}}:{{ .Values.irisapp.tag }}"
           imagePullPolicy: "{{ .Values.irisapp.imagePullPolicy }}"
           command: ['nohup', './iris-entrypoint.sh', 'iriswebapp']

--- a/deploy/kubernetes/charts/templates/iris_worker.yaml
+++ b/deploy/kubernetes/charts/templates/iris_worker.yaml
@@ -54,6 +54,16 @@ spec:
     spec:
       containers:
         - name: {{ .Values.irisworker.name }}
+          {{- if and .Values.irisworker.limits_memory .Values.irisworker.limits_cpu .Values.irisworker.requests_memory .Values.irisworker.requests_cpu -}}
+            limits:
+              memory: {{ .Values.irisworker.limits_memory }}
+              cpu: {{ .Values.irisworker.limits_cpu }}
+            requests:
+              memory: {{ .Values.irisworker.requests_memory }}
+              cpu: {{ .Values.irisworker.requests_cpu }}
+            {{- else -}}
+            {}
+            {{- end -}}
           image: "{{ .Values.irisworker.image}}:{{ .Values.irisworker.tag }}"
           imagePullPolicy: "{{ .Values.irisworker.imagePullPolicy }}"
           command: ['./wait-for-iriswebapp.sh', "{{ .Values.irisapp.name }}:{{ .Values.irisapp.service.port }}", './iris-entrypoint.sh', 'iris-worker']

--- a/deploy/kubernetes/charts/templates/postgres.yaml
+++ b/deploy/kubernetes/charts/templates/postgres.yaml
@@ -50,6 +50,17 @@ spec:
     spec:
       containers:
         - name: {{ .Values.postgres.name }}
+          resources:
+            {{- if and .Values.postgres.limits_memory .Values.postgres.limits_cpu .Values.postgres.requests_memory .Values.postgres.requests_cpu -}}
+            limits:
+              memory: {{ .Values.postgres.limits_memory }}
+              cpu: {{ .Values.postgres.limits_cpu }}
+            requests:
+              memory: {{ .Values.postgres.requests_memory }}
+              cpu: {{ .Values.postgres.requests_cpu }}
+            {{- else -}}
+            {}
+            {{- end -}}
           image: "{{ .Values.postgres.image}}:{{ .Values.postgres.tag }}"
           imagePullPolicy: "{{ .Values.postgres.imagePullPolicy }}"
 

--- a/deploy/kubernetes/charts/templates/rabbitmq.yaml
+++ b/deploy/kubernetes/charts/templates/rabbitmq.yaml
@@ -15,6 +15,17 @@ spec:
     spec:
       containers:
       - image: "{{ .Values.rabbitmq.image}}:{{ .Values.rabbitmq.tag}}"
+        resources:
+            {{- if and .Values.rabbitmq.limits_memory .Values.rabbitmq.limits_cpu .Values.rabbitmq.requests_memory .Values.rabbitmq.requests_cpu -}}
+            limits:
+              memory: {{ .Values.rabbitmq.limits_memory }}
+              cpu: {{ .Values.rabbitmq.limits_cpu }}
+            requests:
+              memory: {{ .Values.rabbitmq.requests_memory }}
+              cpu: {{ .Values.rabbitmq.requests_cpu }}
+            {{- else -}}
+            {}
+            {{- end -}}
         imagePullPolicy: {{ .Values.rabbitmq.imagePullPolicy}}
         name:  {{ .Values.rabbitmq.name }}
         ports:

--- a/deploy/kubernetes/charts/values.yaml
+++ b/deploy/kubernetes/charts/values.yaml
@@ -19,6 +19,18 @@ rabbitmq:
    ## @param rabbitmq.replicaCount ReplicaCount for rabbitmq
    ##
    replicaCount: 1
+   ## @param rabbitmq.limits_memory limits_memory for rabbitmq
+   ##
+   limits_memory: false
+   ## @param rabbitmq.limits_cpu limits cpu for rabbitmq
+   ##
+   limits_cpu: false
+   ## @param rabbitmq.requests_memory requests_memory for rabbitmq
+   ##
+   requests_memory: false
+   ## @param rabbitmq.requests_cpu requests_cpu for rabbitmq
+   ##
+   requests_cpu: false
    
 
 ## @section PostgreSQL Configuration
@@ -41,6 +53,19 @@ postgres:
    ## @param postgres.replicaCount PostgreSQL ReplicaCount
    ##
    replicaCount: 1
+   ## @param postgres.limits_memory limits_memory for postgres
+   ##
+   limits_memory: false
+   ## @param postgres.limits_cpu limits cpu for postgres
+   ##
+   limits_cpu: false
+   ## @param postgres.requests_memory requests_memory for postgres
+   ##
+   requests_memory: false
+   ## @param postgres.requests_cpu requests_cpu for postgres
+   ##
+   requests_cpu: false
+   
    
    ## @param postgres.service PostgreSQL Service
    ##
@@ -78,6 +103,18 @@ irisapp:
    ## @param irisapp.replicaCount Iris Frontend replicaCount
    ##
    replicaCount: 1
+   ## @param irisapp.limits_memory limits_memory for irisapp
+   ##
+   limits_memory: false
+   ## @param irisapp.limits_cpu limits cpu for irisapp
+   ##
+   limits_cpu: false
+   ## @param irisapp.requests_memory requests_memory for irisapp
+   ##
+   requests_memory: false
+   ## @param irisapp.requests_cpu requests_cpu for irisapp
+   ##
+   requests_cpu: false
 
    ## @param irisapp.service Iris Frontend Service
    ##
@@ -126,6 +163,18 @@ irisworker:
    ## @param irisworker.replicaCount Iris Backend replicaCount
    ##
    replicaCount: 1
+   ## @param irisworker.limits_memory limits_memory for irisworker
+   ##
+   limits_memory: false
+   ## @param irisworker.limits_cpu limits cpu for irisworker
+   ##
+   limits_cpu: false
+   ## @param irisworker.requests_memory requests_memory for irisworker
+   ##
+   requests_memory: false
+   ## @param irisworker.requests_cpu requests_cpu for irisworker
+   ##
+   requests_cpu: false
 
    ## @param  Iris Backend Environments
    ##


### PR DESCRIPTION
Added the ability to add `limits`/`request` on deployments in case the values ​​are not `false`
Useful in the case where someone is working on a cluster that contains restrictions and requires setting `limits`/`request` on deployements