### PR TITLE
[IMP] Added owner email to Alert class.

### DIFF
--- a/source/app/models/alerts.py
+++ b/source/app/models/alerts.py
@@ -11,6 +11,7 @@ from sqlalchemy import Text
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship, backref
+from sqlalchemy.ext.associationproxy import association_proxy
 
 from app import db
 from app.models import Base, alert_assets_association, alert_iocs_association
@@ -50,6 +51,8 @@ class Alert(db.Model):
     alert_resolution_status_id = Column(ForeignKey('alert_resolution_status.resolution_status_id'), nullable=True)
 
     owner = relationship('User', foreign_keys=[alert_owner_id])
+    # 'owner_email' is available via association_proxy accessed through 'owner.email'
+    owner_email = association_proxy('owner', 'email')
     severity = relationship('Severity')
     status = relationship('AlertStatus')
     customer = relationship('Client')


### PR DESCRIPTION
Available via association proxy so might be a bit unclear code wise. 
Also added a short comment.

Alert object
``` 
dir(alert[0])=['__abstract__', '__annotations__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__fsa__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__mapper__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slotnames__', '__str__', '__subclasshook__', '__table__', '__tablename__', '__weakref__', '_sa_class_manager', '_sa_instance_state', '_sa_registry', 'alert_classification_id', 'alert_context', 'alert_creation_time', 'alert_customer_id', 'alert_description', 'alert_id', 'alert_note', 'alert_owner_id', 'alert_resolution_status_id', 'alert_severity_id', 'alert_source', 'alert_source_content', 'alert_source_event_time', 'alert_source_link', 'alert_source_ref', 'alert_status_id', 'alert_tags', 'alert_title', 'alert_uuid', 'assets', 'cases', 'classification', 'comments', 'customer', 'iocs', 'metadata', 'modification_history', 'owner', 'query', 'query_class', 'registry', 'resolution_status', 'severity', 'status']
```

Owner
```
dir(alert[0].owner)=['__abstract__', '__annotations__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__fsa__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__mapper__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__table__', '__tablename__', '__weakref__', '_sa_class_manager', '_sa_instance_state', '_sa_registry', 'active', 'api_key', 'ctx_case', 'ctx_human_case', 'email', 'external_id', 'get_id', 'has_deletion_confirmation', 'has_mini_sidebar', 'id', 'in_dark_mode', 'is_active', 'is_anonymous', 'is_authenticated', 'is_service_account', 'metadata', 'mfa_secrets', 'mfa_setup_complete', 'name', 'password', 'query', 'query_class', 'registry', 'save', 'user', 'uuid', 'webauthn_credentials']
```

Email
`alert[0].owner.email='administrator@localhost'`