### PR TITLE
Fixed the alert route so not to trow a TypeError

### DIFF
--- a/source/app/blueprints/alerts/alerts_routes.py
+++ b/source/app/blueprints/alerts/alerts_routes.py
@@ -494,7 +494,7 @@ def alerts_batch_delete_route() -> Response:
     if not success:
         return response_error(logs)
     
-    alert = call_modules_hook('on_postload_alert_delete', data={"alert_ids": {alert_ids}})
+    alert = call_modules_hook('on_postload_alert_delete', data={"alert_ids": alert_ids})
 
     track_activity(f"deleted alerts #{','.join(str(alert_id) for alert_id in alert_ids)}", ctx_less=True)
 


### PR DESCRIPTION
The batch delete alert route broken in commit [c6d6f3e](https://github.com/dfir-iris/iris-web/commit/c6d6f3e7abe0ba7f0dce605765c56825f3f1c46c),
Updated this to work as expected.

Also updated the IrisWebHooksModule to work with this change. [PR-7](https://github.com/dfir-iris/iris-webhooks-module/pull/7)