### PR TITLE
Added endpoint GET /api/v2/cases/{identifier}/iocs and other REST related improvements

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -24,6 +24,8 @@ The IRIS backend is a Flask application.
 This is the public API of the `app`. It contains all the endpoints: REST, GraphQL, Flask templates (pages and modals). 
 The requests payloads are converted to business objects from `models` and passed down to calls into the business layer.
 
+Enforcing the permissions, i.e. checking a user is allowed to perform an action, is done in this layer.
+
 Forbidden imports in this layer:
 
 * `from app.datamgmt`, as everything should go through the business layer first 

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -1,0 +1,330 @@
+#  IRIS Source Code
+#  Copyright (C) 2024 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import json
+import logging as log
+import uuid
+from functools import wraps
+
+from flask import request, session, render_template
+from flask_login import current_user
+from flask_wtf import FlaskForm
+from werkzeug.utils import redirect
+
+from app import TEMPLATE_PATH
+from app.datamgmt.case.case_db import get_case
+from app.datamgmt.manage.manage_access_control_db import user_has_client_access
+from app.iris_engine.access_control.utils import ac_fast_check_user_has_case_access
+from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
+from app.models.authorization import Permissions
+from app.models.authorization import CaseAccessLevel
+from app.util import update_current_case
+from app.util import log_exception_and_error
+from app.util import response_error
+from app.util import is_user_authenticated
+from app.util import not_authenticated_redirection_url
+from app.util import ac_api_return_access_denied
+
+
+def _user_has_at_least_a_required_permission(permissions: list[Permissions]):
+    """
+        Returns true as soon as the user has at least one permission in the list of permissions
+        Returns true if the list of required permissions is empty
+    """
+    if not permissions:
+        return True
+
+    for permission in permissions:
+        if session['permissions'] & permission.value:
+            return True
+
+    return False
+
+
+def _set_caseid_from_current_user():
+    redir = False
+    if current_user.ctx_case is None:
+        redir = True
+        current_user.ctx_case = 1
+    caseid = current_user.ctx_case
+    return redir, caseid
+
+
+def _get_caseid_from_request_data(request_data, no_cid_required):
+    caseid = request_data.args.get('cid', default=None, type=int)
+    if caseid:
+        return False, caseid, True
+
+    if no_cid_required:
+        return False, caseid, True
+
+    js_d = None
+
+    try:
+        if request_data.content_type == 'application/json':
+            js_d = request_data.get_json()
+
+        if not js_d:
+            redir, caseid = _set_caseid_from_current_user()
+            return redir, caseid, True
+
+        if 'cid' not in js_d:
+            cookie_session = request_data.cookies.get('session')
+            if not cookie_session:
+                redir, caseid = _set_caseid_from_current_user()
+                return redir, caseid, True
+
+        caseid = js_d.get('cid')
+
+        return False, caseid, True
+
+    except Exception as e:
+        cookie_session = request_data.cookies.get('session')
+        if not cookie_session:
+            redir, caseid = _set_caseid_from_current_user()
+            return redir, caseid, True
+
+        log_exception_and_error(e)
+        return True, 0, False
+
+
+def _handle_no_cid_required(no_cid_required):
+    if no_cid_required:
+        js_d = request.get_json(silent=True)
+
+        try:
+
+            if type(js_d) == str:
+                js_d = json.loads(js_d)
+
+            caseid = js_d.get('cid') if type(js_d) == dict else None
+            if caseid and 'cid' in request.json:
+                request.json.pop('cid')
+
+        except Exception:
+            return None, False
+
+        return caseid, True
+
+    return None, False
+
+
+def _update_denied_case(caseid):
+    session['current_case'] = {
+        'case_name': "{} to #{}".format("Access denied", caseid),
+        'case_info': "",
+        'case_id': caseid,
+        'access': '<i class="ml-2 text-danger mt-1 fa-solid fa-ban"></i>'
+    }
+
+
+def _update_session(caseid, eaccess_level):
+    restricted_access = ''
+    if not eaccess_level:
+        eaccess_level = [CaseAccessLevel.read_only, CaseAccessLevel.full_access]
+
+    if CaseAccessLevel.read_only.value == eaccess_level:
+        restricted_access = '<i class="ml-2 text-warning mt-1 fa-solid fa-lock" title="Read only access"></i>'
+
+    update_current_case(caseid, restricted_access)
+
+
+# TODO would be nice to remove parameter no_cid_required
+def _get_case_access(request_data, access_level, no_cid_required=False):
+    redir, caseid, has_access = _get_caseid_from_request_data(request_data, no_cid_required)
+
+    ctmp, has_access = _handle_no_cid_required(no_cid_required)
+    redir = False
+    if ctmp is not None:
+        return redir, ctmp, has_access
+
+    eaccess_level = ac_fast_check_user_has_case_access(current_user.id, caseid, access_level)
+    if eaccess_level is None and access_level:
+        _update_denied_case(caseid)
+        return redir, caseid, False
+
+    _update_session(caseid, eaccess_level)
+
+    if caseid is not None and not get_case(caseid):
+        log.warning('No case found. Using default case')
+        return True, 1, True
+
+    return redir, caseid, True
+
+
+def _is_csrf_token_valid():
+    if request.method != 'POST':
+        return True
+    if request.headers.get('X-IRIS-AUTH') is not None:
+        return True
+    if request.headers.get('Authorization') is not None:
+        return True
+    cookie_session = request.cookies.get('session')
+    # True in the absence of a session cookie, because no CSRF token is required for API calls
+    if not cookie_session:
+        return True
+    form = FlaskForm()
+    if not form.validate():
+        return False
+    # TODO not nice to have a side-effect within a 'is' method.
+    if request.is_json:
+        request.json.pop('csrf_token')
+    return True
+
+
+def _ac_return_access_denied(caseid: int = None):
+    error_uuid = uuid.uuid4()
+    log.warning(f"Access denied to case #{caseid} for user ID {current_user.id}. Error {error_uuid}")
+    return render_template('pages/error-403.html', user=current_user, caseid=caseid, error_uuid=error_uuid,
+                           template_folder=TEMPLATE_PATH), 403
+
+
+def ac_requires_case_identifier(*access_level):
+    def decorate_with_requires_case_identifier(f):
+        @wraps(f)
+        def wrap(*args, **kwargs):
+            try:
+                redir, caseid, has_access = get_case_access_from_api(request, access_level)
+            except Exception as e:
+                log.exception(e)
+                return response_error('Invalid data. Check server logs', status=500)
+
+            if not caseid and not redir:
+                return response_error('Invalid case ID', status=404)
+
+            if not has_access:
+                return ac_api_return_access_denied(caseid=caseid)
+
+            kwargs.update({'caseid': caseid})
+
+            return f(*args, **kwargs)
+
+        return wrap
+    return decorate_with_requires_case_identifier
+
+
+def get_case_access_from_api(request_data, access_level):
+    redir, caseid, has_access = _get_caseid_from_request_data(request_data, False)
+    redir = False
+
+    eaccess_level = ac_fast_check_user_has_case_access(current_user.id, caseid, access_level)
+    if eaccess_level is None and access_level:
+        return redir, caseid, False
+
+    if caseid is not None and not get_case(caseid):
+        log.warning('No case found. Using default case')
+        return True, 1, True
+
+    return redir, caseid, True
+
+
+def ac_case_requires(*access_level):
+    def inner_wrap(f):
+        @wraps(f)
+        def wrap(*args, **kwargs):
+            if not is_user_authenticated(request):
+                return redirect(not_authenticated_redirection_url(request.full_path))
+
+            redir, caseid, has_access = _get_case_access(request, access_level)
+
+            if not has_access:
+                return _ac_return_access_denied(caseid=caseid)
+
+            kwargs.update({"caseid": caseid, "url_redir": redir})
+
+            return f(*args, **kwargs)
+
+        return wrap
+    return inner_wrap
+
+
+# TODO try to remove option no_cid_required
+def ac_requires(*permissions, no_cid_required=False):
+    def inner_wrap(f):
+        @wraps(f)
+        def wrap(*args, **kwargs):
+            if not is_user_authenticated(request):
+                return redirect(not_authenticated_redirection_url(request.full_path))
+
+            redir, caseid, _ = _get_case_access(request, [], no_cid_required=no_cid_required)
+            kwargs.update({'caseid': caseid, 'url_redir': redir})
+
+            if not _user_has_at_least_a_required_permission(permissions):
+                return _ac_return_access_denied()
+
+            return f(*args, **kwargs)
+        return wrap
+    return inner_wrap
+
+
+def ac_api_requires(*permissions):
+    def inner_wrap(f):
+        @wraps(f)
+        def wrap(*args, **kwargs):
+            if not _is_csrf_token_valid():
+                return response_error('Invalid CSRF token')
+
+            if not is_user_authenticated(request):
+                return response_error('Authentication required', status=401)
+
+            if 'permissions' not in session:
+                session['permissions'] = ac_get_effective_permissions_of_user(current_user)
+
+            if not _user_has_at_least_a_required_permission(permissions):
+                return response_error('Permission denied', status=403)
+
+            return f(*args, **kwargs)
+        return wrap
+    return inner_wrap
+
+
+def ac_requires_client_access():
+    def inner_wrap(f):
+        @wraps(f)
+        def wrap(*args, **kwargs):
+            client_id = kwargs.get('client_id')
+            if not user_has_client_access(current_user.id, client_id):
+                return _ac_return_access_denied()
+
+            return f(*args, **kwargs)
+        return wrap
+    return inner_wrap
+
+
+def ac_socket_requires(*access_level):
+    def inner_wrap(f):
+        @wraps(f)
+        def wrap(*args, **kwargs):
+            if not is_user_authenticated(request):
+                return redirect(not_authenticated_redirection_url(request.full_path))
+
+            else:
+                chan_id = args[0].get('channel')
+                if chan_id:
+                    case_id = int(chan_id.replace('case-', '').split('-')[0])
+                else:
+                    return _ac_return_access_denied(caseid=0)
+
+                access = ac_fast_check_user_has_case_access(current_user.id, case_id, access_level)
+                if not access:
+                    return _ac_return_access_denied(caseid=case_id)
+
+                return f(*args, **kwargs)
+
+        return wrap
+    return inner_wrap

--- a/source/app/blueprints/graphql/cases.py
+++ b/source/app/blueprints/graphql/cases.py
@@ -35,8 +35,8 @@ from app.business.iocs import iocs_build_filter_query
 from app.business.cases import cases_create
 from app.business.cases import cases_delete
 from app.business.cases import cases_update
-from app.business.permissions import permissions_check_current_user_has_some_permission
-from app.business.permissions import permissions_check_current_user_has_some_case_access
+from app.blueprints.graphql.permissions import permissions_check_current_user_has_some_permission
+from app.blueprints.graphql.permissions import permissions_check_current_user_has_some_case_access
 
 from app.blueprints.graphql.iocs import IOCConnection
 

--- a/source/app/blueprints/graphql/graphql_route.py
+++ b/source/app/blueprints/graphql/graphql_route.py
@@ -50,7 +50,7 @@ from app.blueprints.graphql.cases import CaseUpdate
 from app.blueprints.graphql.cases import CaseConnection
 
 from app.business.cases import cases_get_by_identifier
-from app.business.iocs import iocs_get_by_identifier
+from app.business.iocs import iocs_get
 from app.business.permissions import permissions_check_current_user_has_some_case_access
 
 
@@ -80,7 +80,7 @@ class Query(ObjectType):
 
     @staticmethod
     def resolve_ioc(root, info, ioc_id):
-        return iocs_get_by_identifier(ioc_id)
+        return iocs_get(ioc_id)
 
 
 class Mutation(ObjectType):

--- a/source/app/blueprints/graphql/graphql_route.py
+++ b/source/app/blueprints/graphql/graphql_route.py
@@ -51,7 +51,7 @@ from app.blueprints.graphql.cases import CaseConnection
 
 from app.business.cases import cases_get_by_identifier
 from app.business.iocs import iocs_get
-from app.business.permissions import permissions_check_current_user_has_some_case_access
+from app.blueprints.graphql.permissions import permissions_check_current_user_has_some_case_access
 
 
 class Query(ObjectType):

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -139,5 +139,5 @@ class IOCDelete(Mutation):
         ioc = iocs_get(ioc_id)
         permissions_check_current_user_has_some_case_access(ioc.case_id, [CaseAccessLevel.full_access])
 
-        message = iocs_delete(ioc_id)
+        message = iocs_delete(ioc)
         return IOCDelete(message=message)

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -24,8 +24,8 @@ from graphene import Int
 from graphene import Float
 from graphene import String
 
-from app.business.permissions import permissions_check_current_user_has_some_case_access
-from app.business.permissions import permissions_check_current_user_has_some_case_access_stricter
+from app.blueprints.graphql.permissions import permissions_check_current_user_has_some_case_access
+from app.blueprints.graphql.permissions import permissions_check_current_user_has_some_case_access_stricter
 from app.models.authorization import CaseAccessLevel
 from app.models.models import Ioc
 from app.business.iocs import iocs_create

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -29,6 +29,7 @@ from app.business.permissions import permissions_check_current_user_has_some_cas
 from app.models.authorization import CaseAccessLevel
 from app.models.models import Ioc
 from app.business.iocs import iocs_create
+from app.business.iocs import iocs_get
 from app.business.iocs import iocs_update
 from app.business.iocs import iocs_delete
 
@@ -135,7 +136,8 @@ class IOCDelete(Mutation):
 
     @staticmethod
     def mutate(root, info, ioc_id):
-        permissions_check_current_user_has_some_case_access_stricter([CaseAccessLevel.full_access])
+        ioc = iocs_get(ioc_id)
+        permissions_check_current_user_has_some_case_access(ioc.case_id, [CaseAccessLevel.full_access])
 
         message = iocs_delete(ioc_id)
         return IOCDelete(message=message)

--- a/source/app/blueprints/graphql/iocs.py
+++ b/source/app/blueprints/graphql/iocs.py
@@ -24,6 +24,7 @@ from graphene import Int
 from graphene import Float
 from graphene import String
 
+from app.business.permissions import permissions_check_current_user_has_some_case_access
 from app.business.permissions import permissions_check_current_user_has_some_case_access_stricter
 from app.models.authorization import CaseAccessLevel
 from app.models.models import Ioc
@@ -74,7 +75,7 @@ class IOCCreate(Mutation):
             'ioc_description': description,
             'ioc_tags': tags
         }
-        permissions_check_current_user_has_some_case_access_stricter([CaseAccessLevel.full_access])
+        permissions_check_current_user_has_some_case_access(case_id, [CaseAccessLevel.full_access])
 
         ioc, _ = iocs_create(request, case_id)
         return IOCCreate(ioc=ioc)

--- a/source/app/blueprints/graphql/permissions.py
+++ b/source/app/blueprints/graphql/permissions.py
@@ -26,7 +26,10 @@ from flask import request
 from app.util import get_case_access_from_api
 from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
-from app.business.errors import PermissionDeniedError
+
+
+class PermissionDeniedError(Exception):
+    pass
 
 
 def _deny_permission():

--- a/source/app/blueprints/graphql/permissions.py
+++ b/source/app/blueprints/graphql/permissions.py
@@ -23,7 +23,7 @@ from flask import session
 from flask_login import current_user
 from flask import request
 
-from app.util import get_case_access_from_api
+from app.blueprints.access_controls import get_case_access_from_api
 from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 

