### PR TITLE
Change reference POSTGRES_USER kubernetes template

### DIFF
--- a/deploy/kubernetes/charts/templates/postgres.yaml
+++ b/deploy/kubernetes/charts/templates/postgres.yaml
@@ -59,7 +59,7 @@ spec:
             value: {{ .Values.postgres.POSTGRES_DB | quote }}
 
           - name: POSTGRES_USER  # Setting Database username
-            value: {{ .Values.postgres.POSTGRES_ADMIN_USER | quote }}
+            value: {{ .Values.postgres.POSTGRES_USER | quote }}
 
           - name:  POSTGRES_PASSWORDD # Setting Database password
             value: {{ .Values.postgres.POSTGRES_PASSWORD | quote }}


### PR DESCRIPTION
Change reference for POSTGRES_USER from POSTGRES_ADMIN_USER to POSTGRES_USER in the postgres template file for a Kubernetes deployment.