### PR TITLE
[ADD] option to select Number of child processes processing the queue

### DIFF
--- a/deploy/kubernetes/charts/templates/iris_worker.yaml
+++ b/deploy/kubernetes/charts/templates/iris_worker.yaml
@@ -87,6 +87,9 @@ spec:
           - name:  IRIS_SECURITY_PASSWORD_SALT
             value: {{ .Values.irisworker.IRIS_SECURITY_PASSWORD_SALT | quote }}
 
+          - name: NUMBER_OF_CHILD
+            value: {{ .Values.irisworker.NUMBER_OF_CHILD | quote }}
+
 
           volumeMounts:
             - mountPath: /home/iris/downloads

--- a/deploy/kubernetes/charts/values.yaml
+++ b/deploy/kubernetes/charts/values.yaml
@@ -137,6 +137,7 @@ irisworker:
    POSTGRES_SERVER: postgres.<name_space>.svc.cluster.local
    IRIS_SECRET_KEY: AVerySuperSecretKey-SoNotThisOne
    IRIS_SECURITY_PASSWORD_SALT: ARandomSalt-NotThisOneEither
+   NUMBER_OF_CHILD: <number_of_child_processes>
 
 ## @section Nginx Ingress Configuration
 ##

--- a/docker/webApp/iris-entrypoint.sh
+++ b/docker/webApp/iris-entrypoint.sh
@@ -26,7 +26,7 @@ target=${1-:app}
 printf "Running ${target} ...\n"
 
 if [[ "${target}" == iris-worker ]] ; then
-    celery -A app.celery worker -E -B -l INFO &
+    celery -A app.celery worker -C $NUMBER_OF_CHILD -E -B -l INFO &
 else
     gunicorn app:app --worker-class eventlet --bind 0.0.0.0:8000 --timeout 180 --worker-connections 1000 --log-level=info &
 fi

--- a/docker/webApp/iris-entrypoint.sh
+++ b/docker/webApp/iris-entrypoint.sh
@@ -26,7 +26,11 @@ target=${1-:app}
 printf "Running ${target} ...\n"
 
 if [[ "${target}" == iris-worker ]] ; then
-    celery -A app.celery worker -c $NUMBER_OF_CHILD -E -B -l INFO &
+    if [[ -z $NUMBER_OF_CHILD ]]; then
+        celery -A app.celery worker -E -B -l INFO &
+    else
+        celery -A app.celery worker -c $NUMBER_OF_CHILD -E -B -l INFO &
+    fi
 else
     gunicorn app:app --worker-class eventlet --bind 0.0.0.0:8000 --timeout 180 --worker-connections 1000 --log-level=info &
 fi

--- a/docker/webApp/iris-entrypoint.sh
+++ b/docker/webApp/iris-entrypoint.sh
@@ -26,7 +26,7 @@ target=${1-:app}
 printf "Running ${target} ...\n"
 
 if [[ "${target}" == iris-worker ]] ; then
-    celery -A app.celery worker -C $NUMBER_OF_CHILD -E -B -l INFO &
+    celery -A app.celery worker -c $NUMBER_OF_CHILD -E -B -l INFO &
 else
     gunicorn app:app --worker-class eventlet --bind 0.0.0.0:8000 --timeout 180 --worker-connections 1000 --log-level=info &
 fi


### PR DESCRIPTION
Hello, in the case where iris is deployed on large nodes celery uses as many childs processes processing as there are `CPUs` on the machine. In the case of large configuration this is a problem. 

Is it possible to add the -C option on the command in the iris-entrypoint.sh file?

Celery doc for `-C` :
```
  -c, --concurrency <concurrency>
                                  Number of child processes processing the
                                  queue.  The default is the number of CPUs
                                  available on your system.
```

Thanks !