--- a/source/app/blueprints/pages/activities/activities_routes.py
+++ b/source/app/blueprints/pages/activities/activities_routes.py
@@ -25,7 +25,7 @@ from flask_wtf import FlaskForm
 
 import app
 from app.models.authorization import Permissions
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 activities_blueprint = Blueprint(
     'activities',

--- a/source/app/blueprints/pages/alerts/alerts_routes.py
+++ b/source/app/blueprints/pages/alerts/alerts_routes.py
@@ -29,7 +29,7 @@ from app.datamgmt.alerts.alerts_db import get_alert_by_id
 from app.datamgmt.manage.manage_access_control_db import user_has_client_access
 from app.models.authorization import Permissions
 from app.util import response_error
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 alerts_blueprint = Blueprint(
     'alerts',

--- a/source/app/blueprints/pages/case/case_assets_routes.py
+++ b/source/app/blueprints/pages/case/case_assets_routes.py
@@ -33,7 +33,7 @@ from app.datamgmt.manage.manage_attribute_db import get_default_custom_attribute
 from app.forms import AssetBasicForm
 from app.forms import ModalAddCaseAssetForm
 from app.models.authorization import CaseAccessLevel
-from app.util import ac_case_requires
+from app.blueprints.access_controls import ac_case_requires
 from app.util import response_error
 
 case_assets_blueprint = Blueprint('case_assets',

--- a/source/app/blueprints/pages/case/case_assets_routes.py
+++ b/source/app/blueprints/pages/case/case_assets_routes.py
@@ -96,7 +96,7 @@ def asset_view_modal(cur_id, caseid, url_redir):
 
     # Build the form
     form = AssetBasicForm()
-    asset = get_asset(cur_id, caseid)
+    asset = get_asset(cur_id)
 
     form.asset_name.render_kw = {'value': asset.asset_name}
     form.asset_description.data = asset.asset_description
@@ -119,7 +119,7 @@ def case_comment_asset_modal(cur_id, caseid, url_redir):
     if url_redir:
         return redirect(url_for('case_task.case_task', cid=caseid, redirect=True))
 
-    asset = get_asset(cur_id, caseid=caseid)
+    asset = get_asset(cur_id)
     if not asset:
         return response_error('Invalid asset ID')
 

--- a/source/app/blueprints/pages/case/case_graphs_routes.py
+++ b/source/app/blueprints/pages/case/case_graphs_routes.py
@@ -24,7 +24,7 @@ from flask_wtf import FlaskForm
 
 from app.datamgmt.case.case_db import get_case
 from app.models.authorization import CaseAccessLevel
-from app.util import ac_case_requires
+from app.blueprints.access_controls import ac_case_requires
 
 case_graph_blueprint = Blueprint('case_graph',
                                  __name__,

--- a/source/app/blueprints/pages/case/case_ioc_routes.py
+++ b/source/app/blueprints/pages/case/case_ioc_routes.py
@@ -21,10 +21,10 @@ from flask import redirect
 from flask import render_template
 from flask import url_for
 
+from app.business.iocs import iocs_get
 from app.datamgmt.case.case_assets_db import get_assets_types
 from app.datamgmt.case.case_db import get_case
 from app.datamgmt.case.case_iocs_db import get_case_iocs_comments_count
-from app.datamgmt.case.case_iocs_db import get_ioc
 from app.datamgmt.case.case_iocs_db import get_ioc_types_list
 from app.datamgmt.case.case_iocs_db import get_tlps
 from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
@@ -79,7 +79,7 @@ def case_view_ioc_modal(cur_id, caseid, url_redir):
         return redirect(url_for('case_assets.case_assets', cid=caseid, redirect=True))
 
     form = ModalAddCaseIOCForm()
-    ioc = get_ioc(cur_id)
+    ioc = iocs_get(cur_id)
     if not ioc:
         return response_error("Invalid IOC ID for this case")
 
@@ -102,7 +102,7 @@ def case_comment_ioc_modal(cur_id, caseid, url_redir):
     if url_redir:
         return redirect(url_for('case_ioc.case_ioc', cid=caseid, redirect=True))
 
-    ioc = get_ioc(cur_id)
+    ioc = iocs_get(cur_id)
     if not ioc:
         return response_error('Invalid ioc ID')
 

--- a/source/app/blueprints/pages/case/case_ioc_routes.py
+++ b/source/app/blueprints/pages/case/case_ioc_routes.py
@@ -33,7 +33,7 @@ from app.forms import ModalAddCaseAssetForm
 from app.forms import ModalAddCaseIOCForm
 from app.models.authorization import CaseAccessLevel
 from app.models.models import Ioc
-from app.util import ac_case_requires
+from app.blueprints.access_controls import ac_case_requires
 from app.util import response_error
 
 case_ioc_blueprint = Blueprint(

--- a/source/app/blueprints/pages/case/case_notes_routes.py
+++ b/source/app/blueprints/pages/case/case_notes_routes.py
@@ -26,7 +26,7 @@ from app.datamgmt.case.case_db import case_get_desc_crc
 from app.datamgmt.case.case_db import get_case
 from app.datamgmt.case.case_notes_db import get_note
 from app.models.authorization import CaseAccessLevel
-from app.util import ac_case_requires
+from app.blueprints.access_controls import ac_case_requires
 from app.util import response_error
 
 

--- a/source/app/blueprints/pages/case/case_rfiles_routes.py
+++ b/source/app/blueprints/pages/case/case_rfiles_routes.py
@@ -27,7 +27,7 @@ from app.datamgmt.case.case_rfiles_db import get_case_evidence_comments_count
 from app.datamgmt.case.case_rfiles_db import get_rfile
 from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
 from app.models.authorization import CaseAccessLevel
-from app.util import ac_case_requires
+from app.blueprints.access_controls import ac_case_requires
 from app.util import response_error
 
 case_rfiles_blueprint = Blueprint(

--- a/source/app/blueprints/pages/case/case_routes.py
+++ b/source/app/blueprints/pages/case/case_routes.py
@@ -34,7 +34,7 @@ from app.iris_engine.access_control.utils import ac_get_all_access_level
 from app.iris_engine.module_handler.module_handler import list_available_pipelines
 from app.models import CaseStatus
 from app.models.authorization import CaseAccessLevel
-from app.util import ac_case_requires
+from app.blueprints.access_controls import ac_case_requires
 
 case_blueprint = Blueprint('case',
                            __name__,

--- a/source/app/blueprints/pages/case/case_tasks_routes.py
+++ b/source/app/blueprints/pages/case/case_tasks_routes.py
@@ -33,7 +33,7 @@ from app.forms import CaseTaskForm
 from app.models.authorization import CaseAccessLevel
 from app.models.authorization import User
 from app.models.models import CaseTasks
-from app.util import ac_case_requires
+from app.blueprints.access_controls import ac_case_requires
 from app.util import response_error
 
 case_tasks_blueprint = Blueprint('case_tasks',

--- a/source/app/blueprints/pages/case/case_tasks_routes.py
+++ b/source/app/blueprints/pages/case/case_tasks_routes.py
@@ -77,7 +77,7 @@ def case_task_view_modal(cur_id, caseid, url_redir):
 
     form = CaseTaskForm()
 
-    task = get_task_with_assignees(task_id=cur_id, case_id=caseid)
+    task = get_task_with_assignees(task_id=cur_id)
     form.task_status_id.choices = [(a.id, a.status_name) for a in get_tasks_status()]
     form.task_assignees_id.choices = []
 
@@ -99,7 +99,7 @@ def case_comment_task_modal(cur_id, caseid, url_redir):
     if url_redir:
         return redirect(url_for('case_task.case_task', cid=caseid, redirect=True))
 
-    task = get_task(cur_id, caseid=caseid)
+    task = get_task(cur_id)
     if not task:
         return response_error('Invalid task ID')
 

--- a/source/app/blueprints/pages/case/case_timeline_routes.py
+++ b/source/app/blueprints/pages/case/case_timeline_routes.py
@@ -36,7 +36,7 @@ from app.models.authorization import CaseAccessLevel
 from app.models.authorization import User
 from app.models.cases import Cases
 from app.models.cases import CasesEvent
-from app.util import ac_case_requires
+from app.blueprints.access_controls import ac_case_requires
 from app.util import response_error
 
 _EVENT_TAGS = ['Network', 'Server', 'ActiveDirectory', 'Computer', 'Malware', 'User Interaction']

--- a/source/app/blueprints/pages/dashboard/dashboard_routes.py
+++ b/source/app/blueprints/pages/dashboard/dashboard_routes.py
@@ -33,7 +33,7 @@ from app.iris_engine.access_control.utils import ac_get_user_case_counts
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import User
 from app.models.models import GlobalTasks
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 from app.util import not_authenticated_redirection_url
 
 dashboard_blueprint = Blueprint(

--- a/source/app/blueprints/pages/datastore/datastore_routes.py
+++ b/source/app/blueprints/pages/datastore/datastore_routes.py
@@ -25,7 +25,7 @@ from app.datamgmt.datastore.datastore_db import datastore_get_file
 from app.datamgmt.datastore.datastore_db import datastore_get_path_node
 from app.forms import ModalDSFileForm
 from app.models.authorization import CaseAccessLevel
-from app.util import ac_case_requires
+from app.blueprints.access_controls import ac_case_requires
 from app.util import response_error
 
 datastore_blueprint = Blueprint(

--- a/source/app/blueprints/pages/dim_tasks/dim_tasks.py
+++ b/source/app/blueprints/pages/dim_tasks/dim_tasks.py
@@ -26,8 +26,7 @@ from flask_wtf import FlaskForm
 import app
 from app.models.authorization import CaseAccessLevel
 from app.models.authorization import Permissions
-from app.util import ac_case_requires
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_case_requires, ac_requires
 from app.util import response_error
 from iris_interface.IrisInterfaceStatus import IIStatus
 

--- a/source/app/blueprints/pages/manage/manage_access_control.py
+++ b/source/app/blueprints/pages/manage/manage_access_control.py
@@ -24,7 +24,7 @@ from werkzeug.utils import redirect
 from app.iris_engine.access_control.utils import ac_trace_effective_user_permissions
 from app.iris_engine.access_control.utils import ac_trace_user_effective_cases_access_2
 from app.models.authorization import Permissions
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 manage_ac_blueprint = Blueprint(
         'access_control',

--- a/source/app/blueprints/pages/manage/manage_assets_type_routes.py
+++ b/source/app/blueprints/pages/manage/manage_assets_type_routes.py
@@ -27,7 +27,7 @@ from app import app
 from app.forms import AddAssetForm
 from app.models.authorization import Permissions
 from app.models.models import AssetsType
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 from app.util import response_error
 
 manage_assets_type_blueprint = Blueprint('manage_assets_type',

--- a/source/app/blueprints/pages/manage/manage_attributes_routes.py
+++ b/source/app/blueprints/pages/manage/manage_attributes_routes.py
@@ -27,7 +27,7 @@ from app.forms import AddAssetForm
 from app.forms import AttributeForm
 from app.models.authorization import Permissions
 from app.models.models import CustomAttribute
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 from app.util import response_error
 
 manage_attributes_blueprint = Blueprint('manage_attributes', __name__, template_folder='templates')

--- a/source/app/blueprints/pages/manage/manage_case_classification_routes.py
+++ b/source/app/blueprints/pages/manage/manage_case_classification_routes.py
@@ -27,7 +27,7 @@ from app.datamgmt.manage.manage_case_classifications_db import get_case_classifi
 from app.forms import CaseClassificationForm
 from app.models.authorization import Permissions
 from app.util import response_error
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 manage_case_classification_blueprint = Blueprint('manage_case_classifications',
                                                  __name__,

--- a/source/app/blueprints/pages/manage/manage_case_state.py
+++ b/source/app/blueprints/pages/manage/manage_case_state.py
@@ -27,7 +27,7 @@ from app.datamgmt.manage.manage_case_state_db import get_case_state_by_id
 from app.forms import CaseStateForm
 from app.models.authorization import Permissions
 from app.util import response_error
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 manage_case_state_blueprint = Blueprint('manage_case_state',
                                         __name__,

--- a/source/app/blueprints/pages/manage/manage_case_templates_routes.py
+++ b/source/app/blueprints/pages/manage/manage_case_templates_routes.py
@@ -24,7 +24,7 @@ from app.datamgmt.manage.manage_case_templates_db import get_case_template_by_id
 from app.forms import CaseTemplateForm, AddAssetForm
 from app.models import CaseTemplate
 from app.models.authorization import Permissions
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 from app.util import response_error
 
 manage_case_templates_blueprint = Blueprint('manage_case_templates',

--- a/source/app/blueprints/pages/manage/manage_cases_routes.py
+++ b/source/app/blueprints/pages/manage/manage_cases_routes.py
@@ -40,7 +40,7 @@ from app.models.authorization import CaseAccessLevel
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseDetailsSchema
 from app.util import ac_api_return_access_denied
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 from app.util import response_error
 
 manage_cases_blueprint = Blueprint('manage_case',

--- a/source/app/blueprints/pages/manage/manage_customers_routes.py
+++ b/source/app/blueprints/pages/manage/manage_customers_routes.py
@@ -31,8 +31,7 @@ from app.forms import AddCustomerForm
 from app.forms import ContactForm
 from app.models.authorization import Permissions
 from app.schema.marshables import ContactSchema
-from app.util import ac_requires_client_access
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires, ac_requires_client_access
 from app.util import page_not_found
 from app.util import response_error
 

--- a/source/app/blueprints/pages/manage/manage_customers_routes.py
+++ b/source/app/blueprints/pages/manage/manage_customers_routes.py
@@ -31,7 +31,8 @@ from app.forms import AddCustomerForm
 from app.forms import ContactForm
 from app.models.authorization import Permissions
 from app.schema.marshables import ContactSchema
-from app.blueprints.access_controls import ac_requires, ac_requires_client_access
+from app.blueprints.access_controls import ac_requires
+from app.blueprints.access_controls import ac_requires_client_access
 from app.util import page_not_found
 from app.util import response_error
 

--- a/source/app/blueprints/pages/manage/manage_evidence_types_route.py
+++ b/source/app/blueprints/pages/manage/manage_evidence_types_route.py
@@ -27,7 +27,7 @@ from app.datamgmt.manage.manage_evidence_types_db import get_evidence_type_by_id
 from app.forms import EvidenceTypeForm
 from app.models.authorization import Permissions
 from app.util import response_error
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 manage_evidence_types_blueprint = Blueprint('manage_evidence_types',
                                             __name__,

--- a/source/app/blueprints/pages/manage/manage_groups_routes.py
+++ b/source/app/blueprints/pages/manage/manage_groups_routes.py
@@ -28,7 +28,7 @@ from app.forms import AddGroupForm
 from app.iris_engine.access_control.utils import ac_get_all_access_level
 from app.iris_engine.access_control.utils import ac_get_all_permissions
 from app.models.authorization import Permissions
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 from app.util import response_error
 
 manage_groups_blueprint = Blueprint(

--- a/source/app/blueprints/pages/manage/manage_ioc_types_routes.py
+++ b/source/app/blueprints/pages/manage/manage_ioc_types_routes.py
@@ -24,7 +24,7 @@ from werkzeug.utils import redirect
 from app.forms import AddIocTypeForm
 from app.models import IocType
 from app.models.authorization import Permissions
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 from app.util import response_error
 
 manage_ioc_type_blueprint = Blueprint('manage_ioc_types',

--- a/source/app/blueprints/pages/manage/manage_modules_routes.py
+++ b/source/app/blueprints/pages/manage/manage_modules_routes.py
@@ -28,7 +28,7 @@ from app.datamgmt.iris_engine.modules_db import is_mod_configured
 from app.forms import AddModuleForm
 from app.forms import UpdateModuleParameterForm
 from app.models.authorization import Permissions
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 from app.util import response_error
 
 manage_modules_blueprint = Blueprint(

--- a/source/app/blueprints/pages/manage/manage_objects_routes.py
+++ b/source/app/blueprints/pages/manage/manage_objects_routes.py
@@ -23,7 +23,7 @@ from flask import url_for
 
 from app.forms import AddAssetForm
 from app.models.authorization import Permissions
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 manage_objects_blueprint = Blueprint('manage_objects',
                                           __name__,

--- a/source/app/blueprints/pages/manage/manage_srv_settings_routes.py
+++ b/source/app/blueprints/pages/manage/manage_srv_settings_routes.py
@@ -27,8 +27,7 @@ from app.datamgmt.manage.manage_srv_settings_db import get_alembic_revision
 from app.datamgmt.manage.manage_srv_settings_db import get_srv_settings
 from app.iris_engine.updater.updater import is_updates_available
 from app.models.authorization import Permissions
-from app.util import ac_requires
-
+from app.blueprints.access_controls import ac_requires
 
 manage_srv_settings_blueprint = Blueprint(
     'manage_srv_settings_blueprint',

--- a/source/app/blueprints/pages/manage/manage_templates_routes.py
+++ b/source/app/blueprints/pages/manage/manage_templates_routes.py
@@ -26,7 +26,7 @@ from app.models.authorization import Permissions
 from app.models.models import CaseTemplateReport
 from app.models.models import Languages
 from app.models.models import ReportType
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 manage_templates_blueprint = Blueprint(
     'manage_templates',

--- a/source/app/blueprints/pages/manage/manage_users.py
+++ b/source/app/blueprints/pages/manage/manage_users.py
@@ -32,7 +32,7 @@ from app.forms import AddUserForm
 from app.iris_engine.access_control.utils import ac_get_all_access_level
 from app.iris_engine.access_control.utils import ac_current_user_has_permission
 from app.models.authorization import Permissions
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 from app.util import response_error
 
 manage_users_blueprint = Blueprint('manage_users', __name__, template_folder='templates')

--- a/source/app/blueprints/pages/overview/overview_routes.py
+++ b/source/app/blueprints/pages/overview/overview_routes.py
@@ -22,7 +22,7 @@ from flask import url_for
 from flask_wtf import FlaskForm
 from werkzeug.utils import redirect
 
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 overview_blueprint = Blueprint(
     'overview',

--- a/source/app/blueprints/pages/profile/profile_routes.py
+++ b/source/app/blueprints/pages/profile/profile_routes.py
@@ -25,7 +25,7 @@ from flask_wtf import FlaskForm
 from app import app
 from app.datamgmt.manage.manage_srv_settings_db import get_server_settings_as_dict
 from app.datamgmt.manage.manage_srv_settings_db import get_srv_settings
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 profile_blueprint = Blueprint('profile',
                               __name__,

--- a/source/app/blueprints/pages/search/search_routes.py
+++ b/source/app/blueprints/pages/search/search_routes.py
@@ -24,7 +24,7 @@ from flask import url_for
 
 from app.forms import SearchForm
 from app.models.authorization import Permissions
-from app.util import ac_requires
+from app.blueprints.access_controls import ac_requires
 
 search_blueprint = Blueprint('search',
                              __name__,

--- a/source/app/blueprints/rest/activities_routes.py
+++ b/source/app/blueprints/rest/activities_routes.py
@@ -21,7 +21,7 @@ from flask import Blueprint
 from app.datamgmt.activities.activities_db import get_all_users_activities
 from app.datamgmt.activities.activities_db import get_users_activities
 from app.models.authorization import Permissions
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_success
 
 activities_rest_blueprint = Blueprint('activities_rest', __name__)

--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -56,7 +56,7 @@ from app.schema.marshables import CaseSchema
 from app.schema.marshables import CommentSchema
 from app.schema.marshables import CaseAssetsSchema
 from app.schema.marshables import IocSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import add_obj_history_entry
 from app.util import response_success

--- a/source/app/blueprints/rest/api_routes.py
+++ b/source/app/blueprints/rest/api_routes.py
@@ -19,7 +19,7 @@
 from flask import Blueprint
 
 from app import app
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_success
 
 rest_api_blueprint = Blueprint('rest_api', __name__)

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -268,11 +268,12 @@ def deprecated_asset_view(cur_id, caseid):
 def asset_view(identifier):
     try:
         asset = assets_get(identifier)
+        if not ac_fast_check_current_user_has_case_access(asset.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=asset.case_id)
+
         return response_api_success(asset)
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
-    except PermissionDeniedError:
-        return ac_api_return_access_denied()
 
 
 @case_assets_rest_blueprint.route('/case/assets/update/<int:cur_id>', methods=['POST'])

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -35,7 +35,6 @@ from app.business.assets import assets_create
 from app.business.assets import assets_get_detailed
 from app.business.assets import assets_get
 from app.business.errors import BusinessProcessingError
-from app.business.errors import PermissionDeniedError
 from app.datamgmt.case.case_assets_db import add_comment_to_asset
 from app.datamgmt.case.case_assets_db import create_asset
 from app.datamgmt.case.case_assets_db import delete_asset_comment

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -322,22 +322,28 @@ def asset_update(cur_id, caseid):
 @ac_api_requires()
 def deprecated_asset_delete(cur_id, caseid):
     try:
-        assets_delete(cur_id)
-        return response_success("Deleted")
+        asset = assets_get(cur_id)
+        if not ac_fast_check_current_user_has_case_access(asset.case_id, [CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=asset.case_id)
+
+        assets_delete(asset)
+        return response_success('Deleted')
     except BusinessProcessingError as _:
-        return response_error("Invalid asset ID for this case")
+        return response_error('Invalid asset ID for this case')
 
 
 @case_assets_rest_blueprint.route('/api/v2/assets/<int:identifier>', methods=['DELETE'])
 @ac_api_requires()
 def asset_delete(identifier):
     try:
-        assets_delete(identifier)
+        asset = assets_get(identifier)
+        if not ac_fast_check_current_user_has_case_access(asset.case_id, [CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=asset.case_id)
+
+        assets_delete(asset)
         return response_api_deleted()
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
-    except PermissionDeniedError:
-        return ac_api_return_access_denied()
 
 
 @case_assets_rest_blueprint.route('/case/assets/<int:cur_id>/comments/list', methods=['GET'])

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -58,8 +58,7 @@ from app.models import AnalysisStatus
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
 from app.schema.marshables import CommentSchema
-from app.util import ac_api_requires
-from app.util import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import response_error
 from app.util import response_success
 from app.util import ac_api_return_access_denied

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -31,6 +31,7 @@ from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_created
 from app.business.assets import assets_delete, assets_create, assets_get
 from app.business.errors import BusinessProcessingError
+from app.business.errors import PermissionDeniedError
 from app.datamgmt.case.case_assets_db import add_comment_to_asset
 from app.datamgmt.case.case_assets_db import create_asset
 from app.datamgmt.case.case_assets_db import delete_asset_comment
@@ -252,21 +253,22 @@ def case_upload_ioc(caseid):
 @ac_api_requires()
 def deprecated_asset_view(cur_id, caseid):
     try:
-        asset = assets_get(cur_id, caseid)
+        asset = assets_get(cur_id)
         return response_success(asset)
     except BusinessProcessingError as e:
         return response_error(e.get_message())
 
 
-@case_assets_rest_blueprint.route('/api/v2/assets/<int:cur_id>', methods=['GET'])
-@ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
+@case_assets_rest_blueprint.route('/api/v2/assets/<int:identifier>', methods=['GET'])
 @ac_api_requires()
-def asset_view(cur_id, caseid):
+def asset_view(identifier):
     try:
-        asset = assets_get(cur_id, caseid)
+        asset = assets_get(identifier)
         return response_api_created(asset)
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
+    except PermissionDeniedError:
+        return ac_api_return_access_denied()
 
 
 @case_assets_rest_blueprint.route('/case/assets/update/<int:cur_id>', methods=['POST'])

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -27,6 +27,7 @@ from app import db
 from app.blueprints.rest.case_comments import case_comment_update
 from app.blueprints.rest.endpoints import endpoint_deprecated
 from app.blueprints.rest.endpoints import response_api_deleted
+from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_created
 from app.business.assets import assets_delete, assets_create, assets_get
@@ -264,7 +265,7 @@ def deprecated_asset_view(cur_id, caseid):
 def asset_view(identifier):
     try:
         asset = assets_get(identifier)
-        return response_api_created(asset)
+        return response_api_success(asset)
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
     except PermissionDeniedError:

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -30,7 +30,10 @@ from app.blueprints.rest.endpoints import response_api_deleted
 from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_created
-from app.business.assets import assets_delete, assets_create, assets_get
+from app.business.assets import assets_delete
+from app.business.assets import assets_create
+from app.business.assets import assets_get_detailed
+from app.business.assets import assets_get
 from app.business.errors import BusinessProcessingError
 from app.business.errors import PermissionDeniedError
 from app.datamgmt.case.case_assets_db import add_comment_to_asset
@@ -254,7 +257,7 @@ def case_upload_ioc(caseid):
 @ac_api_requires()
 def deprecated_asset_view(cur_id, caseid):
     try:
-        asset = assets_get(cur_id)
+        asset = assets_get_detailed(cur_id)
         return response_success(asset)
     except BusinessProcessingError as e:
         return response_error(e.get_message())

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -335,6 +335,8 @@ def asset_delete(identifier):
         return response_api_deleted()
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
+    except PermissionDeniedError:
+        return ac_api_return_access_denied()
 
 
 @case_assets_rest_blueprint.route('/case/assets/<int:cur_id>/comments/list', methods=['GET'])

--- a/source/app/blueprints/rest/case/case_evidences_routes.py
+++ b/source/app/blueprints/rest/case/case_evidences_routes.py
@@ -40,8 +40,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseEvidenceSchema
 from app.schema.marshables import CommentSchema
-from app.util import ac_api_requires
-from app.util import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/case/case_evidences_routes.py
+++ b/source/app/blueprints/rest/case/case_evidences_routes.py
@@ -40,7 +40,8 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseEvidenceSchema
 from app.schema.marshables import CommentSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/case/case_graphs_routes.py
+++ b/source/app/blueprints/rest/case/case_graphs_routes.py
@@ -24,8 +24,7 @@ from flask import Blueprint
 from app.datamgmt.case.case_events_db import get_case_events_assets_graph
 from app.datamgmt.case.case_events_db import get_case_events_ioc_graph
 from app.models.authorization import CaseAccessLevel
-from app.util import ac_requires_case_identifier
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import response_success
 
 case_graph_rest_blueprint = Blueprint('case_graph_rest', __name__)

--- a/source/app/blueprints/rest/case/case_graphs_routes.py
+++ b/source/app/blueprints/rest/case/case_graphs_routes.py
@@ -24,7 +24,8 @@ from flask import Blueprint
 from app.datamgmt.case.case_events_db import get_case_events_assets_graph
 from app.datamgmt.case.case_events_db import get_case_events_ioc_graph
 from app.models.authorization import CaseAccessLevel
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_success
 
 case_graph_rest_blueprint = Blueprint('case_graph_rest', __name__)

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -59,8 +59,7 @@ from app.models import Tlp
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CommentSchema
 from app.schema.marshables import IocSchema
-from app.util import ac_requires_case_identifier
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -311,7 +311,7 @@ def delete_case_ioc(identifier):
         if not ac_fast_check_current_user_has_case_access(ioc.case_id, [CaseAccessLevel.full_access]):
             return ac_api_return_access_denied(caseid=ioc.case_id)
 
-        iocs_delete(identifier)
+        iocs_delete(ioc)
         return response_api_deleted()
 
     except ObjectNotFoundError:

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -33,6 +33,12 @@ from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import endpoint_deprecated
+from app.business.iocs import iocs_create
+from app.business.iocs import iocs_update
+from app.business.iocs import iocs_delete
+from app.business.iocs import iocs_get
+from app.business.errors import BusinessProcessingError
+from app.business.errors import PermissionDeniedError
 from app.datamgmt.case.case_iocs_db import add_comment_to_ioc
 from app.datamgmt.case.case_iocs_db import get_filtered_iocs
 from app.datamgmt.case.case_iocs_db import add_ioc
@@ -41,7 +47,6 @@ from app.datamgmt.case.case_iocs_db import delete_ioc_comment
 from app.datamgmt.case.case_iocs_db import get_case_ioc_comment
 from app.datamgmt.case.case_iocs_db import get_case_ioc_comments
 from app.datamgmt.case.case_iocs_db import get_detailed_iocs
-from app.datamgmt.case.case_iocs_db import get_ioc
 from app.datamgmt.case.case_iocs_db import get_ioc_links
 from app.datamgmt.case.case_iocs_db import get_ioc_type_id
 from app.datamgmt.case.case_iocs_db import get_tlps_dict
@@ -59,11 +64,6 @@ from app.util import ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success
-from app.business.iocs import iocs_create
-from app.business.iocs import iocs_update
-from app.business.iocs import iocs_delete
-from app.business.errors import BusinessProcessingError
-from app.business.errors import PermissionDeniedError
 
 case_ioc_rest_blueprint = Blueprint('case_ioc_rest', __name__)
 
@@ -318,7 +318,7 @@ def delete_case_ioc(identifier):
 @ac_api_requires()
 def deprecated_case_view_ioc(cur_id, caseid):
     ioc_schema = IocSchema()
-    ioc = get_ioc(cur_id)
+    ioc = iocs_get(cur_id)
     if not ioc:
         return response_error('Invalid IOC identifier')
 
@@ -329,7 +329,7 @@ def deprecated_case_view_ioc(cur_id, caseid):
 @ac_api_requires()
 def get_case_ioc(identifier):
     ioc_schema = IocSchema()
-    ioc = get_ioc(identifier)
+    ioc = iocs_get(identifier)
     if not ioc:
         return response_api_not_found()
     if not ac_fast_check_current_user_has_case_access(ioc.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
@@ -367,7 +367,7 @@ def case_comment_ioc_list(cur_id, caseid):
 @ac_api_requires()
 def case_comment_ioc_add(cur_id, caseid):
     try:
-        ioc = get_ioc(cur_id)
+        ioc = iocs_get(cur_id)
         if not ioc:
             return response_error('Invalid ioc ID')
 

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -297,6 +297,7 @@ def deprecated_case_delete_ioc(cur_id, caseid):
     except BusinessProcessingError as e:
         return response_error(e.get_message())
 
+
 @case_ioc_rest_blueprint.route('/api/v2/iocs/<int:identifier>', methods=['DELETE'])
 @ac_api_requires()
 def delete_case_ioc(identifier):

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -59,7 +59,8 @@ from app.models import Tlp
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CommentSchema
 from app.schema.marshables import IocSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -172,16 +172,16 @@ def deprecated_case_add_ioc(caseid):
         return response_error(e.get_message(), data=e.get_data())
 
 
-@case_ioc_rest_blueprint.route('/api/v2/cases/<int:case_identifier>/iocs', methods=['POST'])
+@case_ioc_rest_blueprint.route('/api/v2/cases/<int:identifier>/iocs', methods=['POST'])
 @ac_api_requires()
-def case_add_ioc(case_identifier):
-    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
-        return ac_api_return_access_denied(caseid=case_identifier)
+def case_add_ioc(identifier):
+    if not ac_fast_check_current_user_has_case_access(identifier, [CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=identifier)
 
     ioc_schema = IocSchema()
 
     try:
-        ioc, _ = iocs_create(request.get_json(), case_identifier)
+        ioc, _ = iocs_create(request.get_json(), identifier)
         return response_api_created(ioc_schema.dump(ioc))
     except BusinessProcessingError as e:
         log.error(e)
@@ -297,12 +297,12 @@ def deprecated_case_delete_ioc(cur_id, caseid):
     except BusinessProcessingError as e:
         return response_error(e.get_message())
 
-@case_ioc_rest_blueprint.route('/api/v2/iocs/<int:cur_id>', methods=['DELETE'])
+@case_ioc_rest_blueprint.route('/api/v2/iocs/<int:identifier>', methods=['DELETE'])
 @ac_api_requires()
-def delete_case_ioc(cur_id):
+def delete_case_ioc(identifier):
     try:
 
-        iocs_delete(cur_id)
+        iocs_delete(identifier)
         return response_api_deleted()
 
     except PermissionDeniedError:

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -322,14 +322,17 @@ def deprecated_case_view_ioc(cur_id, caseid):
 
 
 @case_ioc_rest_blueprint.route('/api/v2/iocs/<int:identifier>', methods=['GET'])
-@ac_requires_case_access(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def get_case_ioc(identifier):
     ioc_schema = IocSchema()
     ioc = get_ioc(identifier)
     if not ioc:
+        # TODO should be response_api_not_found here => add a test
         return response_api_error('Invalid IOC identifier')
+    if not ac_fast_check_current_user_has_case_access(ioc.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=ioc.case_id)
 
+    # TODO should be reponse_api_success here => add a test
     return response_api_created(ioc_schema.dump(ioc))
 
 

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -332,7 +332,7 @@ def get_case_ioc(identifier):
         return ac_api_return_access_denied(caseid=ioc.case_id)
 
     # TODO should be reponse_api_success here => add a test
-    return response_api_created(ioc_schema.dump(ioc))
+    return response_api_success(ioc_schema.dump(ioc))
 
 
 @case_ioc_rest_blueprint.route('/case/ioc/update/<int:cur_id>', methods=['POST'])

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -167,14 +167,14 @@ def deprecated_case_add_ioc(caseid):
         return response_error(e.get_message(), data=e.get_data())
 
 
-@case_ioc_rest_blueprint.route('/api/v2/cases/<int:caseid>/iocs', methods=['POST'])
+@case_ioc_rest_blueprint.route('/api/v2/cases/<int:case_identifier>/iocs', methods=['POST'])
 @ac_requires_case_access(CaseAccessLevel.full_access)
 @ac_api_requires()
-def case_add_ioc(caseid):
+def case_add_ioc(case_identifier):
     ioc_schema = IocSchema()
 
     try:
-        ioc, _ = iocs_create(request.get_json(), caseid)
+        ioc, _ = iocs_create(request.get_json(), case_identifier)
         return response_api_created(ioc_schema.dump(ioc))
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -136,7 +136,6 @@ def list_ioc(case_identifier):
         'iocs': iocs,
         'last_page': filtered_iocs.pages,
         'current_page': filtered_iocs.page,
-        'state': get_ioc_state(caseid=case_identifier),
         'next_page': filtered_iocs.next_num if filtered_iocs.has_next else None,
     }
 

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -27,7 +27,7 @@ from flask_login import current_user
 
 from app import db
 from app.blueprints.rest.case_comments import case_comment_update
-from app.blueprints.rest.endpoints import response_api_deleted
+from app.blueprints.rest.endpoints import response_api_deleted, response_api_not_found
 from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.endpoints import response_api_error
@@ -327,8 +327,7 @@ def get_case_ioc(identifier):
     ioc_schema = IocSchema()
     ioc = get_ioc(identifier)
     if not ioc:
-        # TODO should be response_api_not_found here => add a test
-        return response_api_error('Invalid IOC identifier')
+        return response_api_not_found()
     if not ac_fast_check_current_user_has_case_access(ioc.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=ioc.case_id)
 

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -52,8 +52,7 @@ from app.schema.marshables import CaseNoteDirectorySchema
 from app.schema.marshables import CaseNoteRevisionSchema
 from app.schema.marshables import CaseNoteSchema
 from app.schema.marshables import CommentSchema
-from app.util import ac_requires_case_identifier
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import endpoint_removed
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -52,7 +52,8 @@ from app.schema.marshables import CaseNoteDirectorySchema
 from app.schema.marshables import CaseNoteRevisionSchema
 from app.schema.marshables import CaseNoteSchema
 from app.schema.marshables import CommentSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import endpoint_removed
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -67,8 +67,7 @@ from app.schema.marshables import TaskLogSchema
 from app.schema.marshables import CaseSchema
 from app.schema.marshables import CaseDetailsSchema
 from app.schema.marshables import CaseSchemaForAPIV2
-from app.util import ac_requires_case_identifier
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import add_obj_history_entry
 from app.util import ac_api_return_access_denied
 from app.util import response_error

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -440,7 +440,6 @@ def case_routes_get(identifier):
     return response_api_success(CaseSchemaForAPIV2().dump(case))
 
 
-
 @case_rest_blueprint.route('/api/v2/cases/<int:identifier>', methods=['DELETE'])
 @ac_api_requires(Permissions.standard_user)
 def case_routes_delete(identifier):

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -70,7 +70,6 @@ from app.schema.marshables import CaseDetailsSchema
 from app.schema.marshables import CaseSchemaForAPIV2
 from app.util import ac_requires_case_identifier
 from app.util import ac_api_requires
-from app.util import ac_requires_case_access
 from app.util import add_obj_history_entry
 from app.util import ac_api_return_access_denied
 from app.util import response_error

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -427,7 +427,7 @@ def get_cases() -> Response:
     return response_api_success(data=cases)
 
 
-@case_rest_blueprint.route('/api/v2/cases/<int:identifier>')
+@case_rest_blueprint.route('/api/v2/cases/<int:identifier>', methods=['GET'])
 @ac_api_requires()
 def case_routes_get(identifier):
     case = get_case(identifier)

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -429,11 +429,11 @@ def get_cases() -> Response:
     return response_api_success(data=cases)
 
 
-@case_rest_blueprint.route('/api/v2/cases/<int:identifier>')
+@case_rest_blueprint.route('/api/v2/cases/<int:case_identifier>')
 @ac_requires_case_access(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
-def case_routes_get(identifier):
-    case = get_case(identifier)
+def case_routes_get(case_identifier):
+    case = get_case(case_identifier)
     if not case:
         return response_api_not_found()
     return response_api_success(CaseSchemaForAPIV2().dump(case))

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -67,7 +67,8 @@ from app.schema.marshables import TaskLogSchema
 from app.schema.marshables import CaseSchema
 from app.schema.marshables import CaseDetailsSchema
 from app.schema.marshables import CaseSchemaForAPIV2
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
 from app.util import ac_api_return_access_denied
 from app.util import response_error

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -429,14 +429,14 @@ def get_cases() -> Response:
     return response_api_success(data=cases)
 
 
-@case_rest_blueprint.route('/api/v2/cases/<int:case_identifier>')
+@case_rest_blueprint.route('/api/v2/cases/<int:identifier>')
 @ac_api_requires()
-def case_routes_get(case_identifier):
-    case = get_case(case_identifier)
+def case_routes_get(identifier):
+    case = get_case(identifier)
     if not case:
         return response_api_not_found()
-    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
-        return ac_api_return_access_denied(caseid=case_identifier)
+    if not ac_fast_check_current_user_has_case_access(identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=identifier)
     return response_api_success(CaseSchemaForAPIV2().dump(case))
 
 

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -183,8 +183,8 @@ def case_edit_task(cur_id, caseid):
 @ac_api_requires()
 def deprecated_case_delete_task(cur_id, caseid):
     try:
-        msg = tasks_delete(cur_id)
-        return response_success(msg)
+        tasks_delete(cur_id)
+        return response_success('Task deleted')
     except BusinessProcessingError as e:
         return response_error(e.get_message())
 

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -52,8 +52,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseTaskSchema
 from app.schema.marshables import CommentSchema
-from app.util import ac_requires_case_identifier
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -157,12 +157,11 @@ def deprecated_case_task_view(cur_id, caseid):
 def case_task_view(identifier):
     try:
         task = tasks_get(identifier)
+        if not ac_fast_check_current_user_has_case_access(task.task_case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=task.task_case_id)
 
         task_schema = CaseTaskSchema()
         return response_api_created(task_schema.dump(task))
-    except PermissionDeniedError:
-        return ac_api_return_access_denied()
-
     except ObjectNotFoundError:
         return response_api_not_found()
 

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -148,11 +148,11 @@ def deprecated_case_task_view(cur_id, caseid):
     return response_success(data=task_schema.dump(task))
 
 
-@case_tasks_rest_blueprint.route('/api/v2/tasks/<int:cur_id>', methods=['GET'])
+@case_tasks_rest_blueprint.route('/api/v2/tasks/<int:identifier>', methods=['GET'])
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
-def case_task_view(cur_id, caseid):
-    task = get_task_with_assignees(task_id=cur_id)
+def case_task_view(identifier, caseid):
+    task = get_task_with_assignees(task_id=identifier)
     if not task:
         return response_api_error('Invalid task ID for this case')
 

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -184,19 +184,20 @@ def case_edit_task(cur_id, caseid):
 @ac_api_requires()
 def deprecated_case_delete_task(cur_id, caseid):
     try:
-        msg = tasks_delete(cur_id, caseid)
+        msg = tasks_delete(cur_id)
         return response_success(msg)
     except BusinessProcessingError as e:
         return response_error(e.get_message())
 
 
 @case_tasks_rest_blueprint.route('/api/v2/tasks/<int:identifier>', methods=['DELETE'])
-@ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
-def case_delete_task(identifier, caseid):
+def case_delete_task(identifier):
     try:
-        tasks_delete(identifier, caseid)
+        tasks_delete(identifier)
         return response_api_deleted()
+    except PermissionDeniedError:
+        return ac_api_return_access_denied()
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
 

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -52,7 +52,8 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseTaskSchema
 from app.schema.marshables import CommentSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -184,12 +184,12 @@ def deprecated_case_delete_task(cur_id, caseid):
         return response_error(e.get_message())
 
 
-@case_tasks_rest_blueprint.route('/api/v2/tasks/<int:cur_id>', methods=['DELETE'])
+@case_tasks_rest_blueprint.route('/api/v2/tasks/<int:identifier>', methods=['DELETE'])
 @ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
-def case_delete_task(cur_id, caseid):
+def case_delete_task(identifier, caseid):
     try:
-        tasks_delete(cur_id, caseid)
+        tasks_delete(identifier, caseid)
         return response_api_deleted()
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -43,6 +43,7 @@ from app.datamgmt.case.case_tasks_db import get_tasks_status
 from app.datamgmt.case.case_tasks_db import get_tasks_with_assignees
 from app.datamgmt.case.case_tasks_db import update_task_status
 from app.datamgmt.states import get_tasks_state
+from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
@@ -50,6 +51,7 @@ from app.schema.marshables import CaseTaskSchema
 from app.schema.marshables import CommentSchema
 from app.util import ac_requires_case_identifier
 from app.util import ac_api_requires
+from app.util import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success
 
@@ -90,7 +92,7 @@ def case_get_tasks_state(caseid):
 @ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_task_status_update(cur_id, caseid):
-    task = get_task(task_id=cur_id, caseid=caseid)
+    task = get_task(task_id=cur_id)
     if not task:
         return response_error("Invalid task ID for this case")
 
@@ -118,13 +120,15 @@ def deprecated_case_add_task(caseid):
         return response_error(e.get_message(), data=e.get_data())
 
 
-@case_tasks_rest_blueprint.route('/api/v2/cases/<int:caseid>/tasks', methods=['POST'])
-@ac_requires_case_identifier(CaseAccessLevel.full_access)
+@case_tasks_rest_blueprint.route('/api/v2/cases/<int:identifier>/tasks', methods=['POST'])
 @ac_api_requires()
-def case_add_task(caseid):
+def case_add_task(identifier):
+    if not ac_fast_check_current_user_has_case_access(identifier, [CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=identifier)
+
     task_schema = CaseTaskSchema()
     try:
-        case, _ = tasks_create(caseid, request.get_json())
+        _, case = tasks_create(identifier, request.get_json())
         return response_api_created(task_schema.dump(case))
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
@@ -135,9 +139,9 @@ def case_add_task(caseid):
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def deprecated_case_task_view(cur_id, caseid):
-    task = get_task_with_assignees(task_id=cur_id, case_id=caseid)
+    task = get_task_with_assignees(task_id=cur_id)
     if not task:
-        return response_error("Invalid task ID for this case")
+        return response_error('Invalid task ID for this case')
 
     task_schema = CaseTaskSchema()
 
@@ -148,9 +152,9 @@ def deprecated_case_task_view(cur_id, caseid):
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_task_view(cur_id, caseid):
-    task = get_task_with_assignees(task_id=cur_id, case_id=caseid)
+    task = get_task_with_assignees(task_id=cur_id)
     if not task:
-        return response_api_error("Invalid task ID for this case")
+        return response_api_error('Invalid task ID for this case')
 
     task_schema = CaseTaskSchema()
 
@@ -209,7 +213,7 @@ def case_comment_task_list(cur_id, caseid):
 def case_comment_task_add(cur_id, caseid):
 
     try:
-        task = get_task(cur_id, caseid=caseid)
+        task = get_task(cur_id)
         if not task:
             return response_error('Invalid task ID')
 

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -66,8 +66,7 @@ from app.models.models import EventCategory
 from app.models.models import Ioc
 from app.schema.marshables import CommentSchema
 from app.schema.marshables import EventSchema
-from app.util import ac_requires_case_identifier
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import add_obj_history_entry
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -66,7 +66,8 @@ from app.models.models import EventCategory
 from app.models.models import Ioc
 from app.schema.marshables import CommentSchema
 from app.schema.marshables import EventSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/context_routes.py
+++ b/source/app/blueprints/rest/context_routes.py
@@ -28,7 +28,7 @@ from app.datamgmt.context.context_db import ctx_search_user_cases
 from app.models.authorization import Permissions
 from app.models.cases import Cases
 from app.models.models import Client
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import not_authenticated_redirection_url
 from app.util import response_success
 

--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -42,8 +42,7 @@ from app.models.models import TaskStatus
 from app.schema.marshables import CaseTaskSchema
 from app.schema.marshables import CaseDetailsSchema
 from app.schema.marshables import GlobalTasksSchema
-from app.util import ac_api_requires
-from app.util import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -42,7 +42,8 @@ from app.models.models import TaskStatus
 from app.schema.marshables import CaseTaskSchema
 from app.schema.marshables import CaseDetailsSchema
 from app.schema.marshables import GlobalTasksSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/datastore_routes.py
+++ b/source/app/blueprints/rest/datastore_routes.py
@@ -46,8 +46,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import DSFileSchema
 from app.schema.marshables import DSPathSchema
-from app.util import ac_api_requires
-from app.util import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import add_obj_history_entry
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/datastore_routes.py
+++ b/source/app/blueprints/rest/datastore_routes.py
@@ -46,7 +46,8 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import DSFileSchema
 from app.schema.marshables import DSPathSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/dim_tasks_routes.py
+++ b/source/app/blueprints/rest/dim_tasks_routes.py
@@ -37,8 +37,7 @@ from app.models import Ioc
 from app.models import Notes
 from app.models.alerts import Alert
 from app.models.authorization import CaseAccessLevel
-from app.util import ac_api_requires
-from app.util import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import response_error
 from app.util import response_success
 from iris_interface.IrisInterfaceStatus import IIStatus

--- a/source/app/blueprints/rest/dim_tasks_routes.py
+++ b/source/app/blueprints/rest/dim_tasks_routes.py
@@ -37,7 +37,8 @@ from app.models import Ioc
 from app.models import Notes
 from app.models.alerts import Alert
 from app.models.authorization import CaseAccessLevel
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 from iris_interface.IrisInterfaceStatus import IIStatus

--- a/source/app/blueprints/rest/filters_routes.py
+++ b/source/app/blueprints/rest/filters_routes.py
@@ -25,7 +25,7 @@ from app.datamgmt.filters.filters_db import get_filter_by_id
 from app.datamgmt.filters.filters_db import list_filters_by_type
 from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import SavedFilterSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_success
 from app.util import response_error
 

--- a/source/app/blueprints/rest/manage/manage_access_control_routes.py
+++ b/source/app/blueprints/rest/manage/manage_access_control_routes.py
@@ -24,7 +24,7 @@ from app.iris_engine.access_control.utils import ac_recompute_effective_ac
 from app.iris_engine.access_control.utils import ac_trace_effective_user_permissions
 from app.iris_engine.access_control.utils import ac_trace_user_effective_cases_access_2
 from app.models.authorization import Permissions
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_success
 
 manage_ac_rest_blueprint = Blueprint('access_control_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_alerts_status_routes.py
+++ b/source/app/blueprints/rest/manage/manage_alerts_status_routes.py
@@ -25,7 +25,7 @@ from app.datamgmt.alerts.alerts_db import get_alert_resolution_list
 from app.datamgmt.alerts.alerts_db import search_alert_resolution_by_name
 from app.schema.marshables import AlertStatusSchema
 from app.schema.marshables import AlertResolutionSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_analysis_status_routes.py
+++ b/source/app/blueprints/rest/manage/manage_analysis_status_routes.py
@@ -24,7 +24,7 @@ from app.datamgmt.case.case_assets_db import get_case_outcome_status_dict
 from app.datamgmt.manage.manage_case_objs import search_analysis_status_by_name
 from app.models.models import AnalysisStatus
 from app.schema.marshables import AnalysisStatusSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_assets_routes.py
+++ b/source/app/blueprints/rest/manage/manage_assets_routes.py
@@ -24,7 +24,7 @@ from app.datamgmt.manage.manage_assets_db import get_filtered_assets
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_assets_type_routes.py
+++ b/source/app/blueprints/rest/manage/manage_assets_type_routes.py
@@ -31,7 +31,7 @@ from app.models.authorization import Permissions
 from app.models.models import AssetsType
 from app.models.models import CaseAssets
 from app.schema.marshables import AssetTypeSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_attributes_routes.py
+++ b/source/app/blueprints/rest/manage/manage_attributes_routes.py
@@ -24,7 +24,7 @@ from app.datamgmt.manage.manage_attribute_db import update_all_attributes
 from app.datamgmt.manage.manage_attribute_db import validate_attribute
 from app.models.authorization import Permissions
 from app.models.models import CustomAttribute
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_case_classifications_routes.py
+++ b/source/app/blueprints/rest/manage/manage_case_classifications_routes.py
@@ -29,7 +29,7 @@ from app.datamgmt.manage.manage_case_classifications_db import search_classifica
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseClassificationSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_case_state.py
+++ b/source/app/blueprints/rest/manage/manage_case_state.py
@@ -29,7 +29,7 @@ from app.datamgmt.manage.manage_case_state_db import get_cases_using_state
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseStateSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_case_templates_routes.py
+++ b/source/app/blueprints/rest/manage/manage_case_templates_routes.py
@@ -31,8 +31,7 @@ from app.models import CaseTemplate
 from app.models.authorization import Permissions
 from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import CaseTemplateSchema
-from app.util import ac_api_requires
-from app.util import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_case_templates_routes.py
+++ b/source/app/blueprints/rest/manage/manage_case_templates_routes.py
@@ -31,7 +31,8 @@ from app.models import CaseTemplate
 from app.models.authorization import Permissions
 from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import CaseTemplateSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -58,7 +58,6 @@ from app.util import response_success
 from app.business.cases import cases_delete
 from app.business.cases import cases_update
 from app.business.cases import cases_create
-from app.business.permissions import permissions_check_current_user_has_some_case_access
 from app.business.errors import BusinessProcessingError
 
 manage_cases_rest_blueprint = Blueprint('manage_case_rest', __name__)
@@ -267,7 +266,8 @@ def api_list_case():
 @manage_cases_rest_blueprint.route('/manage/cases/update/<int:cur_id>', methods=['POST'])
 @ac_api_requires(Permissions.standard_user)
 def update_case_info(cur_id):
-    permissions_check_current_user_has_some_case_access(cur_id, [CaseAccessLevel.full_access])
+    if not ac_fast_check_current_user_has_case_access(cur_id, [CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=cur_id)
 
     case_schema = CaseSchema()
     try:

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -50,8 +50,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import CaseSchema
 from app.schema.marshables import CaseDetailsSchema
 from app.util import add_obj_history_entry
-from app.util import ac_api_requires
-from app.util import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -50,7 +50,8 @@ from app.models.authorization import Permissions
 from app.schema.marshables import CaseSchema
 from app.schema.marshables import CaseDetailsSchema
 from app.util import add_obj_history_entry
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/manage/manage_customers_routes.py
+++ b/source/app/blueprints/rest/manage/manage_customers_routes.py
@@ -42,7 +42,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import ContactSchema
 from app.schema.marshables import CustomerSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import ac_api_requires_client_access
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/manage/manage_event_categories_routes.py
+++ b/source/app/blueprints/rest/manage/manage_event_categories_routes.py
@@ -21,7 +21,7 @@ from flask import Blueprint, request
 from app.datamgmt.manage.manage_case_objs import search_event_category_by_name
 from app.models.models import EventCategory
 from app.schema.marshables import EventCategorySchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_evidence_types_routes.py
+++ b/source/app/blueprints/rest/manage/manage_evidence_types_routes.py
@@ -29,7 +29,7 @@ from app.datamgmt.manage.manage_evidence_types_db import verify_evidence_type_in
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import EvidenceTypeSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_groups.py
+++ b/source/app/blueprints/rest/manage/manage_groups.py
@@ -43,7 +43,7 @@ from app.iris_engine.access_control.utils import ac_recompute_effective_ac_from_
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import AuthorizationGroupSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/manage/manage_ioc_types_routes.py
+++ b/source/app/blueprints/rest/manage/manage_ioc_types_routes.py
@@ -28,7 +28,7 @@ from app.models import Ioc
 from app.models import IocType
 from app.models.authorization import Permissions
 from app.schema.marshables import IocTypeSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_modules_routes.py
+++ b/source/app/blueprints/rest/manage/manage_modules_routes.py
@@ -38,7 +38,7 @@ from app.iris_engine.module_handler.module_handler import iris_update_hooks
 from app.iris_engine.module_handler.module_handler import register_module
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 from app.schema.marshables import IrisModuleSchema

--- a/source/app/blueprints/rest/manage/manage_server_settings_routes.py
+++ b/source/app/blueprints/rest/manage/manage_server_settings_routes.py
@@ -30,7 +30,7 @@ from app.iris_engine.updater.updater import setup_periodic_update_checks
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import ServerSettingsSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 from dictdiffer import diff

--- a/source/app/blueprints/rest/manage/manage_severities_routes.py
+++ b/source/app/blueprints/rest/manage/manage_severities_routes.py
@@ -23,7 +23,7 @@ from app.datamgmt.manage.manage_common import get_severity_by_id
 from app.datamgmt.manage.manage_common import get_severities_list
 from app.datamgmt.manage.manage_common import search_severity_by_name
 from app.schema.marshables import SeveritySchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_tags.py
+++ b/source/app/blueprints/rest/manage/manage_tags.py
@@ -22,7 +22,7 @@ from werkzeug import Response
 from app import app
 from app.datamgmt.manage.manage_tags_db import get_filtered_tags
 from app.schema.marshables import TagsSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import AlchemyEncoder
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_task_status_routes.py
+++ b/source/app/blueprints/rest/manage/manage_task_status_routes.py
@@ -19,7 +19,7 @@
 from flask import Blueprint
 
 from app.models.models import TaskStatus
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_templates_routes.py
+++ b/source/app/blueprints/rest/manage/manage_templates_routes.py
@@ -36,7 +36,7 @@ from app.models.authorization import User
 from app.models.models import CaseTemplateReport
 from app.models.models import Languages
 from app.models.models import ReportType
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_tlps_routes.py
+++ b/source/app/blueprints/rest/manage/manage_tlps_routes.py
@@ -19,7 +19,7 @@
 from flask import Blueprint
 
 from app.models import Tlp
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_users.py
+++ b/source/app/blueprints/rest/manage/manage_users.py
@@ -45,7 +45,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import UserSchema
 from app.schema.marshables import BasicUserSchema
 from app.schema.marshables import UserFullSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import ac_api_return_access_denied
 from app.util import is_authentication_local
 from app.util import response_error

--- a/source/app/blueprints/rest/overview_routes.py
+++ b/source/app/blueprints/rest/overview_routes.py
@@ -21,7 +21,7 @@ from flask import request
 from flask_login import current_user
 
 from app.datamgmt.overview.overview_db import get_overview_db
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_success
 
 overview_rest_blueprint = Blueprint('overview_rest', __name__)

--- a/source/app/blueprints/rest/profile_routes.py
+++ b/source/app/blueprints/rest/profile_routes.py
@@ -34,7 +34,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import UserSchema
 from app.schema.marshables import BasicUserSchema
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 from app.util import endpoint_removed

--- a/source/app/blueprints/rest/reports_route.py
+++ b/source/app/blueprints/rest/reports_route.py
@@ -32,8 +32,7 @@ from app.models import CaseTemplateReport
 from app.models.authorization import CaseAccessLevel
 
 from app.util import FileRemover
-from app.util import ac_api_requires
-from app.util import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
 from app.util import response_error
 
 reports_rest_blueprint = Blueprint('reports_rest', __name__)

--- a/source/app/blueprints/rest/reports_route.py
+++ b/source/app/blueprints/rest/reports_route.py
@@ -31,8 +31,6 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models import CaseTemplateReport
 from app.models.authorization import CaseAccessLevel
 
-from app.business.permissions import permissions_check_current_user_has_some_case_access_stricter
-
 from app.util import FileRemover
 from app.util import ac_api_requires
 from app.util import ac_requires_case_identifier
@@ -45,12 +43,8 @@ file_remover = FileRemover()
 
 @reports_rest_blueprint.route('/case/report/generate-activities/<int:report_id>', methods=['GET'])
 @ac_api_requires()
-@ac_requires_case_identifier()
+@ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 def download_case_activity(report_id, caseid):
-    # TODO should we move this up
-    # and replace by annotation @ac_api_case_requires(CaseAccessLevel.read_only, CaseAccessLevel.full_access)?
-    permissions_check_current_user_has_some_case_access_stricter(
-        [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
 
     call_modules_hook('on_preload_activities_report_create', data=report_id, caseid=caseid)
     if report_id:
@@ -95,12 +89,8 @@ def download_case_activity(report_id, caseid):
 
 @reports_rest_blueprint.route('/case/report/generate-investigation/<int:report_id>', methods=['GET'])
 @ac_api_requires()
-@ac_requires_case_identifier()
+@ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 def generate_report(report_id, caseid):
-    # TODO should we move this up
-    # and replace by annotation @ac_api_case_requires(CaseAccessLevel.read_only, CaseAccessLevel.full_access)?
-    permissions_check_current_user_has_some_case_access_stricter(
-        [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
 
     safe_mode = False
 

--- a/source/app/blueprints/rest/reports_route.py
+++ b/source/app/blueprints/rest/reports_route.py
@@ -32,7 +32,8 @@ from app.models import CaseTemplateReport
 from app.models.authorization import CaseAccessLevel
 
 from app.util import FileRemover
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 
 reports_rest_blueprint = Blueprint('reports_rest', __name__)

--- a/source/app/blueprints/rest/search_routes.py
+++ b/source/app/blueprints/rest/search_routes.py
@@ -29,7 +29,7 @@ from app.models.models import Ioc
 from app.models.models import IocType
 from app.models.models import Notes
 from app.models.models import Tlp
-from app.util import ac_api_requires
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_success
 
 search_rest_blueprint = Blueprint('search_rest', __name__)

--- a/source/app/blueprints/socket_io_event_handlers/case_event_handlers.py
+++ b/source/app/blueprints/socket_io_event_handlers/case_event_handlers.py
@@ -22,7 +22,7 @@ from flask_socketio import emit
 from flask_socketio import join_room
 
 from app import socket_io
-from app.util import ac_socket_requires
+from app.blueprints.access_controls import ac_socket_requires
 from app.models.authorization import CaseAccessLevel
 
 

--- a/source/app/blueprints/socket_io_event_handlers/case_notes_event_handlers.py
+++ b/source/app/blueprints/socket_io_event_handlers/case_notes_event_handlers.py
@@ -22,7 +22,7 @@ from flask_socketio import emit
 from flask_socketio import join_room
 
 from app import socket_io
-from app.util import ac_socket_requires
+from app.blueprints.access_controls import ac_socket_requires
 from app.models.authorization import CaseAccessLevel
 
 

--- a/source/app/blueprints/socket_io_event_handlers/collab.py
+++ b/source/app/blueprints/socket_io_event_handlers/collab.py
@@ -1,0 +1,29 @@
+#  IRIS Source Code
+#  Copyright (C) 2024 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+from flask_socketio import join_room
+
+from app import socket_io
+from app.blueprints.access_controls import ac_socket_requires
+from app.models.authorization import CaseAccessLevel
+
+
+@socket_io.on('join-case-obj-notif')
+@ac_socket_requires(CaseAccessLevel.full_access)
+def socket_join_case_obj_notif(data):
+    room = data['channel']
+    join_room(room=room)

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -69,6 +69,7 @@ def assets_delete(identifier):
     track_activity(f'removed asset ID {asset.asset_name}', caseid=asset.case_id)
     return 'Deleted'
 
+
 def assets_get(identifier):
     asset = get_asset(identifier)
     if not asset:
@@ -76,6 +77,7 @@ def assets_get(identifier):
     permissions_check_current_user_has_some_case_access(asset.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
 
     return asset
+
 
 def assets_get_detailed(identifier):
     asset = assets_get(identifier)

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -28,6 +28,7 @@ from app.datamgmt.case.case_assets_db import get_linked_iocs_finfo_from_asset
 from app.datamgmt.case.case_assets_db import delete_asset
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
+from app.models import CaseAssets
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
 
@@ -67,7 +68,7 @@ def assets_delete(identifier):
     track_activity(f'removed asset ID {asset.asset_name}', caseid=asset.case_id)
 
 
-def assets_get(identifier):
+def assets_get(identifier) -> CaseAssets:
     asset = get_asset(identifier)
     if not asset:
         raise BusinessProcessingError('Invalid asset ID for this case')

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -74,7 +74,6 @@ def assets_get(identifier):
     asset = get_asset(identifier)
     if not asset:
         raise BusinessProcessingError('Invalid asset ID for this case')
-    permissions_check_current_user_has_some_case_access(asset.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
 
     return asset
 

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -20,7 +20,6 @@ from flask_login import current_user
 from marshmallow.exceptions import ValidationError
 
 from app.business.errors import BusinessProcessingError
-from app.business.permissions import permissions_check_current_user_has_some_case_access
 from app.datamgmt.case.case_assets_db import get_asset
 from app.datamgmt.case.case_assets_db import create_asset
 from app.datamgmt.case.case_assets_db import set_ioc_links
@@ -29,7 +28,6 @@ from app.datamgmt.case.case_assets_db import delete_asset
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.models import CaseAssets
-from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
 
 

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -58,9 +58,7 @@ def assets_create(case_identifier, request_json):
 
 def assets_delete(identifier):
     call_modules_hook('on_preload_asset_delete', data=identifier)
-    asset = get_asset(identifier)
-    if not asset:
-        raise BusinessProcessingError('Invalid asset ID for this case')
+    asset = assets_get(identifier)
     permissions_check_current_user_has_some_case_access(asset.case_id, [CaseAccessLevel.full_access])
 
     # Deletes an asset and the potential links with the IoCs from the database

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -65,7 +65,6 @@ def assets_delete(identifier):
     delete_asset(identifier, asset.case_id)
     call_modules_hook('on_postload_asset_delete', data=identifier, caseid=asset.case_id)
     track_activity(f'removed asset ID {asset.asset_name}', caseid=asset.case_id)
-    return 'Deleted'
 
 
 def assets_get(identifier):

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -57,14 +57,11 @@ def assets_create(case_identifier, request_json):
     raise BusinessProcessingError("Unable to create asset for internal reasons")
 
 
-def assets_delete(identifier):
-    call_modules_hook('on_preload_asset_delete', data=identifier)
-    asset = assets_get(identifier)
-    permissions_check_current_user_has_some_case_access(asset.case_id, [CaseAccessLevel.full_access])
-
+def assets_delete(asset: CaseAssets):
+    call_modules_hook('on_preload_asset_delete', data=asset.asset_id)
     # Deletes an asset and the potential links with the IoCs from the database
-    delete_asset(identifier, asset.case_id)
-    call_modules_hook('on_postload_asset_delete', data=identifier, caseid=asset.case_id)
+    delete_asset(asset.asset_id, asset.case_id)
+    call_modules_hook('on_postload_asset_delete', data=asset.asset_id, caseid=asset.case_id)
     track_activity(f'removed asset ID {asset.asset_name}', caseid=asset.case_id)
 
 

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -70,8 +70,6 @@ def assets_delete(identifier):
     return 'Deleted'
 
 
-from app import app
-
 def assets_get(identifier):
     asset_iocs = get_linked_iocs_finfo_from_asset(identifier)
     ioc_prefill = [row._asdict() for row in asset_iocs]
@@ -79,10 +77,10 @@ def assets_get(identifier):
     asset = get_asset(identifier)
     if not asset:
         raise BusinessProcessingError('Invalid asset ID for this case')
-    app.logger.error('-----------------------')
-    app.logger.error(f'Asset case identifier: {asset.case_id}')
     permissions_check_current_user_has_some_case_access(asset.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
 
-    data = _load.dump(asset)
+    # TODO this is a code smell: shouldn't have schemas in the business layer + the CaseAssetsSchema is instantiated twice
+    case_assets_schema = CaseAssetsSchema()
+    data = case_assets_schema.dump(asset)
     data['linked_ioc'] = ioc_prefill
     return data

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -69,18 +69,21 @@ def assets_delete(identifier):
     track_activity(f'removed asset ID {asset.asset_name}', caseid=asset.case_id)
     return 'Deleted'
 
-
 def assets_get(identifier):
-    asset_iocs = get_linked_iocs_finfo_from_asset(identifier)
-    ioc_prefill = [row._asdict() for row in asset_iocs]
-
     asset = get_asset(identifier)
     if not asset:
         raise BusinessProcessingError('Invalid asset ID for this case')
     permissions_check_current_user_has_some_case_access(asset.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
 
+    return asset
+
+def assets_get_detailed(identifier):
+    asset = assets_get(identifier)
+
     # TODO this is a code smell: shouldn't have schemas in the business layer + the CaseAssetsSchema is instantiated twice
     case_assets_schema = CaseAssetsSchema()
     data = case_assets_schema.dump(asset)
-    data['linked_ioc'] = ioc_prefill
+
+    asset_iocs = get_linked_iocs_finfo_from_asset(identifier)
+    data['linked_ioc'] = [row._asdict() for row in asset_iocs]
     return data

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -15,14 +15,20 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 from flask_login import current_user
 from marshmallow.exceptions import ValidationError
 
 from app.business.errors import BusinessProcessingError
-from app.datamgmt.case.case_assets_db import get_asset, create_asset, set_ioc_links, get_linked_iocs_finfo_from_asset
+from app.business.permissions import permissions_check_current_user_has_some_case_access
+from app.datamgmt.case.case_assets_db import get_asset
+from app.datamgmt.case.case_assets_db import create_asset
+from app.datamgmt.case.case_assets_db import set_ioc_links
+from app.datamgmt.case.case_assets_db import get_linked_iocs_finfo_from_asset
 from app.datamgmt.case.case_assets_db import delete_asset
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
+from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
 
 
@@ -37,10 +43,7 @@ def _load(request_data):
 def assets_create(case_identifier, request_json):
     request_data = call_modules_hook('on_preload_asset_create', data=request_json, caseid=case_identifier)
     asset = _load(request_data)
-    asset = create_asset(asset=asset,
-                         caseid=case_identifier,
-                         user_id=current_user.id
-                         )
+    asset = create_asset(asset=asset, caseid=case_identifier, user_id=current_user.id)
     if request_data.get('ioc_links'):
         errors, _ = set_ioc_links(request_data.get('ioc_links'), asset.asset_id)
         if errors:
@@ -48,28 +51,30 @@ def assets_create(case_identifier, request_json):
     asset = call_modules_hook('on_postload_asset_create', data=asset, caseid=case_identifier)
     if asset:
         track_activity(f"added asset \"{asset.asset_name}\"", caseid=case_identifier)
-        return "Asset added", asset
+        return 'Asset added', asset
 
     raise BusinessProcessingError("Unable to create asset for internal reasons")
 
 
-def assets_delete(identifier, case_identifier):
-    call_modules_hook('on_preload_asset_delete', data=identifier, caseid=case_identifier)
-    asset = get_asset(identifier, case_identifier)
+def assets_delete(identifier):
+    call_modules_hook('on_preload_asset_delete', data=identifier)
+    asset = get_asset(identifier)
     if not asset:
-        raise BusinessProcessingError("Invalid asset ID for this case")
+        raise BusinessProcessingError('Invalid asset ID for this case')
+    permissions_check_current_user_has_some_case_access(asset.case_id, [CaseAccessLevel.full_access])
+
     # Deletes an asset and the potential links with the IoCs from the database
-    delete_asset(identifier, case_identifier)
-    call_modules_hook('on_postload_asset_delete', data=identifier, caseid=case_identifier)
-    track_activity(f"removed asset ID {asset.asset_name}", caseid=case_identifier)
-    return "Deleted"
+    delete_asset(identifier, asset.case_id)
+    call_modules_hook('on_postload_asset_delete', data=identifier, caseid=asset.case_id)
+    track_activity(f'removed asset ID {asset.asset_name}', caseid=asset.case_id)
+    return 'Deleted'
 
 
 def assets_get(identifier, case_identifier):
     asset_iocs = get_linked_iocs_finfo_from_asset(identifier)
     ioc_prefill = [row._asdict() for row in asset_iocs]
 
-    asset = get_asset(identifier, case_identifier)
+    asset = get_asset(identifier)
     if not asset:
         raise BusinessProcessingError("Invalid asset ID for this case")
 

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -70,13 +70,18 @@ def assets_delete(identifier):
     return 'Deleted'
 
 
-def assets_get(identifier, case_identifier):
+from app import app
+
+def assets_get(identifier):
     asset_iocs = get_linked_iocs_finfo_from_asset(identifier)
     ioc_prefill = [row._asdict() for row in asset_iocs]
 
     asset = get_asset(identifier)
     if not asset:
-        raise BusinessProcessingError("Invalid asset ID for this case")
+        raise BusinessProcessingError('Invalid asset ID for this case')
+    app.logger.error('-----------------------')
+    app.logger.error(f'Asset case identifier: {asset.case_id}')
+    permissions_check_current_user_has_some_case_access(asset.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
 
     data = _load.dump(asset)
     data['linked_ioc'] = ioc_prefill

--- a/source/app/business/errors.py
+++ b/source/app/business/errors.py
@@ -44,7 +44,3 @@ class UnhandledBusinessError(BusinessProcessingError):
         self._data = data
         app.logger.exception(message)
         app.logger.exception(data)
-
-
-class PermissionDeniedError(Exception):
-    pass

--- a/source/app/business/errors.py
+++ b/source/app/business/errors.py
@@ -31,6 +31,12 @@ class BusinessProcessingError(Exception):
         return self._data
 
 
+class ObjectNotFoundError(BusinessProcessingError):
+
+    def __init__(self):
+        super().__init__('Object not found')
+
+
 class UnhandledBusinessError(BusinessProcessingError):
 
     def __init__(self, message, data=None):

--- a/source/app/business/errors.py
+++ b/source/app/business/errors.py
@@ -32,6 +32,7 @@ class BusinessProcessingError(Exception):
 
 
 class UnhandledBusinessError(BusinessProcessingError):
+
     def __init__(self, message, data=None):
         self._message = message
         self._data = data

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -44,7 +44,7 @@ def _load(request_data):
         raise BusinessProcessingError('Data error', e.messages)
 
 
-def iocs_get_by_identifier(ioc_identifier):
+def iocs_get(ioc_identifier):
     return get_ioc(ioc_identifier)
 
 

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -32,8 +32,6 @@ from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.business.errors import BusinessProcessingError
 from app.business.errors import ObjectNotFoundError
-from app.business.permissions import permissions_check_current_user_has_some_case_access
-from app.models.authorization import CaseAccessLevel
 from app.datamgmt.case.case_iocs_db import get_ioc
 
 

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -45,7 +45,7 @@ def _load(request_data):
         raise BusinessProcessingError('Data error', e.messages)
 
 
-def iocs_get(ioc_identifier):
+def iocs_get(ioc_identifier) -> Ioc:
     ioc = get_ioc(ioc_identifier)
     if not ioc:
         raise ObjectNotFoundError()
@@ -117,21 +117,20 @@ def iocs_update(identifier, request_json):
 
 
 def iocs_delete(identifier):
-
-    call_modules_hook('on_preload_ioc_delete', data=identifier)
     try:
         ioc = iocs_get(identifier)
     except ObjectNotFoundError:
         raise BusinessProcessingError('Not a valid IOC for this case')
-
     permissions_check_current_user_has_some_case_access(ioc.case_id, [CaseAccessLevel.full_access])
+
+    call_modules_hook('on_preload_ioc_delete', data=ioc.ioc_id)
 
     delete_ioc(ioc)
 
-    call_modules_hook('on_postload_ioc_delete', data=identifier, caseid=ioc.case_id)
+    call_modules_hook('on_postload_ioc_delete', data=ioc.ioc_id, caseid=ioc.case_id)
 
     track_activity(f'deleted IOC "{ioc.ioc_value}"', caseid=ioc.case_id)
-    return f'IOC {identifier} deleted'
+    return f'IOC {ioc.ioc_id} deleted'
 
 
 def iocs_exports_to_json(case_id):

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -116,13 +116,7 @@ def iocs_update(identifier, request_json):
         raise BusinessProcessingError('Unexpected error server-side', e)
 
 
-def iocs_delete(identifier):
-    try:
-        ioc = iocs_get(identifier)
-    except ObjectNotFoundError:
-        raise BusinessProcessingError('Not a valid IOC for this case')
-    permissions_check_current_user_has_some_case_access(ioc.case_id, [CaseAccessLevel.full_access])
-
+def iocs_delete(ioc: Ioc):
     call_modules_hook('on_preload_ioc_delete', data=ioc.ioc_id)
 
     delete_ioc(ioc)

--- a/source/app/business/iocs.py
+++ b/source/app/business/iocs.py
@@ -31,6 +31,8 @@ from app.schema.marshables import IocSchema
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.business.errors import BusinessProcessingError
+from app.business.permissions import permissions_check_current_user_has_some_case_access
+from app.models.authorization import CaseAccessLevel
 from app.datamgmt.case.case_iocs_db import get_ioc
 
 
@@ -117,6 +119,7 @@ def iocs_delete(identifier):
 
     if not ioc:
         raise BusinessProcessingError('Not a valid IOC for this case')
+    permissions_check_current_user_has_some_case_access(ioc.case_id, [CaseAccessLevel.full_access])
 
     delete_ioc(ioc)
 

--- a/source/app/business/permissions.py
+++ b/source/app/business/permissions.py
@@ -23,7 +23,7 @@ from flask import session
 from flask_login import current_user
 from flask import request
 
-from app.util import get_case_access
+from app.util import get_case_access_from_api
 from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.business.errors import PermissionDeniedError
@@ -48,7 +48,7 @@ def permissions_check_current_user_has_some_case_access(case_identifier, access_
 # When moving down permission checks from the REST layer into the business layer,
 # this method is used to replace annotation ac_api_case_requires
 def permissions_check_current_user_has_some_case_access_stricter(access_levels):
-    redir, caseid, has_access = get_case_access(request, access_levels, from_api=True)
+    redir, caseid, has_access = get_case_access_from_api(request, access_levels)
 
     # TODO: do we really want to keep the details of the errors, when permission is denied => more work, more complex code?
     if not caseid or redir:

--- a/source/app/business/permissions.py
+++ b/source/app/business/permissions.py
@@ -43,7 +43,8 @@ def permissions_check_current_user_has_some_case_access(case_identifier, access_
         _deny_permission()
 
 
-# TODO: really this and the previous method should be merged.
+# TODO: should remove this method and use permissions_check_current_user_has_some_case_access, only
+#       I am pretty sure the access checks are done with the wrong case identifier for graphql
 #       This one comes from ac_api_case_requires, whereas the other one comes from the way api_delete_case was written...
 # When moving down permission checks from the REST layer into the business layer,
 # this method is used to replace annotation ac_api_case_requires

--- a/source/app/business/tasks.py
+++ b/source/app/business/tasks.py
@@ -47,16 +47,13 @@ def _load(request_data):
 
 def tasks_delete(identifier):
     call_modules_hook('on_preload_task_delete', data=identifier)
-    task = get_task_with_assignees(task_id=identifier)
-    if not task:
-        raise BusinessProcessingError('Invalid task ID for this case')
+    task = tasks_get(identifier)
     permissions_check_current_user_has_some_case_access(task.task_case_id, [CaseAccessLevel.full_access])
 
     delete_task(identifier)
     update_tasks_state(caseid=task.task_case_id)
     call_modules_hook('on_postload_task_delete', data=identifier, caseid=task.task_case_id)
     track_activity(f'deleted task "{task.task_title}"')
-    return 'Task deleted'
 
 
 def tasks_create(case_identifier, request_json):

--- a/source/app/business/tasks.py
+++ b/source/app/business/tasks.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from flask_login import current_user
 
 from app import db
-from app.business.permissions import permissions_check_current_user_has_some_case_access
 from app.datamgmt.case.case_tasks_db import delete_task
 from app.datamgmt.case.case_tasks_db import add_task
 from app.datamgmt.case.case_tasks_db import update_task_assignees
@@ -31,7 +30,6 @@ from app.datamgmt.states import update_tasks_state
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.models import CaseTasks
-from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseTaskSchema
 from app.business.errors import BusinessProcessingError
 from app.business.errors import ObjectNotFoundError

--- a/source/app/business/tasks.py
+++ b/source/app/business/tasks.py
@@ -88,7 +88,6 @@ def tasks_get(identifier):
     task = get_task(identifier)
     if not task:
         raise ObjectNotFoundError()
-    permissions_check_current_user_has_some_case_access(task.task_case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
     return task
 
 

--- a/source/app/business/tasks.py
+++ b/source/app/business/tasks.py
@@ -91,6 +91,7 @@ def tasks_get(identifier):
     permissions_check_current_user_has_some_case_access(task.task_case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access])
     return task
 
+
 def tasks_update(current_identifier, case_identifier, request_json):
 
     task = get_task_with_assignees(task_id=current_identifier)

--- a/source/app/business/tasks.py
+++ b/source/app/business/tasks.py
@@ -42,7 +42,7 @@ def _load(request_data):
 
 def tasks_delete(identifier, context_case_identifier):
     call_modules_hook('on_preload_task_delete', data=identifier, caseid=context_case_identifier)
-    task = get_task_with_assignees(task_id=identifier, case_id=context_case_identifier)
+    task = get_task_with_assignees(task_id=identifier)
     if not task:
         raise BusinessProcessingError('Invalid task ID for this case')
     delete_task(identifier)
@@ -72,14 +72,14 @@ def tasks_create(case_identifier, request_json):
     ctask = call_modules_hook('on_postload_task_create', data=ctask, caseid=case_identifier)
 
     if ctask:
-        track_activity(f"added task \"{ctask.task_title}\"", caseid=case_identifier)
-        return "Task '{}' added".format(ctask.task_title), ctask
+        track_activity(f'added task "{ctask.task_title}"', caseid=case_identifier)
+        return f'Task "{ctask.task_title}" added', ctask
     raise BusinessProcessingError("Unable to create task for internal reasons")
 
 
 def tasks_update(current_identifier, case_identifier, request_json):
 
-    task = get_task_with_assignees(task_id=current_identifier, case_id=case_identifier)
+    task = get_task_with_assignees(task_id=current_identifier)
 
     if task:
         request_data = call_modules_hook('on_preload_task_update', data=request_json, caseid=case_identifier)

--- a/source/app/business/tasks.py
+++ b/source/app/business/tasks.py
@@ -45,15 +45,17 @@ def _load(request_data):
         raise BusinessProcessingError('Data error', e.messages)
 
 
-def tasks_delete(identifier, context_case_identifier):
-    call_modules_hook('on_preload_task_delete', data=identifier, caseid=context_case_identifier)
+def tasks_delete(identifier):
+    call_modules_hook('on_preload_task_delete', data=identifier)
     task = get_task_with_assignees(task_id=identifier)
     if not task:
         raise BusinessProcessingError('Invalid task ID for this case')
+    permissions_check_current_user_has_some_case_access(task.task_case_id, [CaseAccessLevel.full_access])
+
     delete_task(identifier)
-    update_tasks_state(caseid=context_case_identifier)
-    call_modules_hook('on_postload_task_delete', data=identifier, caseid=context_case_identifier)
-    track_activity(f"deleted task \"{task.task_title}\"")
+    update_tasks_state(caseid=task.task_case_id)
+    call_modules_hook('on_postload_task_delete', data=identifier, caseid=task.task_case_id)
+    track_activity(f'deleted task "{task.task_title}"')
     return 'Task deleted'
 
 

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -92,10 +92,9 @@ def get_assets_name(caseid):
     return assets_names
 
 
-def get_asset(asset_id, caseid):
+def get_asset(asset_id) -> CaseAssets:
     asset = CaseAssets.query.filter(
         CaseAssets.asset_id == asset_id,
-        CaseAssets.case_id == caseid
     ).first()
 
     return asset
@@ -103,7 +102,7 @@ def get_asset(asset_id, caseid):
 
 def update_asset(asset_name, asset_description, asset_ip, asset_info, asset_domain,
                  asset_compromise_status_id, asset_type, asset_id, caseid, analysis_status, asset_tags):
-    asset = get_asset(asset_id, caseid)
+    asset = get_asset(asset_id)
     asset.asset_name = asset_name
     asset.asset_description = asset_description
     asset.asset_ip = asset_ip
@@ -120,7 +119,7 @@ def update_asset(asset_name, asset_description, asset_ip, asset_info, asset_doma
 
 
 def delete_asset(asset_id, caseid):
-    case_asset = get_asset(asset_id, caseid)
+    case_asset = get_asset(asset_id)
     if case_asset is None:
         return
 

--- a/source/app/datamgmt/case/case_iocs_db.py
+++ b/source/app/datamgmt/case/case_iocs_db.py
@@ -294,7 +294,7 @@ def user_list_cases_view(user_id):
     return [r.case_id for r in res]
 
 
-def build_filter_ioc_query(
+def _build_filter_ioc_query(
         caseid: int = None,
         ioc_type_id: int = None,
         ioc_type: str = None,
@@ -358,12 +358,11 @@ def get_filtered_iocs(
         sort_dir='asc'
         ):
 
-    data = build_filter_ioc_query(caseid=caseid, ioc_type_id=ioc_type_id, ioc_type=ioc_type, ioc_tlp_id=ioc_tlp_id, ioc_value=ioc_value,
-                                  ioc_description=ioc_description, ioc_tags=ioc_tags,
-                                  sort_by=sort_by, sort_dir=sort_dir)
+    query = _build_filter_ioc_query(caseid=caseid, ioc_type_id=ioc_type_id, ioc_type=ioc_type, ioc_tlp_id=ioc_tlp_id, ioc_value=ioc_value,
+                                   ioc_description=ioc_description, ioc_tags=ioc_tags, sort_by=sort_by, sort_dir=sort_dir)
 
     try:
-        filtered_iocs = data.paginate(page=page, per_page=per_page, error_out=False)
+        filtered_iocs = query.paginate(page=page, per_page=per_page, error_out=False)
 
     except Exception as e:
         app.logger.exception(f"Error getting cases: {str(e)}")

--- a/source/app/datamgmt/case/case_tasks_db.py
+++ b/source/app/datamgmt/case/case_tasks_db.py
@@ -24,7 +24,8 @@ from app import db
 from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
 from app.datamgmt.manage.manage_users_db import get_users_list_restricted_from_case
 from app.datamgmt.states import update_tasks_state
-from app.models import CaseTasks, TaskAssignee
+from app.models import CaseTasks
+from app.models import TaskAssignee
 from app.models import Cases
 from app.models import Comments
 from app.models import TaskComments

--- a/source/app/datamgmt/case/case_tasks_db.py
+++ b/source/app/datamgmt/case/case_tasks_db.py
@@ -98,25 +98,21 @@ def get_tasks_with_assignees(caseid):
     return task_with_assignees
 
 
-def get_task(task_id, caseid):
-    return CaseTasks.query.filter(CaseTasks.id == task_id, CaseTasks.task_case_id == caseid).first()
+def get_task(task_id):
+    return CaseTasks.query.filter(CaseTasks.id == task_id).first()
 
 
-def get_task_with_assignees(task_id: int, case_id: int):
+def get_task_with_assignees(task_id: int):
     """
     Returns a task with its assignees
 
     Args:
         task_id (int): Task ID
-        case_id (int): Case ID
 
     Returns:
         dict: Task with its assignees
     """
-    task = get_task(
-        task_id=task_id,
-        caseid=case_id
-    )
+    task = get_task(task_id)
 
     if not task:
         return None
@@ -154,7 +150,7 @@ def get_task_with_assignees(task_id: int, case_id: int):
 
 
 def update_task_status(task_status, task_id, caseid):
-    task = get_task(task_id, caseid)
+    task = get_task(task_id)
     if task:
         try:
             task.task_status_id = task_status

--- a/source/app/datamgmt/case/case_tasks_db.py
+++ b/source/app/datamgmt/case/case_tasks_db.py
@@ -98,7 +98,7 @@ def get_tasks_with_assignees(caseid):
     return task_with_assignees
 
 
-def get_task(task_id):
+def get_task(task_id) -> CaseTasks:
     return CaseTasks.query.filter(CaseTasks.id == task_id).first()
 
 

--- a/source/app/iris_engine/utils/collab.py
+++ b/source/app/iris_engine/utils/collab.py
@@ -1,9 +1,6 @@
 import json
-from flask_socketio import join_room
 
 import app
-from app.models.authorization import CaseAccessLevel
-from app.blueprints.access_controls import ac_socket_requires
 
 
 def collab_notify(case_id: int,
@@ -24,10 +21,3 @@ def collab_notify(case_id: int,
                        room=room,
                        to=room,
                        skip_sid=request_sid)
-
-
-@app.socket_io.on('join-case-obj-notif')
-@ac_socket_requires(CaseAccessLevel.full_access)
-def socket_join_case_obj_notif(data):
-    room = data['channel']
-    join_room(room=room)

--- a/source/app/iris_engine/utils/collab.py
+++ b/source/app/iris_engine/utils/collab.py
@@ -3,7 +3,7 @@ from flask_socketio import join_room
 
 import app
 from app.models.authorization import CaseAccessLevel
-from app.util import ac_socket_requires
+from app.blueprints.access_controls import ac_socket_requires
 
 
 def collab_notify(case_id: int,

--- a/source/app/post_init.py
+++ b/source/app/post_init.py
@@ -961,7 +961,7 @@ def create_safe_auth_model():
 
     # Create new Administrator Group object
     try:
-        gadm = get_or_create(db.session, Group, group_name="Administrators", group_description="Administrators",
+        gadm = get_or_create(db.session, Group, group_name='Administrators', group_description='Administrators',
                              group_auto_follow=True, group_auto_follow_access_level=CaseAccessLevel.full_access.value,
                              group_permissions=ac_get_mask_full_permissions())
 
@@ -969,7 +969,7 @@ def create_safe_auth_model():
         db.session.rollback()
         log.warning('Administrator group integrity error. Group permissions were probably changed. Updating.')
         gadm = Group.query.filter(
-            Group.group_name == "Administrators"
+            Group.group_name == 'Administrators'
         ).first()
 
     # Update Administrator Group object attributes
@@ -986,7 +986,7 @@ def create_safe_auth_model():
 
     # Create new Analysts Group object
     try:
-        ganalysts = get_or_create(db.session, Group, group_name="Analysts", group_description="Standard Analysts",
+        ganalysts = get_or_create(db.session, Group, group_name='Analysts', group_description='Standard Analysts',
                                   group_auto_follow=False,
                                   group_auto_follow_access_level=CaseAccessLevel.full_access.value,
                                   group_permissions=ac_get_mask_analyst())
@@ -994,7 +994,7 @@ def create_safe_auth_model():
     except exc.IntegrityError:
         db.session.rollback()
         log.warning('Analysts group integrity error. Group permissions were probably changed. Updating.')
-        ganalysts = get_group_by_name("Analysts")
+        ganalysts = get_group_by_name('Analysts')
 
     # Update Analysts Group object attributes
     if ganalysts.group_permissions != ac_get_mask_analyst():

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -43,7 +43,6 @@ from flask import session
 from flask import url_for
 from flask_login import current_user
 from flask_login import login_user
-from flask_wtf import FlaskForm
 from functools import wraps
 from jwt import PyJWKClient
 from pathlib import Path
@@ -51,7 +50,6 @@ from pyunpack import Archive
 from requests.auth import HTTPBasicAuth
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.orm.attributes import flag_modified
-from werkzeug.utils import redirect
 
 from app import TEMPLATE_PATH
 from app import app
@@ -59,12 +57,9 @@ from app import db
 from app.datamgmt.case.case_db import get_case
 from app.datamgmt.manage.manage_access_control_db import user_has_client_access
 from app.datamgmt.manage.manage_users_db import get_user
-from app.iris_engine.access_control.utils import ac_fast_check_user_has_case_access
 from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
 from app.iris_engine.utils.tracker import track_activity
 from app.models import Cases
-from app.models.authorization import CaseAccessLevel
-from app.models.authorization import Permissions
 
 
 def response(status, data=None):
@@ -203,88 +198,9 @@ class FileRemover(object):
         shutil.rmtree(filepath, ignore_errors=True)
 
 
-def _get_caseid_from_request_data(request_data, no_cid_required):
-    caseid = request_data.args.get('cid', default=None, type=int)
-    if caseid:
-        return False, caseid, True
-
-    if no_cid_required:
-        return False, caseid, True
-
-    js_d = None
-
-    try:
-        if request_data.content_type == 'application/json':
-            js_d = request_data.get_json()
-
-        if not js_d:
-            redir, caseid = _set_caseid_from_current_user()
-            return redir, caseid, True
-
-        if 'cid' not in js_d:
-            cookie_session = request_data.cookies.get('session')
-            if not cookie_session:
-                redir, caseid = _set_caseid_from_current_user()
-                return redir, caseid, True
-
-        caseid = js_d.get('cid')
-
-        return False, caseid, True
-
-    except Exception as e:
-        cookie_session = request_data.cookies.get('session')
-        if not cookie_session:
-            redir, caseid = _set_caseid_from_current_user()
-            return redir, caseid, True
-
-        log_exception_and_error(e)
-        return True, 0, False
-
-
-def _set_caseid_from_current_user():
-    redir = False
-    if current_user.ctx_case is None:
-        redir = True
-        current_user.ctx_case = 1
-    caseid = current_user.ctx_case
-    return redir, caseid
-
-
 def log_exception_and_error(e):
     log.exception(e)
     log.error(traceback.print_exc())
-
-
-def _handle_no_cid_required(no_cid_required):
-    if no_cid_required:
-        js_d = request.get_json(silent=True)
-
-        try:
-
-            if type(js_d) == str:
-                js_d = json.loads(js_d)
-
-            caseid = js_d.get('cid') if type(js_d) == dict else None
-            if caseid and 'cid' in request.json:
-                request.json.pop('cid')
-
-        except Exception:
-            return None, False
-
-        return caseid, True
-
-    return None, False
-
-
-def _update_session(caseid, eaccess_level):
-    restricted_access = ''
-    if not eaccess_level:
-        eaccess_level = [CaseAccessLevel.read_only, CaseAccessLevel.full_access]
-
-    if CaseAccessLevel.read_only.value == eaccess_level:
-        restricted_access = '<i class="ml-2 text-warning mt-1 fa-solid fa-lock" title="Read only access"></i>'
-
-    update_current_case(caseid, restricted_access)
 
 
 def update_current_case(caseid, restricted_access):
@@ -297,53 +213,6 @@ def update_current_case(caseid, restricted_access):
                 'case_id': caseid,
                 'access': restricted_access
             }
-
-
-def _update_denied_case(caseid):
-    session['current_case'] = {
-        'case_name': "{} to #{}".format("Access denied", caseid),
-        'case_info': "",
-        'case_id': caseid,
-        'access': '<i class="ml-2 text-danger mt-1 fa-solid fa-ban"></i>'
-    }
-
-
-# TODO would be nice to remove parameter no_cid_required
-def _get_case_access(request_data, access_level, no_cid_required=False):
-    redir, caseid, has_access = _get_caseid_from_request_data(request_data, no_cid_required)
-
-    ctmp, has_access = _handle_no_cid_required(no_cid_required)
-    redir = False
-    if ctmp is not None:
-        return redir, ctmp, has_access
-
-    eaccess_level = ac_fast_check_user_has_case_access(current_user.id, caseid, access_level)
-    if eaccess_level is None and access_level:
-        _update_denied_case(caseid)
-        return redir, caseid, False
-
-    _update_session(caseid, eaccess_level)
-
-    if caseid is not None and not get_case(caseid):
-        log.warning('No case found. Using default case')
-        return True, 1, True
-
-    return redir, caseid, True
-
-
-def get_case_access_from_api(request_data, access_level):
-    redir, caseid, has_access = _get_caseid_from_request_data(request_data, False)
-    redir = False
-
-    eaccess_level = ac_fast_check_user_has_case_access(current_user.id, caseid, access_level)
-    if eaccess_level is None and access_level:
-        return redir, caseid, False
-
-    if caseid is not None and not get_case(caseid):
-        log.warning('No case found. Using default case')
-        return True, 1, True
-
-    return redir, caseid, True
 
 
 def get_urlcasename():
@@ -505,13 +374,6 @@ def regenerate_session():
     session.modified = True
 
 
-def _ac_return_access_denied(caseid: int = None):
-    error_uuid = uuid.uuid4()
-    log.warning(f"Access denied to case #{caseid} for user ID {current_user.id}. Error {error_uuid}")
-    return render_template('pages/error-403.html', user=current_user, caseid=caseid, error_uuid=error_uuid,
-                           template_folder=TEMPLATE_PATH), 403
-
-
 # TODO should move this method into an util file at the root of the blueprint namespace
 def ac_api_return_access_denied(caseid: int = None):
     error_uuid = uuid.uuid4()
@@ -523,86 +385,6 @@ def ac_api_return_access_denied(caseid: int = None):
         'error_uuid': error_uuid
     }
     return response_error('Permission denied', data=data, status=403)
-
-
-# TODO try to do as the api access controls:
-#   have this method check only the case access levels and use both this method and ac_requires
-def ac_case_requires(*access_level):
-    def inner_wrap(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            if not is_user_authenticated(request):
-                return redirect(not_authenticated_redirection_url(request.full_path))
-
-            redir, caseid, has_access = _get_case_access(request, access_level)
-
-            if not has_access:
-                return _ac_return_access_denied(caseid=caseid)
-
-            kwargs.update({"caseid": caseid, "url_redir": redir})
-
-            return f(*args, **kwargs)
-
-        return wrap
-    return inner_wrap
-
-
-# TODO try to remove option no_cid_required
-def ac_requires(*permissions, no_cid_required=False):
-    def inner_wrap(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            if not is_user_authenticated(request):
-                return redirect(not_authenticated_redirection_url(request.full_path))
-
-            redir, caseid, _ = _get_case_access(request, [], no_cid_required=no_cid_required)
-            kwargs.update({'caseid': caseid, 'url_redir': redir})
-
-            if not _user_has_at_least_a_required_permission(permissions):
-                return _ac_return_access_denied()
-
-            return f(*args, **kwargs)
-        return wrap
-    return inner_wrap
-
-
-def ac_socket_requires(*access_level):
-    def inner_wrap(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            if not is_user_authenticated(request):
-                return redirect(not_authenticated_redirection_url(request.full_path))
-
-            else:
-                chan_id = args[0].get('channel')
-                if chan_id:
-                    case_id = int(chan_id.replace('case-', '').split('-')[0])
-                else:
-                    return _ac_return_access_denied(caseid=0)
-
-                access = ac_fast_check_user_has_case_access(current_user.id, case_id, access_level)
-                if not access:
-                    return _ac_return_access_denied(caseid=case_id)
-
-                return f(*args, **kwargs)
-
-        return wrap
-    return inner_wrap
-
-
-def _user_has_at_least_a_required_permission(permissions: list[Permissions]):
-    """
-        Returns true as soon as the user has at least one permission in the list of permissions
-        Returns true if the list of required permissions is empty
-    """
-    if not permissions:
-        return True
-
-    for permission in permissions:
-        if session['permissions'] & permission.value:
-            return True
-
-    return False
 
 
 def endpoint_removed(message, version):
@@ -621,85 +403,6 @@ def ac_api_requires_client_access():
             client_id = kwargs.get('client_id')
             if not user_has_client_access(current_user.id, client_id):
                 return response_error("Permission denied", status=403)
-
-            return f(*args, **kwargs)
-        return wrap
-    return inner_wrap
-
-
-def ac_requires_client_access():
-    def inner_wrap(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            client_id = kwargs.get('client_id')
-            if not user_has_client_access(current_user.id, client_id):
-                return _ac_return_access_denied()
-
-            return f(*args, **kwargs)
-        return wrap
-    return inner_wrap
-
-
-# TODO should move this method into an util file at the root of the blueprint namespace
-def ac_requires_case_identifier(*access_level):
-    def decorate_with_requires_case_identifier(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            try:
-                redir, caseid, has_access = get_case_access_from_api(request, access_level)
-            except Exception as e:
-                log.exception(e)
-                return response_error('Invalid data. Check server logs', status=500)
-
-            if not caseid and not redir:
-                return response_error('Invalid case ID', status=404)
-
-            if not has_access:
-                return ac_api_return_access_denied(caseid=caseid)
-
-            kwargs.update({'caseid': caseid})
-
-            return f(*args, **kwargs)
-
-        return wrap
-    return decorate_with_requires_case_identifier
-
-
-def _is_csrf_token_valid():
-    if request.method != 'POST':
-        return True
-    if request.headers.get('X-IRIS-AUTH') is not None:
-        return True
-    if request.headers.get('Authorization') is not None:
-        return True
-    cookie_session = request.cookies.get('session')
-    # True in the absence of a session cookie, because no CSRF token is required for API calls
-    if not cookie_session:
-        return True
-    form = FlaskForm()
-    if not form.validate():
-        return False
-    # TODO not nice to have a side-effect within a 'is' method.
-    if request.is_json:
-        request.json.pop('csrf_token')
-    return True
-
-
-def ac_api_requires(*permissions):
-    def inner_wrap(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            if not _is_csrf_token_valid():
-                return response_error('Invalid CSRF token')
-
-            if not is_user_authenticated(request):
-                return response_error('Authentication required', status=401)
-
-            if 'permissions' not in session:
-                session['permissions'] = ac_get_effective_permissions_of_user(current_user)
-
-            if not _user_has_at_least_a_required_permission(permissions):
-                return response_error('Permission denied', status=403)
 
             return f(*args, **kwargs)
         return wrap

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -512,6 +512,7 @@ def _ac_return_access_denied(caseid: int = None):
                            template_folder=TEMPLATE_PATH), 403
 
 
+# TODO should move this method into an util file at the root of the blueprint namespace
 def ac_api_return_access_denied(caseid: int = None):
     error_uuid = uuid.uuid4()
     log.warning(f"EID {error_uuid} - Access denied with case #{caseid} for user ID {current_user.id} "
@@ -639,6 +640,7 @@ def ac_requires_client_access():
     return inner_wrap
 
 
+# TODO should move this method into an util file at the root of the blueprint namespace
 def ac_requires_case_identifier(*access_level):
     def decorate_with_requires_case_identifier(f):
         @wraps(f)

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -639,28 +639,6 @@ def ac_requires_client_access():
     return inner_wrap
 
 
-def ac_requires_case_access(*access_level):
-    def decorate(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            try:
-                redir, caseid, has_access = get_case_access_from_api(request, access_level)
-            except Exception as e:
-                log.exception(e)
-                return response_error('Invalid data. Check server logs', status=500)
-
-            if not caseid and not redir:
-                return response_error('Invalid case ID', status=404)
-
-            if not has_access:
-                return ac_api_return_access_denied(caseid=caseid)
-
-            return f(*args, **kwargs)
-
-        return wrap
-    return decorate
-
-
 def ac_requires_case_identifier(*access_level):
     def decorate_with_requires_case_identifier(f):
         @wraps(f)

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -309,7 +309,7 @@ def _update_denied_case(caseid):
 
 
 # TODO would be nice to remove parameter no_cid_required
-def get_case_access(request_data, access_level, no_cid_required=False):
+def _get_case_access(request_data, access_level, no_cid_required=False):
     redir, caseid, has_access = _get_caseid_from_request_data(request_data, no_cid_required)
 
     ctmp, has_access = _handle_no_cid_required(no_cid_required)
@@ -533,7 +533,7 @@ def ac_case_requires(*access_level):
             if not is_user_authenticated(request):
                 return redirect(not_authenticated_redirection_url(request.full_path))
 
-            redir, caseid, has_access = get_case_access(request, access_level)
+            redir, caseid, has_access = _get_case_access(request, access_level)
 
             if not has_access:
                 return _ac_return_access_denied(caseid=caseid)
@@ -554,7 +554,7 @@ def ac_requires(*permissions, no_cid_required=False):
             if not is_user_authenticated(request):
                 return redirect(not_authenticated_redirection_url(request.full_path))
 
-            redir, caseid, _ = get_case_access(request, [], no_cid_required=no_cid_required)
+            redir, caseid, _ = _get_case_access(request, [], no_cid_required=no_cid_required)
             kwargs.update({'caseid': caseid, 'url_redir': redir})
 
             if not _user_has_at_least_a_required_permission(permissions):

--- a/tests/iris.py
+++ b/tests/iris.py
@@ -35,7 +35,7 @@ class Iris:
     def __init__(self):
         self._docker_compose = DockerCompose(_IRIS_PATH, 'docker-compose.dev.yml')
         self._api = RestApi(API_URL, _API_KEY)
-        self._administrator = User(API_URL, _API_KEY)
+        self._administrator = User(API_URL, _API_KEY, 1)
         self._user_count = 0
 
     def _wait(self, condition, attempts, sleep_duration=1):
@@ -107,7 +107,7 @@ class Iris:
             'user_password': 'aA.1234567890'
         }
         user = self._api.post('/manage/users/add', body).json()
-        return User(API_URL, user['data']['user_api_key'])
+        return User(API_URL, user['data']['user_api_key'], user['data']['id'])
 
     def create_dummy_user(self):
         self._user_count += 1

--- a/tests/tests_graphql.py
+++ b/tests/tests_graphql.py
@@ -124,7 +124,7 @@ class TestsGraphQL(TestCase):
                          }}'''
         }
         response = self._subject.execute_graphql_query(payload)
-        self.assertEqual(f'IOC {ioc_identifier} deleted', response['data']['iocDelete']['message'])
+        self.assertEqual(f'IOC {int(ioc_identifier)} deleted', response['data']['iocDelete']['message'])
 
     def test_graphql_create_ioc_should_allow_optional_description_to_be_set(self):
         case_identifier = self._create_case()

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -20,6 +20,7 @@ from unittest import TestCase
 from iris import Iris
 
 _INITIAL_DEMO_CASE_IDENTIFIER = 1
+_GROUP_ANALYSTS_IDENTIFIER = 2
 _CASE_ACCESS_LEVEL_FULL_ACCESS = 4
 
 # TODO should change None into 123456789 and maybe fix...
@@ -418,6 +419,22 @@ class TestsRest(TestCase):
         }
         self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
         response = user.get(f'/api/v2/cases/{case_identifier}')
+        self.assertEqual(403, response.status_code)
+
+    def test_delete_case_should_return_403_when_user_has_insufficient_rights(self):
+        case_identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+        body = {
+            'groups_membership': [_GROUP_ANALYSTS_IDENTIFIER]
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/groups/update', body)
+
+        response = user.delete(f'/api/v2/cases/{case_identifier}')
         self.assertEqual(403, response.status_code)
 
     def test_create_ioc_should_return_403_when_user_has_insufficient_rights(self):

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -192,8 +192,9 @@ class TestsRest(TestCase):
     def test_delete_asset_should_return_204(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
-        self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body)
-        response = self._subject.delete(f'/api/v2/assets/1')
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
+        asset_identifier = response['asset_id']
+        response = self._subject.delete(f'/api/v2/assets/{asset_identifier}')
         self.assertEqual(204, response.status_code)
 
     def test_delete_asset_with_missing_asset_identifier_should_return_404(self):

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -485,6 +485,14 @@ class TestsRest(TestCase):
         response = user.delete(f'/api/v2/iocs/{ioc_identifier}')
         self.assertEqual(403, response.status_code)
 
+    def test_get_asset_should_return_200(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
+        asset_identifier = response['asset_id']
+        response = self._subject.get(f'/api/v2/assets/{asset_identifier}')
+        self.assertEqual(200, response.status_code)
+
     def test_get_asset_should_return_403_when_user_has_insufficient_rights(self):
         case_identifier = self._subject.create_dummy_case()
         user = self._subject.create_dummy_user()

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -19,6 +19,9 @@
 from unittest import TestCase
 from iris import Iris
 
+_INITIAL_DEMO_CASE_IDENTIFIER = 1
+_CASE_ACCESS_LEVEL_FULL_ACCESS = 4
+
 
 def _get_case_with_identifier(response, identifier):
     for case in response['cases']:
@@ -402,3 +405,14 @@ class TestsRest(TestCase):
         for ioc in response['iocs']:
             identifiers.append(ioc['ioc_type_id'])
         self.assertIn(ioc_type_identifier, identifiers)
+
+    def test_get_case_should_return_403_when_user_has_insufficient_rights(self):
+        identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+        response = user.get(f'/api/v2/cases/{identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -429,3 +429,18 @@ class TestsRest(TestCase):
         body = {'ioc_type_id': 1, 'ioc_tlp_id': 2, 'ioc_value': '8.8.8.8', 'ioc_description': 'rewrw', 'ioc_tags': ''}
         response = user.create(f'/api/v2/cases/{case_identifier}/iocs', body)
         self.assertEqual(403, response.status_code)
+
+    def test_get_ioc_should_return_403_when_user_has_insufficient_rights(self):
+        case_identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {'ioc_type_id': 1, 'ioc_tlp_id': 2, 'ioc_value': '8.8.8.8', 'ioc_description': 'rewrw', 'ioc_tags': ''}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/iocs', body).json()
+        ioc_identifier = response['ioc_id']
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+
+        response = user.get(f'/api/v2/iocs/{ioc_identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -507,3 +507,18 @@ class TestsRest(TestCase):
 
         response = user.get(f'/api/v2/assets/{asset_identifier}')
         self.assertEqual(403, response.status_code)
+
+    def test_delete_asset_should_return_403_when_user_has_insufficient_rights(self):
+        case_identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
+        asset_identifier = response['asset_id']
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+
+        response = user.delete(f'/api/v2/assets/{asset_identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -484,3 +484,18 @@ class TestsRest(TestCase):
 
         response = user.delete(f'/api/v2/iocs/{ioc_identifier}')
         self.assertEqual(403, response.status_code)
+
+    def test_get_asset_should_return_403_when_user_has_insufficient_rights(self):
+        case_identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
+        asset_identifier = response['asset_id']
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+
+        response = user.get(f'/api/v2/assets/{asset_identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -457,3 +457,14 @@ class TestsRest(TestCase):
         response = self._subject.get(f'/api/v2/iocs/{ioc_identifier}')
         self.assertEqual(200, response.status_code)
 
+    def test_get_iocs_should_return_403_when_user_has_insufficient_rights(self):
+        case_identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+
+        response = user.get(f'/api/v2/cases/{case_identifier}/iocs')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -449,3 +449,11 @@ class TestsRest(TestCase):
         response = self._subject.get(f'/api/v2/iocs/137')
         self.assertEqual(404, response.status_code)
 
+    def test_get_ioc_should_return_200_on_success(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'ioc_type_id': 1, 'ioc_tlp_id': 2, 'ioc_value': '8.8.8.8', 'ioc_description': 'rewrw', 'ioc_tags': ''}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/iocs', body).json()
+        ioc_identifier = response['ioc_id']
+        response = self._subject.get(f'/api/v2/iocs/{ioc_identifier}')
+        self.assertEqual(200, response.status_code)
+

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -271,11 +271,11 @@ class TestsRest(TestCase):
 
     def test_get_tasks_should_return_201(self):
         case_identifier = self._subject.create_dummy_case()
-        task_id = 2
-        body = {'task_assignees_id': [task_id], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title',
+        body = {'task_assignees_id': [2], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title',
                 'custom_attributes': {}}
-        self._subject.create(f'/api/v2/cases/{case_identifier}/tasks',  body)
-        response = self._subject.get(f'/api/v2/tasks/{task_id}')
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/tasks',  body).json()
+        task_identifier = response['id']
+        response = self._subject.get(f'/api/v2/tasks/{task_identifier}')
         self.assertEqual(201, response.status_code)
 
     def test_get_tasks_with_missing_task_identifier_should_return_error(self):

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -280,19 +280,18 @@ class TestsRest(TestCase):
 
     def test_get_tasks_with_missing_task_identifier_should_return_error(self):
         case_identifier = self._subject.create_dummy_case()
-        task_id = 1
-        body = {'task_assignees_id': [task_id], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title', 'custom_attributes': {}}
+        body = {'task_assignees_id': [1], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title', 'custom_attributes': {}}
         self._subject.create(f'/api/v2/cases/{case_identifier}/tasks',  body)
         response = self._subject.get(f'/api/v2/tasks/{None}')
         self.assertEqual(404, response.status_code)
 
     def test_delete_task_should_return_204(self):
         case_identifier = self._subject.create_dummy_case()
-        task_id = 1
-        body = {'task_assignees_id': [task_id], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title',
+        body = {'task_assignees_id': [1], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title',
                 'custom_attributes': {}}
-        self._subject.create(f'/api/v2/cases/{case_identifier}/tasks',  body)
-        test = self._subject.delete(f'/api/v2/tasks/{task_id}')
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/tasks',  body).json()
+        task_identifier = response['id']
+        test = self._subject.delete(f'/api/v2/tasks/{task_identifier}')
         self.assertEqual(204, test.status_code)
 
     def test_delete_task_with_missing_task_identifier_should_return_404(self):

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -444,3 +444,8 @@ class TestsRest(TestCase):
 
         response = user.get(f'/api/v2/iocs/{ioc_identifier}')
         self.assertEqual(403, response.status_code)
+
+    def test_get_ioc_should_return_404_when_not_present(self):
+        response = self._subject.get(f'/api/v2/iocs/137')
+        self.assertEqual(404, response.status_code)
+

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -524,3 +524,18 @@ class TestsRest(TestCase):
 
         response = user.delete(f'/api/v2/assets/{asset_identifier}')
         self.assertEqual(403, response.status_code)
+
+    def test_get_task_should_return_403_when_user_has_insufficient_rights(self):
+        case_identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {'task_assignees_id': [1], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title', 'custom_attributes': {}}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/tasks',  body).json()
+        task_identifier = response['id']
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+
+        response = user.get(f'/api/v2/tasks/{task_identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -468,3 +468,18 @@ class TestsRest(TestCase):
 
         response = user.get(f'/api/v2/cases/{case_identifier}/iocs')
         self.assertEqual(403, response.status_code)
+
+    def test_delete_ioc_should_return_403_when_user_has_insufficient_rights(self):
+        case_identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {'ioc_type_id': 1, 'ioc_tlp_id': 2, 'ioc_value': '8.8.8.8', 'ioc_description': 'rewrw', 'ioc_tags': ''}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/iocs', body).json()
+        ioc_identifier = response['ioc_id']
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+
+        response = user.delete(f'/api/v2/iocs/{ioc_identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -22,6 +22,9 @@ from iris import Iris
 _INITIAL_DEMO_CASE_IDENTIFIER = 1
 _CASE_ACCESS_LEVEL_FULL_ACCESS = 4
 
+# TODO should change None into 123456789 and maybe fix...
+_IDENTIFIER_FOR_NONEXISTENT_OBJECT = None
+
 
 def _get_case_with_identifier(response, identifier):
     for case in response['cases']:
@@ -186,7 +189,7 @@ class TestsRest(TestCase):
         self.assertEqual(204, response.status_code)
 
     def test_delete_ioc_with_missing_ioc_identifier_should_return_404(self):
-        response = self._subject.delete(f'/api/v2/iocs/{None}')
+        response = self._subject.delete(f'/api/v2/iocs/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)
 
     def test_delete_asset_should_return_204(self):
@@ -198,7 +201,7 @@ class TestsRest(TestCase):
         self.assertEqual(204, response.status_code)
 
     def test_delete_asset_with_missing_asset_identifier_should_return_404(self):
-        response = self._subject.delete(f'/api/v2/assets/{None}')
+        response = self._subject.delete(f'/api/v2/assets/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)
 
     def test_create_asset_should_work(self):
@@ -209,7 +212,7 @@ class TestsRest(TestCase):
 
     def test_create_asset_with_missing_case_identifier_should_return_404(self):
         body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
-        response = self._subject.create(f'/api/v2/cases/{None}/assets', body)
+        response = self._subject.create(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/assets', body)
         self.assertEqual(404, response.status_code)
 
     def test_get_asset_with_missing_asset_identifier_should_return_404(self):
@@ -282,7 +285,7 @@ class TestsRest(TestCase):
         case_identifier = self._subject.create_dummy_case()
         body = {'task_assignees_id': [1], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title', 'custom_attributes': {}}
         self._subject.create(f'/api/v2/cases/{case_identifier}/tasks',  body)
-        response = self._subject.get(f'/api/v2/tasks/{None}')
+        response = self._subject.get(f'/api/v2/tasks/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)
 
     def test_delete_task_should_return_204(self):
@@ -300,7 +303,7 @@ class TestsRest(TestCase):
         body = {'task_assignees_id': [task_id], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title',
                 'custom_attributes': {}}
         self._subject.create(f'/api/v2/cases/{case_identifier}/tasks',  body)
-        test = self._subject.delete(f'/api/v2/tasks/{None}')
+        test = self._subject.delete(f'/api/v2/tasks/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, test.status_code)
 
     def test_get_cases_should_not_fail(self):

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -191,7 +191,7 @@ class TestsRest(TestCase):
 
     def test_delete_asset_should_return_204(self):
         case_identifier = self._subject.create_dummy_case()
-        body = {"asset_type_id": "1", "asset_name": "admin_laptop_test"}
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
         self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body)
         response = self._subject.delete(f'/api/v2/assets/1')
         self.assertEqual(204, response.status_code)
@@ -202,12 +202,12 @@ class TestsRest(TestCase):
 
     def test_create_asset_should_work(self):
         case_identifier = self._subject.create_dummy_case()
-        body = {"asset_type_id": "1", "asset_name": "admin_laptop_test"}
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body)
         self.assertEqual(201, response.status_code)
 
     def test_create_asset_with_missing_case_identifier_should_return_404(self):
-        body = {"asset_type_id": "1", "asset_name": "admin_laptop_test"}
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
         response = self._subject.create(f'/api/v2/cases/{None}/assets', body)
         self.assertEqual(404, response.status_code)
 
@@ -407,12 +407,25 @@ class TestsRest(TestCase):
         self.assertIn(ioc_type_identifier, identifiers)
 
     def test_get_case_should_return_403_when_user_has_insufficient_rights(self):
-        identifier = self._subject.create_dummy_case()
+        case_identifier = self._subject.create_dummy_case()
         user = self._subject.create_dummy_user()
         body = {
             'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
             'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
         }
         self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
-        response = user.get(f'/api/v2/cases/{identifier}')
+        response = user.get(f'/api/v2/cases/{case_identifier}')
+        self.assertEqual(403, response.status_code)
+
+    def test_create_ioc_should_return_403_when_user_has_insufficient_rights(self):
+        case_identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+
+        body = {'ioc_type_id': 1, 'ioc_tlp_id': 2, 'ioc_value': '8.8.8.8', 'ioc_description': 'rewrw', 'ioc_tags': ''}
+        response = user.create(f'/api/v2/cases/{case_identifier}/iocs', body)
         self.assertEqual(403, response.status_code)

--- a/tests/tests_rest.py
+++ b/tests/tests_rest.py
@@ -539,3 +539,18 @@ class TestsRest(TestCase):
 
         response = user.get(f'/api/v2/tasks/{task_identifier}')
         self.assertEqual(403, response.status_code)
+
+    def test_delete_task_should_return_403_when_user_has_insufficient_rights(self):
+        case_identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        body = {'task_assignees_id': [1], 'task_description': '', 'task_status_id': 1, 'task_tags': '', 'task_title': 'dummy title', 'custom_attributes': {}}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/tasks',  body).json()
+        task_identifier = response['id']
+        body = {
+            'cases_list': [_INITIAL_DEMO_CASE_IDENTIFIER],
+            'access_level': _CASE_ACCESS_LEVEL_FULL_ACCESS
+        }
+        self._subject.create(f'/manage/users/{user.get_identifier()}/cases-access/update', body)
+
+        response = user.delete(f'/api/v2/tasks/{task_identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/user.py
+++ b/tests/user.py
@@ -37,3 +37,6 @@ class User:
 
     def get(self, path, query_parameters=None):
         return self._api.get(path, query_parameters=query_parameters)
+
+    def create(self, path, payload, query_parameters=None):
+        return self._api.post(path, payload, query_parameters)

--- a/tests/user.py
+++ b/tests/user.py
@@ -21,9 +21,13 @@ from rest_api import RestApi
 
 class User:
 
-    def __init__(self, iris_url, api_key):
+    def __init__(self, iris_url, api_key, identifier):
         self._graphql_api = GraphQLApi(iris_url + '/graphql', api_key)
         self._api = RestApi(iris_url, api_key)
+        self._identifier = identifier
+
+    def get_identifier(self):
+        return self._identifier
 
     def execute_graphql_query(self, payload):
         response = self._graphql_api.execute(payload)

--- a/tests/user.py
+++ b/tests/user.py
@@ -35,8 +35,11 @@ class User:
         print(f'{payload} => {body}')
         return body
 
-    def get(self, path, query_parameters=None):
-        return self._api.get(path, query_parameters=query_parameters)
+    def create(self, path, payload):
+        return self._api.post(path, payload)
 
-    def create(self, path, payload, query_parameters=None):
-        return self._api.post(path, payload, query_parameters)
+    def get(self, path):
+        return self._api.get(path)
+
+    def delete(self, path):
+        return self._api.delete(path)

--- a/ui/src/pages/case.asset.js
+++ b/ui/src/pages/case.asset.js
@@ -538,7 +538,7 @@ $(document).ready(function(){
     }).container().appendTo($('#tables_button'));
 
     get_case_assets();
-    setInterval(function() { check_update('assets/state'); }, 3000);
+    setInterval(function() { check_update('/case/assets/state'); }, 3000);
 
     shared_id = getSharedLink();
     if (shared_id) {

--- a/ui/src/pages/case.ioc.js
+++ b/ui/src/pages/case.ioc.js
@@ -145,6 +145,13 @@ function save_ioc() {
 function get_case_ioc() {
     show_loader();
 
+    get_request_data_api('/case/ioc/state').done((response, textStatus) => {
+        if (textStatus !== 'success') {
+            return;
+        }
+        set_last_state(response.data);
+    });
+
     get_request_data_api(`/api/v2/cases/${get_caseid()}/iocs`)
     .done((data, textStatus) => {
         if (textStatus !== 'success') {
@@ -159,9 +166,8 @@ function get_case_ioc() {
         }
 
         Table.clear();
-        Table.rows.add(data.iocs)
+        Table.rows.add(data.iocs);
 
-        set_last_state(data.state);
         $('#ioc_table_wrapper').on('click', function(e){
             if($('.popover').length>1)
                 $('.popover').popover('hide');
@@ -183,7 +189,7 @@ function get_case_ioc() {
 
             edit_ioc(ioc_id);
         });
-    })
+    });
 }
 
 

--- a/ui/src/pages/case.ioc.js
+++ b/ui/src/pages/case.ioc.js
@@ -478,7 +478,7 @@ $(document).ready(function(){
 }).container().appendTo($('#tables_button'));
 
     get_case_ioc();
-    setInterval(function() { check_update('ioc/state'); }, 3000);
+    setInterval(function() { check_update('/case/ioc/state'); }, 3000);
 
     shared_id = getSharedLink();
     if (shared_id) {

--- a/ui/src/pages/case.ioc.js
+++ b/ui/src/pages/case.ioc.js
@@ -484,6 +484,7 @@ $(document).ready(function(){
 }).container().appendTo($('#tables_button'));
 
     get_case_ioc();
+    // TODO instead of polling, could work with socket IO events (would maybe be more reactive timewise)
     setInterval(function() { check_update('/case/ioc/state'); }, 3000);
 
     shared_id = getSharedLink();

--- a/ui/src/pages/case.rfiles.js
+++ b/ui/src/pages/case.rfiles.js
@@ -476,7 +476,7 @@ $(document).ready(function(){
     });
 
     get_case_rfiles();
-    setInterval(function() { check_update('evidences/state'); }, 3000);
+    setInterval(function() { check_update('/case/evidences/state'); }, 3000);
 
     /* Modal to add rfiles is closed, clear its contents */
     $('.modal').on('hidden.bs.modal', function () {

--- a/ui/src/pages/case.tasks.js
+++ b/ui/src/pages/case.tasks.js
@@ -469,7 +469,7 @@ $(document).ready(function(){
 
     get_tasks();
 
-    setInterval(function() { check_update('tasks/state'); }, 3000);
+    setInterval(function() { check_update('/case/tasks/state'); }, 3000);
 
     shared_id = getSharedLink();
     if (shared_id) {

--- a/ui/src/pages/case.timeline.js
+++ b/ui/src/pages/case.timeline.js
@@ -1402,7 +1402,7 @@ $(document).ready(function(){
 
     get_or_filter_tm();
 
-    setInterval(function() { check_update('timeline/state'); }, 3000);
+    setInterval(function() { check_update('/case/timeline/state'); }, 3000);
 
     collab_case.on('case-obj-notif', function(data) {
         let js_data = JSON.parse(data);

--- a/ui/src/pages/common.js
+++ b/ui/src/pages/common.js
@@ -507,50 +507,51 @@ function update_last_resfresh() {
 }
 
 function check_update(url) {
-    if (need_check) {
-        $.ajax({
-            url: url + case_param(),
-            type: "GET",
-            dataType: "json",
-            success: function(data) {
-                    if (last_state == null || last_state < data.data.object_state) {
-                        $('#last_resfresh').text("Updates available").addClass("text-warning");
-                        need_check = false;
-                    }
-                },
-            error: function (data) {
-                if (data.status == 404) {
-                    swal("Stop everything !",
-                    "The case you are working on was deleted",
-                    "error",
-                    {
-                        buttons: {
-                            again: {
-                                text: "Go to my default case",
-                                value: "default"
-                            }
-                        }
-                    }
-                    ).then((value) => {
-                        switch (value) {
-                            case "dash":
-                                location.reload();
-                                break;
-
-                            default:
-                                location.reload();
-                        }
-                    });
-                } else if (data.status == 403) {
-                    window.location.replace("/case" + case_param());
-                } else if (data.status == 400) {
-
-                } else {
-                    notify_error('Connection with server lost');
-                }
-            }
-        });
+    if (!need_check) {
+        return;
     }
+    $.ajax({
+        url: url + case_param(),
+        type: "GET",
+        dataType: "json",
+        success: function(data) {
+                if (last_state == null || last_state < data.data.object_state) {
+                    $('#last_resfresh').text("Updates available").addClass("text-warning");
+                    need_check = false;
+                }
+            },
+        error: function (data) {
+            if (data.status == 404) {
+                swal("Stop everything !",
+                "The case you are working on was deleted",
+                "error",
+                {
+                    buttons: {
+                        again: {
+                            text: "Go to my default case",
+                            value: "default"
+                        }
+                    }
+                }
+                ).then((value) => {
+                    switch (value) {
+                        case "dash":
+                            location.reload();
+                            break;
+
+                        default:
+                            location.reload();
+                    }
+                });
+            } else if (data.status == 403) {
+                window.location.replace("/case" + case_param());
+            } else if (data.status == 400) {
+
+            } else {
+                notify_error('Connection with server lost');
+            }
+        }
+    });
 }
 
 function set_last_state(state) {

--- a/ui/src/pages/common.js
+++ b/ui/src/pages/common.js
@@ -512,7 +512,7 @@ function check_update(url) {
             url: url + case_param(),
             type: "GET",
             dataType: "json",
-            success: function (data) {
+            success: function(data) {
                     if (last_state == null || last_state < data.data.object_state) {
                         $('#last_resfresh').text("Updates available").addClass("text-warning");
                         need_check = false;

--- a/ui/src/pages/common.js
+++ b/ui/src/pages/common.js
@@ -515,11 +515,11 @@ function check_update(url) {
         type: "GET",
         dataType: "json",
         success: function(data) {
-                if (last_state == null || last_state < data.data.object_state) {
-                    $('#last_resfresh').text("Updates available").addClass("text-warning");
-                    need_check = false;
-                }
-            },
+            if (last_state == null || last_state < data.data.object_state) {
+                $('#last_resfresh').text("Updates available").addClass("text-warning");
+                need_check = false;
+            }
+        },
         error: function (data) {
             if (data.status == 404) {
                 swal("Stop everything !",


### PR DESCRIPTION
This PR covers the following changes:
* add endpoint GET /api/v2/cases/{identifier}/iocs
* move all permission checks in the blueprint layer (nothing remaining in the business layer) and documentation of this choice in the architecture document
* fix permission check bug on new /api/v2 endpoints: since the case identifier is not passed through the query parameter `cid`, the previous annotations were not working as expected. As soon as the user had access to the defaut case (with identifier 1), access was granted.
* move many access controls utility methods (endpoint annotations) in the blueprint layer (since they are used in this layer only)
* remove unnecessary parameter case_id on graphql mutations IOCUpdate and IOCDelete
* move socketIO event handler join-case-obj-notif out of iris_engine into the blueprints layer
* remove case identifier argument to some functions of the business and database layer which do not need the case identifier to retrieve the object
* add ObjectNotFoundError in business layer
* added tests
* update ui code with new endpoints
* transformed relative into absolute urls for some ui requests


