### PR TITLE
More fine tuning

### DIFF
--- a/docker/webApp/Dockerfile
+++ b/docker/webApp/Dockerfile
@@ -48,7 +48,7 @@ RUN pip3 install -r requirements.txt
 ###############
 # BUILD IMAGE #
 ###############
-FROM python:3.9 as iriswebapp
+FROM python:3.9 AS iriswebapp
 ENV PYTHONUNBUFFERED=1 DOCKERIZED=1
 
 COPY --from=compile-image /opt/venv /opt/venv

--- a/e2e/tests/administrator/manage/customers.spec.js
+++ b/e2e/tests/administrator/manage/customers.spec.js
@@ -12,3 +12,10 @@ test('should be able to open "Add customer" modal', async ({ page }) => {
     await page.getByRole('button', { name: 'Add customer' }).click();
     await expect(page.getByRole('heading', { name: 'Add customer' })).toBeVisible()
 });
+
+test('should present IrisInitialClient associated cases', async ({ page }) => {
+    await page.getByRole('link', { name: 'IrisInitialClient' }).click();
+
+    await page.getByRole('button', { name: ' Cases' }).click();
+    await expect(page.getByRole('gridcell', { name: '#1 - Initial Demo' })).toBeVisible();
+});

--- a/source/app/__init__.py
+++ b/source/app/__init__.py
@@ -65,6 +65,7 @@ logger.basicConfig(level=logger.INFO, format=LOG_FORMAT, datefmt=LOG_TIME_FORMAT
 
 app = Flask(__name__, static_folder="../static")
 
+
 def ac_current_user_has_permission(*permissions):
     """
     Return True if current user has permission

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -35,6 +35,7 @@ from app.iris_engine.access_control.utils import ac_fast_check_user_has_case_acc
 from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
 from app.models.authorization import Permissions
 from app.models.authorization import CaseAccessLevel
+
 from app.util import update_current_case
 from app.util import log_exception_and_error
 from app.util import response_error
@@ -341,3 +342,16 @@ def ac_api_return_access_denied(caseid: int = None):
         'error_uuid': error_uuid
     }
     return response_error('Permission denied', data=data, status=403)
+
+
+def ac_api_requires_client_access():
+    def inner_wrap(f):
+        @wraps(f)
+        def wrap(*args, **kwargs):
+            client_id = kwargs.get('client_id')
+            if not user_has_client_access(current_user.id, client_id):
+                return response_error("Permission denied", status=403)
+
+            return f(*args, **kwargs)
+        return wrap
+    return inner_wrap

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -146,7 +146,7 @@ def _update_denied_case(caseid):
     }
 
 
-def update_current_case(caseid, restricted_access):
+def _update_current_case(caseid, restricted_access):
     if session['current_case']['case_id'] != caseid:
         case = get_case(caseid)
         if case:
@@ -166,7 +166,7 @@ def _update_session(caseid, eaccess_level):
     if CaseAccessLevel.read_only.value == eaccess_level:
         restricted_access = '<i class="ml-2 text-warning mt-1 fa-solid fa-lock" title="Read only access"></i>'
 
-    update_current_case(caseid, restricted_access)
+    _update_current_case(caseid, restricted_access)
 
 
 # TODO would be nice to remove parameter no_cid_required

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -498,3 +498,7 @@ def is_user_authenticated(incoming_request: Request):
 
 def is_authentication_oidc():
     return app.config.get('AUTHENTICATION_TYPE') == "oidc"
+
+
+def is_authentication_ldap():
+    return app.config.get('AUTHENTICATION_TYPE') == "ldap"

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -40,6 +40,7 @@ from app import TEMPLATE_PATH
 
 from app import app
 from app import db
+from app.blueprints.responses import response_error
 from app.datamgmt.case.case_db import get_case
 from app.datamgmt.manage.manage_access_control_db import user_has_client_access
 from app.datamgmt.manage.manage_users_db import get_user
@@ -50,7 +51,6 @@ from app.models import Cases
 from app.models.authorization import Permissions
 from app.models.authorization import CaseAccessLevel
 
-from app.blueprints.responses import response_error
 from app.util import not_authenticated_redirection_url
 
 

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -36,7 +36,7 @@ from jwt import PyJWKClient
 from requests.auth import HTTPBasicAuth
 from werkzeug.utils import redirect
 
-from app import TEMPLATE_PATH
+from app import TEMPLATE_PATH, app
 
 from app import app
 from app import db
@@ -494,3 +494,7 @@ def is_user_authenticated(incoming_request: Request):
     }
 
     return authentication_mapper.get(app.config.get("AUTHENTICATION_TYPE"))(incoming_request)
+
+
+def is_authentication_oidc():
+    return app.config.get('AUTHENTICATION_TYPE') == "oidc"

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -21,7 +21,9 @@ import logging as log
 import uuid
 from functools import wraps
 
-from flask import request, session, render_template
+from flask import request
+from flask import session
+from flask import render_template
 from flask_login import current_user
 from flask_wtf import FlaskForm
 from werkzeug.utils import redirect
@@ -38,7 +40,6 @@ from app.util import log_exception_and_error
 from app.util import response_error
 from app.util import is_user_authenticated
 from app.util import not_authenticated_redirection_url
-from app.util import ac_api_return_access_denied
 
 
 def _user_has_at_least_a_required_permission(permissions: list[Permissions]):
@@ -328,3 +329,15 @@ def ac_socket_requires(*access_level):
 
         return wrap
     return inner_wrap
+
+
+def ac_api_return_access_denied(caseid: int = None):
+    error_uuid = uuid.uuid4()
+    log.warning(f"EID {error_uuid} - Access denied with case #{caseid} for user ID {current_user.id} "
+                f"accessing URI {request.full_path}")
+    data = {
+        'user_id': current_user.id,
+        'case_id': caseid,
+        'error_uuid': error_uuid
+    }
+    return response_error('Permission denied', data=data, status=403)

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -18,6 +18,7 @@
 
 import json
 import logging as log
+import traceback
 import uuid
 from functools import wraps
 
@@ -49,7 +50,6 @@ from app.models import Cases
 from app.models.authorization import Permissions
 from app.models.authorization import CaseAccessLevel
 
-from app.util import log_exception_and_error
 from app.util import response_error
 from app.util import not_authenticated_redirection_url
 
@@ -76,6 +76,11 @@ def _set_caseid_from_current_user():
         current_user.ctx_case = 1
     caseid = current_user.ctx_case
     return redir, caseid
+
+
+def _log_exception_and_error(e):
+    log.exception(e)
+    log.error(traceback.print_exc())
 
 
 def _get_caseid_from_request_data(request_data, no_cid_required):
@@ -112,7 +117,7 @@ def _get_caseid_from_request_data(request_data, no_cid_required):
             redir, caseid = _set_caseid_from_current_user()
             return redir, caseid, True
 
-        log_exception_and_error(e)
+        _log_exception_and_error(e)
         return True, 0, False
 
 

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -49,7 +49,6 @@ from app.models import Cases
 from app.models.authorization import Permissions
 from app.models.authorization import CaseAccessLevel
 
-from app.util import update_current_case
 from app.util import log_exception_and_error
 from app.util import response_error
 from app.util import not_authenticated_redirection_url
@@ -145,6 +144,18 @@ def _update_denied_case(caseid):
         'case_id': caseid,
         'access': '<i class="ml-2 text-danger mt-1 fa-solid fa-ban"></i>'
     }
+
+
+def update_current_case(caseid, restricted_access):
+    if session['current_case']['case_id'] != caseid:
+        case = get_case(caseid)
+        if case:
+            session['current_case'] = {
+                'case_name': "{}".format(case.name),
+                'case_info': "(#{} - {})".format(caseid, case.client.name),
+                'case_id': caseid,
+                'access': restricted_access
+            }
 
 
 def _update_session(caseid, eaccess_level):

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -50,7 +50,7 @@ from app.models import Cases
 from app.models.authorization import Permissions
 from app.models.authorization import CaseAccessLevel
 
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import not_authenticated_redirection_url
 
 

--- a/source/app/blueprints/graphql/graphql_route.py
+++ b/source/app/blueprints/graphql/graphql_route.py
@@ -34,7 +34,7 @@ from graphene import String
 from graphene_sqlalchemy import SQLAlchemyConnectionField
 
 from app.datamgmt.manage.manage_cases_db import build_filter_case_query
-from app.util import is_user_authenticated
+from app.blueprints.access_controls import is_user_authenticated
 from app.util import response_error
 
 from app.models.authorization import CaseAccessLevel

--- a/source/app/blueprints/graphql/graphql_route.py
+++ b/source/app/blueprints/graphql/graphql_route.py
@@ -35,7 +35,7 @@ from graphene_sqlalchemy import SQLAlchemyConnectionField
 
 from app.datamgmt.manage.manage_cases_db import build_filter_case_query
 from app.blueprints.access_controls import is_user_authenticated
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 from app.models.authorization import CaseAccessLevel
 

--- a/source/app/blueprints/pages/alerts/alerts_routes.py
+++ b/source/app/blueprints/pages/alerts/alerts_routes.py
@@ -28,7 +28,7 @@ from werkzeug import Response
 from app.datamgmt.alerts.alerts_db import get_alert_by_id
 from app.datamgmt.manage.manage_access_control_db import user_has_client_access
 from app.models.authorization import Permissions
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.blueprints.access_controls import ac_requires
 
 alerts_blueprint = Blueprint(

--- a/source/app/blueprints/pages/case/case_assets_routes.py
+++ b/source/app/blueprints/pages/case/case_assets_routes.py
@@ -34,7 +34,7 @@ from app.forms import AssetBasicForm
 from app.forms import ModalAddCaseAssetForm
 from app.models.authorization import CaseAccessLevel
 from app.blueprints.access_controls import ac_case_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 case_assets_blueprint = Blueprint('case_assets',
                                   __name__,

--- a/source/app/blueprints/pages/case/case_ioc_routes.py
+++ b/source/app/blueprints/pages/case/case_ioc_routes.py
@@ -34,7 +34,7 @@ from app.forms import ModalAddCaseIOCForm
 from app.models.authorization import CaseAccessLevel
 from app.models.models import Ioc
 from app.blueprints.access_controls import ac_case_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 case_ioc_blueprint = Blueprint(
     'case_ioc',

--- a/source/app/blueprints/pages/case/case_notes_routes.py
+++ b/source/app/blueprints/pages/case/case_notes_routes.py
@@ -27,8 +27,7 @@ from app.datamgmt.case.case_db import get_case
 from app.datamgmt.case.case_notes_db import get_note
 from app.models.authorization import CaseAccessLevel
 from app.blueprints.access_controls import ac_case_requires
-from app.util import response_error
-
+from app.blueprints.responses import response_error
 
 case_notes_blueprint = Blueprint('case_notes',
                                  __name__,

--- a/source/app/blueprints/pages/case/case_rfiles_routes.py
+++ b/source/app/blueprints/pages/case/case_rfiles_routes.py
@@ -28,7 +28,7 @@ from app.datamgmt.case.case_rfiles_db import get_rfile
 from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
 from app.models.authorization import CaseAccessLevel
 from app.blueprints.access_controls import ac_case_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 case_rfiles_blueprint = Blueprint(
     'case_rfiles',

--- a/source/app/blueprints/pages/case/case_tasks_routes.py
+++ b/source/app/blueprints/pages/case/case_tasks_routes.py
@@ -34,7 +34,7 @@ from app.models.authorization import CaseAccessLevel
 from app.models.authorization import User
 from app.models.models import CaseTasks
 from app.blueprints.access_controls import ac_case_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 case_tasks_blueprint = Blueprint('case_tasks',
                                  __name__,

--- a/source/app/blueprints/pages/case/case_timeline_routes.py
+++ b/source/app/blueprints/pages/case/case_timeline_routes.py
@@ -37,7 +37,7 @@ from app.models.authorization import User
 from app.models.cases import Cases
 from app.models.cases import CasesEvent
 from app.blueprints.access_controls import ac_case_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 _EVENT_TAGS = ['Network', 'Server', 'ActiveDirectory', 'Computer', 'Malware', 'User Interaction']
 

--- a/source/app/blueprints/pages/dashboard/dashboard_routes.py
+++ b/source/app/blueprints/pages/dashboard/dashboard_routes.py
@@ -34,9 +34,8 @@ from app.iris_engine.access_control.utils import ac_get_user_case_counts
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import User
 from app.models.models import GlobalTasks
-from app.blueprints.access_controls import ac_requires
+from app.blueprints.access_controls import ac_requires, is_authentication_oidc
 from app.util import not_authenticated_redirection_url
-from app.util import is_authentication_oidc
 
 from oic.oauth2.exception import GrantError
 

--- a/source/app/blueprints/pages/dashboard/dashboard_routes.py
+++ b/source/app/blueprints/pages/dashboard/dashboard_routes.py
@@ -34,8 +34,7 @@ from app.iris_engine.access_control.utils import ac_get_user_case_counts
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import User
 from app.models.models import GlobalTasks
-from app.blueprints.access_controls import ac_requires, is_authentication_oidc
-from app.util import not_authenticated_redirection_url
+from app.blueprints.access_controls import ac_requires, is_authentication_oidc, not_authenticated_redirection_url
 
 from oic.oauth2.exception import GrantError
 

--- a/source/app/blueprints/pages/datastore/datastore_routes.py
+++ b/source/app/blueprints/pages/datastore/datastore_routes.py
@@ -26,7 +26,7 @@ from app.datamgmt.datastore.datastore_db import datastore_get_path_node
 from app.forms import ModalDSFileForm
 from app.models.authorization import CaseAccessLevel
 from app.blueprints.access_controls import ac_case_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 datastore_blueprint = Blueprint(
     'datastore',

--- a/source/app/blueprints/pages/dim_tasks/dim_tasks.py
+++ b/source/app/blueprints/pages/dim_tasks/dim_tasks.py
@@ -27,7 +27,7 @@ import app
 from app.models.authorization import CaseAccessLevel
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_case_requires, ac_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from iris_interface.IrisInterfaceStatus import IIStatus
 
 dim_tasks_blueprint = Blueprint(

--- a/source/app/blueprints/pages/login/login_routes.py
+++ b/source/app/blueprints/pages/login/login_routes.py
@@ -48,9 +48,8 @@ from app.iris_engine.access_control.utils import ac_get_effective_permissions_of
 from app.iris_engine.utils.tracker import track_activity
 from app.models.cases import Cases
 
-from app.util import is_authentication_ldap
 from app.blueprints.responses import response_error
-from app.blueprints.access_controls import is_authentication_oidc
+from app.blueprints.access_controls import is_authentication_oidc, is_authentication_ldap
 from app.datamgmt.manage.manage_users_db import get_active_user_by_login, get_user
 from app.datamgmt.manage.manage_users_db import create_user
 

--- a/source/app/blueprints/pages/login/login_routes.py
+++ b/source/app/blueprints/pages/login/login_routes.py
@@ -50,7 +50,7 @@ from app.models.cases import Cases
 
 from app.util import is_authentication_ldap
 from app.blueprints.responses import response_error
-from app.util import is_authentication_oidc
+from app.blueprints.access_controls import is_authentication_oidc
 from app.datamgmt.manage.manage_users_db import get_active_user_by_login, get_user
 from app.datamgmt.manage.manage_users_db import create_user
 

--- a/source/app/blueprints/pages/login/login_routes.py
+++ b/source/app/blueprints/pages/login/login_routes.py
@@ -48,7 +48,8 @@ from app.iris_engine.access_control.utils import ac_get_effective_permissions_of
 from app.iris_engine.utils.tracker import track_activity
 from app.models.cases import Cases
 
-from app.util import is_authentication_ldap, response_error
+from app.util import is_authentication_ldap
+from app.blueprints.responses import response_error
 from app.util import is_authentication_oidc
 from app.datamgmt.manage.manage_users_db import get_active_user_by_login, get_user
 from app.datamgmt.manage.manage_users_db import create_user

--- a/source/app/blueprints/pages/manage/manage_assets_type_routes.py
+++ b/source/app/blueprints/pages/manage/manage_assets_type_routes.py
@@ -28,7 +28,7 @@ from app.forms import AddAssetForm
 from app.models.authorization import Permissions
 from app.models.models import AssetsType
 from app.blueprints.access_controls import ac_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 manage_assets_type_blueprint = Blueprint('manage_assets_type',
                                          __name__,

--- a/source/app/blueprints/pages/manage/manage_attributes_routes.py
+++ b/source/app/blueprints/pages/manage/manage_attributes_routes.py
@@ -28,7 +28,7 @@ from app.forms import AttributeForm
 from app.models.authorization import Permissions
 from app.models.models import CustomAttribute
 from app.blueprints.access_controls import ac_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 manage_attributes_blueprint = Blueprint('manage_attributes', __name__, template_folder='templates')
 

--- a/source/app/blueprints/pages/manage/manage_case_classification_routes.py
+++ b/source/app/blueprints/pages/manage/manage_case_classification_routes.py
@@ -26,7 +26,7 @@ from werkzeug.utils import redirect
 from app.datamgmt.manage.manage_case_classifications_db import get_case_classification_by_id
 from app.forms import CaseClassificationForm
 from app.models.authorization import Permissions
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.blueprints.access_controls import ac_requires
 
 manage_case_classification_blueprint = Blueprint('manage_case_classifications',

--- a/source/app/blueprints/pages/manage/manage_case_state.py
+++ b/source/app/blueprints/pages/manage/manage_case_state.py
@@ -26,7 +26,7 @@ from werkzeug.utils import redirect
 from app.datamgmt.manage.manage_case_state_db import get_case_state_by_id
 from app.forms import CaseStateForm
 from app.models.authorization import Permissions
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.blueprints.access_controls import ac_requires
 
 manage_case_state_blueprint = Blueprint('manage_case_state',

--- a/source/app/blueprints/pages/manage/manage_case_templates_routes.py
+++ b/source/app/blueprints/pages/manage/manage_case_templates_routes.py
@@ -25,7 +25,7 @@ from app.forms import CaseTemplateForm, AddAssetForm
 from app.models import CaseTemplate
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 manage_case_templates_blueprint = Blueprint('manage_case_templates',
                                             __name__,

--- a/source/app/blueprints/pages/manage/manage_cases_routes.py
+++ b/source/app/blueprints/pages/manage/manage_cases_routes.py
@@ -39,7 +39,7 @@ from app.iris_engine.access_control.utils import ac_current_user_has_permission
 from app.models.authorization import CaseAccessLevel
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseDetailsSchema
-from app.util import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.access_controls import ac_requires
 from app.util import response_error
 

--- a/source/app/blueprints/pages/manage/manage_cases_routes.py
+++ b/source/app/blueprints/pages/manage/manage_cases_routes.py
@@ -41,7 +41,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import CaseDetailsSchema
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.access_controls import ac_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 manage_cases_blueprint = Blueprint('manage_case',
                                    __name__,

--- a/source/app/blueprints/pages/manage/manage_customers_routes.py
+++ b/source/app/blueprints/pages/manage/manage_customers_routes.py
@@ -34,7 +34,7 @@ from app.schema.marshables import ContactSchema
 from app.blueprints.access_controls import ac_requires
 from app.blueprints.access_controls import ac_requires_client_access
 from app.blueprints.responses import page_not_found
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 manage_customers_blueprint = Blueprint(
     'manage_customers',

--- a/source/app/blueprints/pages/manage/manage_customers_routes.py
+++ b/source/app/blueprints/pages/manage/manage_customers_routes.py
@@ -33,7 +33,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import ContactSchema
 from app.blueprints.access_controls import ac_requires
 from app.blueprints.access_controls import ac_requires_client_access
-from app.util import page_not_found
+from app.blueprints.responses import page_not_found
 from app.util import response_error
 
 manage_customers_blueprint = Blueprint(

--- a/source/app/blueprints/pages/manage/manage_evidence_types_route.py
+++ b/source/app/blueprints/pages/manage/manage_evidence_types_route.py
@@ -26,7 +26,7 @@ from werkzeug.utils import redirect
 from app.datamgmt.manage.manage_evidence_types_db import get_evidence_type_by_id
 from app.forms import EvidenceTypeForm
 from app.models.authorization import Permissions
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.blueprints.access_controls import ac_requires
 
 manage_evidence_types_blueprint = Blueprint('manage_evidence_types',

--- a/source/app/blueprints/pages/manage/manage_groups_routes.py
+++ b/source/app/blueprints/pages/manage/manage_groups_routes.py
@@ -29,7 +29,7 @@ from app.iris_engine.access_control.utils import ac_get_all_access_level
 from app.iris_engine.access_control.utils import ac_get_all_permissions
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 manage_groups_blueprint = Blueprint(
         'manage_groups',

--- a/source/app/blueprints/pages/manage/manage_ioc_types_routes.py
+++ b/source/app/blueprints/pages/manage/manage_ioc_types_routes.py
@@ -25,7 +25,7 @@ from app.forms import AddIocTypeForm
 from app.models import IocType
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 manage_ioc_type_blueprint = Blueprint('manage_ioc_types',
                                       __name__,

--- a/source/app/blueprints/pages/manage/manage_modules_routes.py
+++ b/source/app/blueprints/pages/manage/manage_modules_routes.py
@@ -29,7 +29,7 @@ from app.forms import AddModuleForm
 from app.forms import UpdateModuleParameterForm
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 manage_modules_blueprint = Blueprint(
     'manage_module',

--- a/source/app/blueprints/pages/manage/manage_users.py
+++ b/source/app/blueprints/pages/manage/manage_users.py
@@ -33,7 +33,7 @@ from app.iris_engine.access_control.utils import ac_get_all_access_level
 from app.iris_engine.access_control.utils import ac_current_user_has_permission
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 manage_users_blueprint = Blueprint('manage_users', __name__, template_folder='templates')
 

--- a/source/app/blueprints/responses.py
+++ b/source/app/blueprints/responses.py
@@ -15,14 +15,18 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import datetime
+import decimal
 import json
+import pickle
+import uuid
 
 from flask import render_template
 from flask import request
+from sqlalchemy.orm import DeclarativeMeta
 
 from app import TEMPLATE_PATH
 from app import app
-from app.util import AlchemyEncoder
 
 
 # Set basic 404
@@ -57,3 +61,39 @@ def response_success(msg='', data=None):
         "data": data if data is not None else []
     }
     return response(200, data=content)
+
+
+class AlchemyEncoder(json.JSONEncoder):
+
+    def default(self, obj):
+        if isinstance(obj.__class__, DeclarativeMeta):
+            # an SQLAlchemy class
+            fields = {}
+            for field in [x for x in dir(obj) if not x.startswith('_') and x != 'metadata'
+                                                 and x != 'query' and x != 'query_class']:
+                data = obj.__getattribute__(field)
+                try:
+                    json.dumps(data)  # this will fail on non-encodable values, like other classes
+                    fields[field] = data
+                except TypeError:
+                    fields[field] = None
+            # a json-encodable dict
+            return fields
+
+        if isinstance(obj, decimal.Decimal):
+            return str(obj)
+
+        if isinstance(obj, datetime.datetime) or isinstance(obj, datetime.date):
+            return obj.isoformat()
+
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
+
+        else:
+            if obj.__class__ == bytes:
+                try:
+                    return pickle.load(obj)
+                except Exception:
+                    return str(obj)
+
+        return json.JSONEncoder.default(self, obj)

--- a/source/app/blueprints/responses.py
+++ b/source/app/blueprints/responses.py
@@ -1,0 +1,34 @@
+#  IRIS Source Code
+#  Copyright (C) 2024 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from flask import render_template
+from flask import request
+
+from app import TEMPLATE_PATH
+from app import app
+from app.util import response_error
+
+
+# Set basic 404
+@app.errorhandler(404)
+def page_not_found(e):
+    # note that we set the 404 status explicitly
+    if request.content_type and 'application/json' in request.content_type:
+        return response_error("Resource not found", status=404)
+
+    return render_template('pages/error-404.html', template_folder=TEMPLATE_PATH), 404

--- a/source/app/blueprints/responses.py
+++ b/source/app/blueprints/responses.py
@@ -15,13 +15,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import json
 
 from flask import render_template
 from flask import request
 
 from app import TEMPLATE_PATH
 from app import app
-from app.util import response
+from app.util import AlchemyEncoder
 
 
 # Set basic 404
@@ -32,6 +33,12 @@ def page_not_found(e):
         return response_error("Resource not found", status=404)
 
     return render_template('pages/error-404.html', template_folder=TEMPLATE_PATH), 404
+
+
+def response(status, data=None):
+    if data is not None:
+        data = json.dumps(data, cls=AlchemyEncoder)
+    return app.response_class(response=data, status=status, mimetype='application/json')
 
 
 def response_error(msg, data=None, status=400):

--- a/source/app/blueprints/responses.py
+++ b/source/app/blueprints/responses.py
@@ -21,7 +21,7 @@ from flask import request
 
 from app import TEMPLATE_PATH
 from app import app
-from app.util import response_error
+from app.util import response
 
 
 # Set basic 404
@@ -32,3 +32,12 @@ def page_not_found(e):
         return response_error("Resource not found", status=404)
 
     return render_template('pages/error-404.html', template_folder=TEMPLATE_PATH), 404
+
+
+def response_error(msg, data=None, status=400):
+    content = {
+        'status': 'error',
+        'message': msg,
+        'data': data if data is not None else []
+    }
+    return response(status, data=content)

--- a/source/app/blueprints/responses.py
+++ b/source/app/blueprints/responses.py
@@ -41,3 +41,12 @@ def response_error(msg, data=None, status=400):
         'data': data if data is not None else []
     }
     return response(status, data=content)
+
+
+def response_success(msg='', data=None):
+    content = {
+        "status": "success",
+        "message": msg,
+        "data": data if data is not None else []
+    }
+    return response(200, data=content)

--- a/source/app/blueprints/rest/activities_routes.py
+++ b/source/app/blueprints/rest/activities_routes.py
@@ -22,7 +22,7 @@ from app.datamgmt.activities.activities_db import get_all_users_activities
 from app.datamgmt.activities.activities_db import get_users_activities
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 activities_rest_blueprint = Blueprint('activities_rest', __name__)
 

--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -57,7 +57,7 @@ from app.schema.marshables import CommentSchema
 from app.schema.marshables import CaseAssetsSchema
 from app.schema.marshables import IocSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import add_obj_history_entry
 from app.util import response_success
 

--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -59,7 +59,7 @@ from app.schema.marshables import IocSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
 from app.util import add_obj_history_entry
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 alerts_rest_blueprint = Blueprint('alerts_rest', __name__)
 

--- a/source/app/blueprints/rest/api_routes.py
+++ b/source/app/blueprints/rest/api_routes.py
@@ -20,7 +20,7 @@ from flask import Blueprint
 
 from app import app
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 rest_api_blueprint = Blueprint('rest_api', __name__)
 

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -26,10 +26,6 @@ from flask_login import current_user
 from app import db
 from app.blueprints.rest.case_comments import case_comment_update
 from app.blueprints.rest.endpoints import endpoint_deprecated
-from app.blueprints.rest.endpoints import response_api_deleted
-from app.blueprints.rest.endpoints import response_api_success
-from app.blueprints.rest.endpoints import response_api_error
-from app.blueprints.rest.endpoints import response_api_created
 from app.business.assets import assets_delete
 from app.business.assets import assets_create
 from app.business.assets import assets_get_detailed
@@ -59,7 +55,8 @@ from app.models import AnalysisStatus
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
 from app.schema.marshables import CommentSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, ac_api_requires
+from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
 from app.util import ac_api_return_access_denied

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -59,8 +59,7 @@ from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
-from app.util import ac_api_return_access_denied
-
+from app.blueprints.access_controls import ac_api_return_access_denied
 
 case_assets_rest_blueprint = Blueprint('case_assets_rest', __name__)
 

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -57,7 +57,7 @@ from app.schema.marshables import CaseAssetsSchema
 from app.schema.marshables import CommentSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 from app.blueprints.access_controls import ac_api_return_access_denied
 

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -58,7 +58,7 @@ from app.schema.marshables import CommentSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from app.blueprints.access_controls import ac_api_return_access_denied
 
 case_assets_rest_blueprint = Blueprint('case_assets_rest', __name__)

--- a/source/app/blueprints/rest/case/case_evidences_routes.py
+++ b/source/app/blueprints/rest/case/case_evidences_routes.py
@@ -42,7 +42,7 @@ from app.schema.marshables import CaseEvidenceSchema
 from app.schema.marshables import CommentSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 case_evidences_rest_blueprint = Blueprint('case_evidences_rest', __name__)

--- a/source/app/blueprints/rest/case/case_evidences_routes.py
+++ b/source/app/blueprints/rest/case/case_evidences_routes.py
@@ -43,7 +43,7 @@ from app.schema.marshables import CommentSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 case_evidences_rest_blueprint = Blueprint('case_evidences_rest', __name__)
 

--- a/source/app/blueprints/rest/case/case_graphs_routes.py
+++ b/source/app/blueprints/rest/case/case_graphs_routes.py
@@ -26,7 +26,7 @@ from app.datamgmt.case.case_events_db import get_case_events_ioc_graph
 from app.models.authorization import CaseAccessLevel
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 case_graph_rest_blueprint = Blueprint('case_graph_rest', __name__)
 

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -54,7 +54,7 @@ from app.schema.marshables import IocSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 case_ioc_rest_blueprint = Blueprint('case_ioc_rest', __name__)

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -27,11 +27,6 @@ from flask_login import current_user
 
 from app import db
 from app.blueprints.rest.case_comments import case_comment_update
-from app.blueprints.rest.endpoints import response_api_deleted
-from app.blueprints.rest.endpoints import response_api_not_found
-from app.blueprints.rest.endpoints import response_api_success
-from app.blueprints.rest.endpoints import response_api_created
-from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import endpoint_deprecated
 from app.business.iocs import iocs_create
 from app.business.iocs import iocs_update
@@ -40,7 +35,6 @@ from app.business.iocs import iocs_get
 from app.business.errors import BusinessProcessingError
 from app.business.errors import ObjectNotFoundError
 from app.datamgmt.case.case_iocs_db import add_comment_to_ioc
-from app.datamgmt.case.case_iocs_db import get_filtered_iocs
 from app.datamgmt.case.case_iocs_db import add_ioc
 from app.datamgmt.case.case_iocs_db import delete_ioc_comment
 from app.datamgmt.case.case_iocs_db import get_case_ioc_comment
@@ -57,7 +51,6 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CommentSchema
 from app.schema.marshables import IocSchema
-from app.schema.marshables import IocSchemaForAPIV2
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.util import ac_api_return_access_denied

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -53,7 +53,7 @@ from app.schema.marshables import CommentSchema
 from app.schema.marshables import IocSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -214,6 +214,7 @@ def deprecated_case_delete_ioc(cur_id, caseid):
     except BusinessProcessingError as e:
         return response_error(e.get_message())
 
+
 @case_ioc_rest_blueprint.route('/case/ioc/<int:cur_id>', methods=['GET'])
 @endpoint_deprecated('GET', '/api/v2/iocs/<int:cur_id>')
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)

--- a/source/app/blueprints/rest/case/case_ioc_routes.py
+++ b/source/app/blueprints/rest/case/case_ioc_routes.py
@@ -55,7 +55,7 @@ from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 case_ioc_rest_blueprint = Blueprint('case_ioc_rest', __name__)
 

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -55,7 +55,7 @@ from app.schema.marshables import CommentSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import endpoint_removed
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 case_notes_rest_blueprint = Blueprint('case_notes_rest', __name__)

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -56,7 +56,7 @@ from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import endpoint_removed
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 case_notes_rest_blueprint = Blueprint('case_notes_rest', __name__)
 

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -54,7 +54,7 @@ from app.schema.marshables import CaseNoteSchema
 from app.schema.marshables import CommentSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import endpoint_removed
+from app.blueprints.rest.endpoints import endpoint_removed
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -414,7 +414,7 @@ def get_cases() -> Response:
     cases = {
         'total': filtered_cases.total,
         # TODO should maybe really uniform all return types of paginated list and replace field cases by field data
-        'cases': CaseSchemaForAPIV2().dump(filtered_cases.items, many=True),
+        'data': CaseSchemaForAPIV2().dump(filtered_cases.items, many=True),
         'last_page': filtered_cases.pages,
         'current_page': filtered_cases.page,
         'next_page': filtered_cases.next_num if filtered_cases.has_next else None,

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -71,7 +71,7 @@ from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 case_rest_blueprint = Blueprint('case_rest', __name__)

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -70,7 +70,7 @@ from app.schema.marshables import CaseSchemaForAPIV2
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
-from app.util import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -72,7 +72,7 @@ from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 case_rest_blueprint = Blueprint('case_rest', __name__)
 

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -42,8 +42,8 @@ from app.blueprints.rest.endpoints import response_api_error
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.business.cases import cases_create
 from app.business.cases import cases_delete
+from app.business.cases import cases_exists
 from app.business.errors import BusinessProcessingError
-from app.datamgmt.case.case_db import case_db_exists
 from app.datamgmt.case.case_db import get_review_id_from_name
 from app.datamgmt.case.case_db import case_get_desc_crc
 from app.datamgmt.case.case_db import get_case
@@ -83,9 +83,9 @@ log = app.logger
 @endpoint_deprecated('GET', '/api/v2/cases/<int:identifier>')
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
-def case_exists_r(caseid):
+def case_routes_exists(caseid):
 
-    if case_db_exists(caseid):
+    if cases_exists(caseid):
         return response_success('Case exists')
     return response_error('Case does not exist', 404)
 

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -43,7 +43,7 @@ from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_
 from app.business.cases import cases_create
 from app.business.cases import cases_delete
 from app.business.errors import BusinessProcessingError
-from app.datamgmt.case.case_db import case_exists
+from app.datamgmt.case.case_db import case_db_exists
 from app.datamgmt.case.case_db import get_review_id_from_name
 from app.datamgmt.case.case_db import case_get_desc_crc
 from app.datamgmt.case.case_db import get_case
@@ -85,7 +85,7 @@ log = app.logger
 @ac_api_requires()
 def case_exists_r(caseid):
 
-    if case_exists(caseid):
+    if case_db_exists(caseid):
         return response_success('Case exists')
     return response_error('Case does not exist', 404)
 

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -56,7 +56,7 @@ from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 case_tasks_rest_blueprint = Blueprint('case_tasks_rest', __name__)
 

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -55,7 +55,7 @@ from app.schema.marshables import CommentSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 case_tasks_rest_blueprint = Blueprint('case_tasks_rest', __name__)

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -199,6 +199,8 @@ def case_delete_task(identifier):
 
         tasks_delete(task)
         return response_api_deleted()
+    except ObjectNotFoundError:
+        return response_api_not_found()
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
 

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -25,13 +25,8 @@ from flask_login import current_user
 
 from app import db
 from app.blueprints.rest.case_comments import case_comment_update
-from app.blueprints.rest.endpoints import response_api_deleted
-from app.blueprints.rest.endpoints import response_api_not_found
 from app.blueprints.rest.endpoints import endpoint_deprecated
-from app.blueprints.rest.endpoints import response_api_error
-from app.blueprints.rest.endpoints import response_api_created
 from app.business.errors import BusinessProcessingError
-from app.business.errors import ObjectNotFoundError
 from app.business.tasks import tasks_delete
 from app.business.tasks import tasks_create
 from app.business.tasks import tasks_get
@@ -46,7 +41,6 @@ from app.datamgmt.case.case_tasks_db import get_tasks_status
 from app.datamgmt.case.case_tasks_db import get_tasks_with_assignees
 from app.datamgmt.case.case_tasks_db import update_task_status
 from app.datamgmt.states import get_tasks_state
-from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import CaseAccessLevel
@@ -54,7 +48,6 @@ from app.schema.marshables import CaseTaskSchema
 from app.schema.marshables import CommentSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.responses import response_error
 from app.blueprints.responses import response_success
 
@@ -123,20 +116,6 @@ def deprecated_case_add_task(caseid):
         return response_error(e.get_message(), data=e.get_data())
 
 
-@case_tasks_rest_blueprint.route('/api/v2/cases/<int:identifier>/tasks', methods=['POST'])
-@ac_api_requires()
-def case_add_task(identifier):
-    if not ac_fast_check_current_user_has_case_access(identifier, [CaseAccessLevel.full_access]):
-        return ac_api_return_access_denied(caseid=identifier)
-
-    task_schema = CaseTaskSchema()
-    try:
-        _, case = tasks_create(identifier, request.get_json())
-        return response_api_created(task_schema.dump(case))
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message())
-
-
 @case_tasks_rest_blueprint.route('/case/tasks/<int:cur_id>', methods=['GET'])
 @endpoint_deprecated('GET', '/api/v2/tasks/<int:cur_id>')
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
@@ -149,20 +128,6 @@ def deprecated_case_task_view(cur_id, caseid):
     task_schema = CaseTaskSchema()
 
     return response_success(data=task_schema.dump(task))
-
-
-@case_tasks_rest_blueprint.route('/api/v2/tasks/<int:identifier>', methods=['GET'])
-@ac_api_requires()
-def case_task_view(identifier):
-    try:
-        task = tasks_get(identifier)
-        if not ac_fast_check_current_user_has_case_access(task.task_case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
-            return ac_api_return_access_denied(caseid=task.task_case_id)
-
-        task_schema = CaseTaskSchema()
-        return response_api_created(task_schema.dump(task))
-    except ObjectNotFoundError:
-        return response_api_not_found()
 
 
 @case_tasks_rest_blueprint.route('/case/tasks/update/<int:cur_id>', methods=['POST'])
@@ -187,22 +152,6 @@ def deprecated_case_delete_task(cur_id, caseid):
         return response_success('Task deleted')
     except BusinessProcessingError as e:
         return response_error(e.get_message())
-
-
-@case_tasks_rest_blueprint.route('/api/v2/tasks/<int:identifier>', methods=['DELETE'])
-@ac_api_requires()
-def case_delete_task(identifier):
-    try:
-        task = tasks_get(identifier)
-        if not ac_fast_check_current_user_has_case_access(task.task_case_id, [CaseAccessLevel.full_access]):
-            return ac_api_return_access_denied(caseid=identifier)
-
-        tasks_delete(task)
-        return response_api_deleted()
-    except ObjectNotFoundError:
-        return response_api_not_found()
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message())
 
 
 @case_tasks_rest_blueprint.route('/case/tasks/<int:cur_id>/comments/list', methods=['GET'])

--- a/source/app/blueprints/rest/case/case_tasks_routes.py
+++ b/source/app/blueprints/rest/case/case_tasks_routes.py
@@ -54,7 +54,7 @@ from app.schema.marshables import CaseTaskSchema
 from app.schema.marshables import CommentSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -69,7 +69,7 @@ from app.schema.marshables import EventSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 case_timeline_rest_blueprint = Blueprint('case_timeline_rest', __name__)

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -679,7 +679,7 @@ def event_view(cur_id, caseid):
     return response_success(data=output)
 
 
-@case_timeline_rest_blueprint.route('/case/timeline/events/update/<int:cur_id>', methods=["POST"])
+@case_timeline_rest_blueprint.route('/case/timeline/events/update/<int:cur_id>', methods=['POST'])
 @ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_edit_event(cur_id, caseid):

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -70,7 +70,7 @@ from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 case_timeline_rest_blueprint = Blueprint('case_timeline_rest', __name__)
 

--- a/source/app/blueprints/rest/case_comments.py
+++ b/source/app/blueprints/rest/case_comments.py
@@ -21,7 +21,7 @@ import marshmallow
 from flask import request
 
 from app.schema.marshables import CommentSchema
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 from app.business.case_comments import case_comments_update
 from app.business.errors import BusinessProcessingError

--- a/source/app/blueprints/rest/case_comments.py
+++ b/source/app/blueprints/rest/case_comments.py
@@ -22,7 +22,7 @@ from flask import request
 
 from app.schema.marshables import CommentSchema
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from app.business.case_comments import case_comments_update
 from app.business.errors import BusinessProcessingError
 

--- a/source/app/blueprints/rest/context_routes.py
+++ b/source/app/blueprints/rest/context_routes.py
@@ -28,8 +28,7 @@ from app.datamgmt.context.context_db import ctx_search_user_cases
 from app.models.authorization import Permissions
 from app.models.cases import Cases
 from app.models.models import Client
-from app.blueprints.access_controls import ac_api_requires
-from app.util import not_authenticated_redirection_url
+from app.blueprints.access_controls import ac_api_requires, not_authenticated_redirection_url
 from app.blueprints.responses import response_success
 
 context_rest_blueprint = Blueprint('context_rest', __name__)

--- a/source/app/blueprints/rest/context_routes.py
+++ b/source/app/blueprints/rest/context_routes.py
@@ -30,7 +30,7 @@ from app.models.cases import Cases
 from app.models.models import Client
 from app.blueprints.access_controls import ac_api_requires
 from app.util import not_authenticated_redirection_url
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 context_rest_blueprint = Blueprint('context_rest', __name__)
 

--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -42,12 +42,11 @@ from app.models.models import TaskStatus
 from app.schema.marshables import CaseTaskSchema
 from app.schema.marshables import CaseDetailsSchema
 from app.schema.marshables import GlobalTasksSchema
-from app.blueprints.access_controls import ac_requires_case_identifier
+from app.blueprints.access_controls import ac_requires_case_identifier, is_authentication_oidc
 from app.blueprints.access_controls import ac_api_requires
 from app.util import not_authenticated_redirection_url
 from app.blueprints.responses import response_error
 from app.blueprints.responses import response_success
-from app.util import is_authentication_oidc
 
 from oic.oauth2.exception import GrantError
 

--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -42,9 +42,9 @@ from app.models.models import TaskStatus
 from app.schema.marshables import CaseTaskSchema
 from app.schema.marshables import CaseDetailsSchema
 from app.schema.marshables import GlobalTasksSchema
-from app.blueprints.access_controls import ac_requires_case_identifier, is_authentication_oidc
+from app.blueprints.access_controls import ac_requires_case_identifier, is_authentication_oidc, \
+    not_authenticated_redirection_url
 from app.blueprints.access_controls import ac_api_requires
-from app.util import not_authenticated_redirection_url
 from app.blueprints.responses import response_error
 from app.blueprints.responses import response_success
 

--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -44,7 +44,8 @@ from app.schema.marshables import CaseDetailsSchema
 from app.schema.marshables import GlobalTasksSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error, not_authenticated_redirection_url
+from app.util import not_authenticated_redirection_url
+from app.blueprints.responses import response_error
 from app.util import response_success
 from app.util import is_authentication_oidc
 

--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -46,7 +46,7 @@ from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.util import not_authenticated_redirection_url
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from app.util import is_authentication_oidc
 
 from oic.oauth2.exception import GrantError

--- a/source/app/blueprints/rest/datastore_routes.py
+++ b/source/app/blueprints/rest/datastore_routes.py
@@ -50,7 +50,7 @@ from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 datastore_rest_blueprint = Blueprint('datastore_rest', __name__)
 

--- a/source/app/blueprints/rest/datastore_routes.py
+++ b/source/app/blueprints/rest/datastore_routes.py
@@ -49,7 +49,7 @@ from app.schema.marshables import DSPathSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.util import add_obj_history_entry
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 datastore_rest_blueprint = Blueprint('datastore_rest', __name__)

--- a/source/app/blueprints/rest/dim_tasks_routes.py
+++ b/source/app/blueprints/rest/dim_tasks_routes.py
@@ -39,7 +39,7 @@ from app.models.alerts import Alert
 from app.models.authorization import CaseAccessLevel
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 from iris_interface.IrisInterfaceStatus import IIStatus
 

--- a/source/app/blueprints/rest/dim_tasks_routes.py
+++ b/source/app/blueprints/rest/dim_tasks_routes.py
@@ -40,7 +40,7 @@ from app.models.authorization import CaseAccessLevel
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from iris_interface.IrisInterfaceStatus import IIStatus
 
 dim_tasks_rest_blueprint = Blueprint('dim_tasks_rest', __name__)

--- a/source/app/blueprints/rest/endpoints.py
+++ b/source/app/blueprints/rest/endpoints.py
@@ -20,7 +20,7 @@ from functools import wraps
 
 from app import app
 from app.util import response
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 logger = app.logger
 

--- a/source/app/blueprints/rest/endpoints.py
+++ b/source/app/blueprints/rest/endpoints.py
@@ -17,9 +17,10 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from functools import wraps
+
 from app import app
-from app.business.errors import BusinessProcessingError
 from app.util import response
+from app.util import response_error
 
 logger = app.logger
 
@@ -58,5 +59,14 @@ def endpoint_deprecated(alternative_verb, alternative_url):
             result.headers['Link'] = f'<{alternative_url}>; rel="alternate"'
             result.headers['Deprecation'] = True
             return result
+        return wrap
+    return inner_wrap
+
+
+def endpoint_removed(message, version):
+    def inner_wrap(f):
+        @wraps(f)
+        def wrap(*args, **kwargs):
+            return response_error(f"Endpoint deprecated in {version}. {message}.", status=410)
         return wrap
     return inner_wrap

--- a/source/app/blueprints/rest/endpoints.py
+++ b/source/app/blueprints/rest/endpoints.py
@@ -19,8 +19,7 @@
 from functools import wraps
 
 from app import app
-from app.util import response
-from app.blueprints.responses import response_error
+from app.blueprints.responses import response_error, response
 
 logger = app.logger
 

--- a/source/app/blueprints/rest/filters_routes.py
+++ b/source/app/blueprints/rest/filters_routes.py
@@ -27,7 +27,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import SavedFilterSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.util import response_success
-from app.util import response_error
+from app.blueprints.responses import response_error
 
 saved_filters_rest_blueprint = Blueprint('saved_filters_rest', __name__)
 

--- a/source/app/blueprints/rest/filters_routes.py
+++ b/source/app/blueprints/rest/filters_routes.py
@@ -26,7 +26,7 @@ from app.datamgmt.filters.filters_db import list_filters_by_type
 from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import SavedFilterSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_success
+from app.blueprints.responses import response_success
 from app.blueprints.responses import response_error
 
 saved_filters_rest_blueprint = Blueprint('saved_filters_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_access_control_routes.py
+++ b/source/app/blueprints/rest/manage/manage_access_control_routes.py
@@ -25,7 +25,7 @@ from app.iris_engine.access_control.utils import ac_trace_effective_user_permiss
 from app.iris_engine.access_control.utils import ac_trace_user_effective_cases_access_2
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_ac_rest_blueprint = Blueprint('access_control_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_alerts_status_routes.py
+++ b/source/app/blueprints/rest/manage/manage_alerts_status_routes.py
@@ -27,7 +27,7 @@ from app.schema.marshables import AlertStatusSchema
 from app.schema.marshables import AlertResolutionSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_alerts_status_rest_blueprint = Blueprint('manage_alerts_status_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_alerts_status_routes.py
+++ b/source/app/blueprints/rest/manage/manage_alerts_status_routes.py
@@ -26,7 +26,7 @@ from app.datamgmt.alerts.alerts_db import search_alert_resolution_by_name
 from app.schema.marshables import AlertStatusSchema
 from app.schema.marshables import AlertResolutionSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_alerts_status_rest_blueprint = Blueprint('manage_alerts_status_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_analysis_status_routes.py
+++ b/source/app/blueprints/rest/manage/manage_analysis_status_routes.py
@@ -25,7 +25,7 @@ from app.datamgmt.manage.manage_case_objs import search_analysis_status_by_name
 from app.models.models import AnalysisStatus
 from app.schema.marshables import AnalysisStatusSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_analysis_status_rest_blueprint = Blueprint('manage_analysis_status_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_analysis_status_routes.py
+++ b/source/app/blueprints/rest/manage/manage_analysis_status_routes.py
@@ -26,7 +26,7 @@ from app.models.models import AnalysisStatus
 from app.schema.marshables import AnalysisStatusSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_analysis_status_rest_blueprint = Blueprint('manage_analysis_status_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_assets_routes.py
+++ b/source/app/blueprints/rest/manage/manage_assets_routes.py
@@ -26,7 +26,7 @@ from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_assets_rest_blueprint = Blueprint('manage_assets_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_assets_routes.py
+++ b/source/app/blueprints/rest/manage/manage_assets_routes.py
@@ -25,7 +25,7 @@ from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.util import response_success
 
 manage_assets_rest_blueprint = Blueprint('manage_assets_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_assets_type_routes.py
+++ b/source/app/blueprints/rest/manage/manage_assets_type_routes.py
@@ -33,7 +33,7 @@ from app.models.models import CaseAssets
 from app.schema.marshables import AssetTypeSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_assets_type_rest_blueprint = Blueprint('manage_assets_type_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_assets_type_routes.py
+++ b/source/app/blueprints/rest/manage/manage_assets_type_routes.py
@@ -32,7 +32,7 @@ from app.models.models import AssetsType
 from app.models.models import CaseAssets
 from app.schema.marshables import AssetTypeSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_assets_type_rest_blueprint = Blueprint('manage_assets_type_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_attributes_routes.py
+++ b/source/app/blueprints/rest/manage/manage_attributes_routes.py
@@ -25,7 +25,7 @@ from app.datamgmt.manage.manage_attribute_db import validate_attribute
 from app.models.authorization import Permissions
 from app.models.models import CustomAttribute
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_attributes_rest_blueprint = Blueprint('manage_attributes_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_attributes_routes.py
+++ b/source/app/blueprints/rest/manage/manage_attributes_routes.py
@@ -26,7 +26,7 @@ from app.models.authorization import Permissions
 from app.models.models import CustomAttribute
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_attributes_rest_blueprint = Blueprint('manage_attributes_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_case_classifications_routes.py
+++ b/source/app/blueprints/rest/manage/manage_case_classifications_routes.py
@@ -30,7 +30,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseClassificationSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_case_classification_rest_blueprint = Blueprint('manage_case_classifications_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_case_classifications_routes.py
+++ b/source/app/blueprints/rest/manage/manage_case_classifications_routes.py
@@ -31,7 +31,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import CaseClassificationSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_case_classification_rest_blueprint = Blueprint('manage_case_classifications_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_case_state.py
+++ b/source/app/blueprints/rest/manage/manage_case_state.py
@@ -31,7 +31,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import CaseStateSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_case_state_rest_blueprint = Blueprint('manage_case_state_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_case_state.py
+++ b/source/app/blueprints/rest/manage/manage_case_state.py
@@ -30,7 +30,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import CaseStateSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_case_state_rest_blueprint = Blueprint('manage_case_state_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_case_templates_routes.py
+++ b/source/app/blueprints/rest/manage/manage_case_templates_routes.py
@@ -34,7 +34,7 @@ from app.schema.marshables import CaseTemplateSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_case_templates_rest_blueprint = Blueprint('manage_case_templates_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_case_templates_routes.py
+++ b/source/app/blueprints/rest/manage/manage_case_templates_routes.py
@@ -33,7 +33,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import CaseTemplateSchema
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_case_templates_rest_blueprint = Blueprint('manage_case_templates_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -52,7 +52,7 @@ from app.schema.marshables import CaseDetailsSchema
 from app.util import add_obj_history_entry
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success
 from app.business.cases import cases_delete

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -54,7 +54,7 @@ from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from app.business.cases import cases_delete
 from app.business.cases import cases_update
 from app.business.cases import cases_create

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -53,7 +53,7 @@ from app.util import add_obj_history_entry
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 from app.business.cases import cases_delete
 from app.business.cases import cases_update

--- a/source/app/blueprints/rest/manage/manage_customers_routes.py
+++ b/source/app/blueprints/rest/manage/manage_customers_routes.py
@@ -44,7 +44,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import ContactSchema
 from app.schema.marshables import CustomerSchema
 from app.blueprints.access_controls import ac_api_requires_client_access
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_customers_rest_blueprint = Blueprint('manage_customers_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_customers_routes.py
+++ b/source/app/blueprints/rest/manage/manage_customers_routes.py
@@ -50,7 +50,7 @@ from app.blueprints.responses import response_success
 manage_customers_rest_blueprint = Blueprint('manage_customers_rest', __name__)
 
 
-@manage_customers_rest_blueprint.route('/manage/customers/list')
+@manage_customers_rest_blueprint.route('/manage/customers/list', methods=['GET'])
 @ac_api_requires(Permissions.customers_read)
 def list_customers():
     user_is_server_administrator = ac_current_user_has_permission(Permissions.server_administrator)

--- a/source/app/blueprints/rest/manage/manage_customers_routes.py
+++ b/source/app/blueprints/rest/manage/manage_customers_routes.py
@@ -43,7 +43,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import ContactSchema
 from app.schema.marshables import CustomerSchema
-from app.util import ac_api_requires_client_access
+from app.blueprints.access_controls import ac_api_requires_client_access
 from app.util import response_error
 from app.util import response_success
 

--- a/source/app/blueprints/rest/manage/manage_customers_routes.py
+++ b/source/app/blueprints/rest/manage/manage_customers_routes.py
@@ -45,7 +45,7 @@ from app.schema.marshables import ContactSchema
 from app.schema.marshables import CustomerSchema
 from app.blueprints.access_controls import ac_api_requires_client_access
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_customers_rest_blueprint = Blueprint('manage_customers_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_event_categories_routes.py
+++ b/source/app/blueprints/rest/manage/manage_event_categories_routes.py
@@ -22,7 +22,7 @@ from app.datamgmt.manage.manage_case_objs import search_event_category_by_name
 from app.models.models import EventCategory
 from app.schema.marshables import EventCategorySchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_event_categories_rest_blueprint = Blueprint('manage_event_categories_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_event_categories_routes.py
+++ b/source/app/blueprints/rest/manage/manage_event_categories_routes.py
@@ -23,7 +23,7 @@ from app.models.models import EventCategory
 from app.schema.marshables import EventCategorySchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_event_categories_rest_blueprint = Blueprint('manage_event_categories_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_evidence_types_routes.py
+++ b/source/app/blueprints/rest/manage/manage_evidence_types_routes.py
@@ -31,7 +31,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import EvidenceTypeSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_evidence_types_rest_blueprint = Blueprint('manage_evidence_types_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_evidence_types_routes.py
+++ b/source/app/blueprints/rest/manage/manage_evidence_types_routes.py
@@ -30,7 +30,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import EvidenceTypeSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_evidence_types_rest_blueprint = Blueprint('manage_evidence_types_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_groups.py
+++ b/source/app/blueprints/rest/manage/manage_groups.py
@@ -46,7 +46,7 @@ from app.schema.marshables import AuthorizationGroupSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from app.iris_engine.demo_builder import protect_demo_mode_group
 
 manage_groups_rest_blueprint = Blueprint('manage_groups_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_groups.py
+++ b/source/app/blueprints/rest/manage/manage_groups.py
@@ -44,7 +44,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import AuthorizationGroupSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.util import response_error
 from app.util import response_success
 from app.iris_engine.demo_builder import protect_demo_mode_group

--- a/source/app/blueprints/rest/manage/manage_groups.py
+++ b/source/app/blueprints/rest/manage/manage_groups.py
@@ -45,7 +45,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import AuthorizationGroupSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 from app.iris_engine.demo_builder import protect_demo_mode_group
 

--- a/source/app/blueprints/rest/manage/manage_ioc_types_routes.py
+++ b/source/app/blueprints/rest/manage/manage_ioc_types_routes.py
@@ -29,7 +29,7 @@ from app.models import IocType
 from app.models.authorization import Permissions
 from app.schema.marshables import IocTypeSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_ioc_type_rest_blueprint = Blueprint('manage_ioc_types_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_ioc_types_routes.py
+++ b/source/app/blueprints/rest/manage/manage_ioc_types_routes.py
@@ -30,7 +30,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import IocTypeSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_ioc_type_rest_blueprint = Blueprint('manage_ioc_types_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_modules_routes.py
+++ b/source/app/blueprints/rest/manage/manage_modules_routes.py
@@ -39,7 +39,7 @@ from app.iris_engine.module_handler.module_handler import register_module
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 from app.schema.marshables import IrisModuleSchema
 

--- a/source/app/blueprints/rest/manage/manage_modules_routes.py
+++ b/source/app/blueprints/rest/manage/manage_modules_routes.py
@@ -216,7 +216,7 @@ def view_modules_hook():
 
 
 # TODO is this endpoint still useful?
-@manage_modules_rest_blueprint.route("/sitemap")
+@manage_modules_rest_blueprint.route('/sitemap', methods=['GET'])
 @ac_api_requires()
 def site_map():
     links = []

--- a/source/app/blueprints/rest/manage/manage_modules_routes.py
+++ b/source/app/blueprints/rest/manage/manage_modules_routes.py
@@ -40,7 +40,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from app.schema.marshables import IrisModuleSchema
 
 manage_modules_rest_blueprint = Blueprint('manage_module_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_server_settings_routes.py
+++ b/source/app/blueprints/rest/manage/manage_server_settings_routes.py
@@ -31,7 +31,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
 from app.schema.marshables import ServerSettingsSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 from dictdiffer import diff
 

--- a/source/app/blueprints/rest/manage/manage_server_settings_routes.py
+++ b/source/app/blueprints/rest/manage/manage_server_settings_routes.py
@@ -32,7 +32,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import ServerSettingsSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from dictdiffer import diff
 
 manage_server_settings_rest_blueprint = Blueprint('manage_server_settings_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_severities_routes.py
+++ b/source/app/blueprints/rest/manage/manage_severities_routes.py
@@ -24,7 +24,7 @@ from app.datamgmt.manage.manage_common import get_severities_list
 from app.datamgmt.manage.manage_common import search_severity_by_name
 from app.schema.marshables import SeveritySchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_severities_rest_blueprint = Blueprint('manage_severities_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_severities_routes.py
+++ b/source/app/blueprints/rest/manage/manage_severities_routes.py
@@ -25,7 +25,7 @@ from app.datamgmt.manage.manage_common import search_severity_by_name
 from app.schema.marshables import SeveritySchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_severities_rest_blueprint = Blueprint('manage_severities_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_tags.py
+++ b/source/app/blueprints/rest/manage/manage_tags.py
@@ -23,8 +23,7 @@ from app import app
 from app.datamgmt.manage.manage_tags_db import get_filtered_tags
 from app.schema.marshables import TagsSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import AlchemyEncoder
-from app.blueprints.responses import response_success
+from app.blueprints.responses import response_success, AlchemyEncoder
 
 manage_tags_rest_blueprint = Blueprint('manage_tags_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_tags.py
+++ b/source/app/blueprints/rest/manage/manage_tags.py
@@ -24,7 +24,7 @@ from app.datamgmt.manage.manage_tags_db import get_filtered_tags
 from app.schema.marshables import TagsSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.util import AlchemyEncoder
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_tags_rest_blueprint = Blueprint('manage_tags_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_task_status_routes.py
+++ b/source/app/blueprints/rest/manage/manage_task_status_routes.py
@@ -21,7 +21,7 @@ from flask import Blueprint
 from app.models.models import TaskStatus
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_task_status_rest_blueprint = Blueprint('manage_task_status_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_task_status_routes.py
+++ b/source/app/blueprints/rest/manage/manage_task_status_routes.py
@@ -20,7 +20,7 @@ from flask import Blueprint
 
 from app.models.models import TaskStatus
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_task_status_rest_blueprint = Blueprint('manage_task_status_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_templates_routes.py
+++ b/source/app/blueprints/rest/manage/manage_templates_routes.py
@@ -37,7 +37,7 @@ from app.models.models import CaseTemplateReport
 from app.models.models import Languages
 from app.models.models import ReportType
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 _ALLOWED_EXTENSIONS = {'md', 'html', 'doc', 'docx'}

--- a/source/app/blueprints/rest/manage/manage_templates_routes.py
+++ b/source/app/blueprints/rest/manage/manage_templates_routes.py
@@ -38,7 +38,7 @@ from app.models.models import Languages
 from app.models.models import ReportType
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 _ALLOWED_EXTENSIONS = {'md', 'html', 'doc', 'docx'}
 

--- a/source/app/blueprints/rest/manage/manage_tlps_routes.py
+++ b/source/app/blueprints/rest/manage/manage_tlps_routes.py
@@ -21,7 +21,7 @@ from flask import Blueprint
 from app.models import Tlp
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 manage_tlp_type_rest_blueprint = Blueprint('manage_tlp_types_rest', __name__)
 

--- a/source/app/blueprints/rest/manage/manage_tlps_routes.py
+++ b/source/app/blueprints/rest/manage/manage_tlps_routes.py
@@ -20,7 +20,7 @@ from flask import Blueprint
 
 from app.models import Tlp
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 
 manage_tlp_type_rest_blueprint = Blueprint('manage_tlp_types_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_users.py
+++ b/source/app/blueprints/rest/manage/manage_users.py
@@ -48,7 +48,7 @@ from app.schema.marshables import UserFullSchema
 
 from app.blueprints.access_controls import ac_api_requires
 from app.util import is_authentication_oidc, is_authentication_ldap
-from app.util import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.util import is_authentication_local
 from app.util import response_error
 from app.util import response_success

--- a/source/app/blueprints/rest/manage/manage_users.py
+++ b/source/app/blueprints/rest/manage/manage_users.py
@@ -47,9 +47,7 @@ from app.schema.marshables import BasicUserSchema
 from app.schema.marshables import UserFullSchema
 
 from app.blueprints.access_controls import ac_api_requires
-from app.util import is_authentication_oidc, is_authentication_ldap
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.util import is_authentication_local
 from app.util import response_error
 from app.util import response_success
 from app.iris_engine.demo_builder import protect_demo_mode_user

--- a/source/app/blueprints/rest/manage/manage_users.py
+++ b/source/app/blueprints/rest/manage/manage_users.py
@@ -49,7 +49,7 @@ from app.schema.marshables import UserFullSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from app.iris_engine.demo_builder import protect_demo_mode_user
 
 manage_users_rest_blueprint = Blueprint('manage_users_rest', __name__)

--- a/source/app/blueprints/rest/manage/manage_users.py
+++ b/source/app/blueprints/rest/manage/manage_users.py
@@ -275,44 +275,6 @@ def manage_user_cac_delete_cases(cur_id):
     return response_error(msg=logs)
 
 
-@manage_users_rest_blueprint.route('/manage/users/<int:cur_id>/case-access/delete', methods=['POST'])
-@ac_api_requires(Permissions.server_administrator)
-def manage_user_cac_delete_case(cur_id):
-
-    user = get_user(cur_id)
-    if not user:
-        return response_error("Invalid user ID")
-
-    if not request.is_json:
-        return response_error("Invalid request")
-
-    data = request.get_json()
-    if not data:
-        return response_error("Invalid request")
-
-    if not isinstance(data.get('case'), int):
-        return response_error("Expecting cases as int")
-
-    try:
-
-        success, logs = remove_case_access_from_user(user.id, data.get('case'))
-        db.session.commit()
-
-    except Exception as e:
-        log.error("Error while removing cases access from user: {}".format(e))
-        log.error(traceback.format_exc())
-        return response_error(msg=str(e))
-
-    if success:
-        track_activity(f"case access for case {data.get('case')} deleted for user {user.user}", ctx_less=True)
-
-        user = get_user_details(cur_id)
-
-        return response_success(msg="User case access updated", data=user)
-
-    return response_error(msg=logs)
-
-
 @manage_users_rest_blueprint.route('/manage/users/update/<int:cur_id>', methods=['POST'])
 @ac_api_requires(Permissions.server_administrator)
 def update_user_api(cur_id):

--- a/source/app/blueprints/rest/manage/manage_users.py
+++ b/source/app/blueprints/rest/manage/manage_users.py
@@ -48,7 +48,7 @@ from app.schema.marshables import UserFullSchema
 
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 from app.iris_engine.demo_builder import protect_demo_mode_user
 

--- a/source/app/blueprints/rest/overview_routes.py
+++ b/source/app/blueprints/rest/overview_routes.py
@@ -22,7 +22,7 @@ from flask_login import current_user
 
 from app.datamgmt.overview.overview_db import get_overview_db
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 overview_rest_blueprint = Blueprint('overview_rest', __name__)
 

--- a/source/app/blueprints/rest/profile_routes.py
+++ b/source/app/blueprints/rest/profile_routes.py
@@ -37,7 +37,7 @@ from app.schema.marshables import BasicUserSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.util import response_error
 from app.util import response_success
-from app.util import endpoint_removed
+from app.blueprints.rest.endpoints import endpoint_removed
 
 profile_rest_blueprint = Blueprint('profile_rest', __name__)
 

--- a/source/app/blueprints/rest/profile_routes.py
+++ b/source/app/blueprints/rest/profile_routes.py
@@ -35,7 +35,7 @@ from app.models.authorization import Permissions
 from app.schema.marshables import UserSchema
 from app.schema.marshables import BasicUserSchema
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.util import response_success
 from app.blueprints.rest.endpoints import endpoint_removed
 

--- a/source/app/blueprints/rest/profile_routes.py
+++ b/source/app/blueprints/rest/profile_routes.py
@@ -36,7 +36,7 @@ from app.schema.marshables import UserSchema
 from app.schema.marshables import BasicUserSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
-from app.util import response_success
+from app.blueprints.responses import response_success
 from app.blueprints.rest.endpoints import endpoint_removed
 
 profile_rest_blueprint = Blueprint('profile_rest', __name__)

--- a/source/app/blueprints/rest/reports_route.py
+++ b/source/app/blueprints/rest/reports_route.py
@@ -35,7 +35,7 @@ from app.models.authorization import CaseAccessLevel
 from app.util import FileRemover
 from app.blueprints.access_controls import ac_requires_case_identifier
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_error
+from app.blueprints.responses import response_error
 from app.datamgmt.case.case_db import get_case
 
 reports_rest_blueprint = Blueprint('reports_rest', __name__)

--- a/source/app/blueprints/rest/search_routes.py
+++ b/source/app/blueprints/rest/search_routes.py
@@ -30,7 +30,7 @@ from app.models.models import IocType
 from app.models.models import Notes
 from app.models.models import Tlp
 from app.blueprints.access_controls import ac_api_requires
-from app.util import response_success
+from app.blueprints.responses import response_success
 
 search_rest_blueprint = Blueprint('search_rest', __name__)
 

--- a/source/app/blueprints/rest/v2/case/api_v2_assets_routes.py
+++ b/source/app/blueprints/rest/v2/case/api_v2_assets_routes.py
@@ -34,7 +34,7 @@ from app.business.errors import ObjectNotFoundError
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
-from app.util import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_return_access_denied
 
 api_v2_assets_blueprint = Blueprint('case_assets_rest_v2',
                                     __name__,

--- a/source/app/blueprints/rest/v2/case/api_v2_assets_routes.py
+++ b/source/app/blueprints/rest/v2/case/api_v2_assets_routes.py
@@ -24,10 +24,13 @@ from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.endpoints import response_api_deleted
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_success
+from app.blueprints.rest.endpoints import response_api_not_found
+from app.business.cases import cases_exists
 from app.business.assets import assets_create
 from app.business.assets import assets_delete
 from app.business.assets import assets_get
 from app.business.errors import BusinessProcessingError
+from app.business.errors import ObjectNotFoundError
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
@@ -41,6 +44,8 @@ api_v2_assets_blueprint = Blueprint('case_assets_rest_v2',
 @api_v2_assets_blueprint.route('/cases/<int:identifier>/assets', methods=['POST'])
 @ac_api_requires()
 def add_asset(identifier):
+    if not cases_exists(identifier):
+        return response_api_not_found()
     if not ac_fast_check_current_user_has_case_access(identifier, [CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=identifier)
 
@@ -77,5 +82,7 @@ def asset_delete(identifier):
 
         assets_delete(asset)
         return response_api_deleted()
+    except ObjectNotFoundError:
+        return response_api_not_found()
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())

--- a/source/app/blueprints/rest/v2/case/api_v2_case_tasks_routes.py
+++ b/source/app/blueprints/rest/v2/case/api_v2_case_tasks_routes.py
@@ -1,0 +1,83 @@
+#  IRIS Source Code
+#  Copyright (C) 2024 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from flask import Blueprint
+from flask import request
+
+from app.blueprints.rest.endpoints import response_api_deleted
+from app.blueprints.rest.endpoints import response_api_not_found
+from app.blueprints.rest.endpoints import response_api_error
+from app.blueprints.rest.endpoints import response_api_created
+from app.blueprints.access_controls import ac_api_return_access_denied
+from app.blueprints.access_controls import ac_api_requires
+from app.schema.marshables import CaseTaskSchema
+from app.business.errors import ObjectNotFoundError
+from app.business.errors import BusinessProcessingError
+from app.business.tasks import tasks_delete
+from app.business.tasks import tasks_create
+from app.business.tasks import tasks_get
+from app.models.authorization import CaseAccessLevel
+from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
+
+api_v2_tasks_blueprint = Blueprint('case_tasks_rest_v2',
+                                   __name__,
+                                   url_prefix='/api/v2')
+
+
+@api_v2_tasks_blueprint.route('/cases/<int:identifier>/tasks', methods=['POST'])
+@ac_api_requires()
+def case_add_task(identifier):
+    if not ac_fast_check_current_user_has_case_access(identifier, [CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=identifier)
+
+    task_schema = CaseTaskSchema()
+    try:
+        _, case = tasks_create(identifier, request.get_json())
+        return response_api_created(task_schema.dump(case))
+    except BusinessProcessingError as e:
+        return response_api_error(e.get_message())
+
+
+@api_v2_tasks_blueprint.route('/tasks/<int:identifier>', methods=['GET'])
+@ac_api_requires()
+def case_task_view(identifier):
+    try:
+        task = tasks_get(identifier)
+        if not ac_fast_check_current_user_has_case_access(task.task_case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=task.task_case_id)
+
+        task_schema = CaseTaskSchema()
+        return response_api_created(task_schema.dump(task))
+    except ObjectNotFoundError:
+        return response_api_not_found()
+
+
+@api_v2_tasks_blueprint.route('/tasks/<int:identifier>', methods=['DELETE'])
+@ac_api_requires()
+def case_delete_task(identifier):
+    try:
+        task = tasks_get(identifier)
+        if not ac_fast_check_current_user_has_case_access(task.task_case_id, [CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=identifier)
+
+        tasks_delete(task)
+        return response_api_deleted()
+    except ObjectNotFoundError:
+        return response_api_not_found()
+    except BusinessProcessingError as e:
+        return response_api_error(e.get_message())

--- a/source/app/blueprints/rest/v2/case/api_v2_ioc_routes.py
+++ b/source/app/blueprints/rest/v2/case/api_v2_ioc_routes.py
@@ -118,7 +118,7 @@ def delete_case_ioc(identifier):
         return response_api_deleted()
 
     except ObjectNotFoundError:
-        raise BusinessProcessingError('Not a valid IOC for this case')
+        return response_api_not_found()
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
 

--- a/source/app/blueprints/rest/v2/case/api_v2_ioc_routes.py
+++ b/source/app/blueprints/rest/v2/case/api_v2_ioc_routes.py
@@ -35,7 +35,9 @@ from app.datamgmt.case.case_iocs_db import get_filtered_iocs
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import IocSchemaForAPIV2
-from app.util import ac_api_return_access_denied, response_success, response_error
+from app.blueprints.access_controls import ac_api_return_access_denied
+from app.blueprints.responses import response_success
+from app.blueprints.responses import response_error
 
 api_v2_ioc_blueprint = Blueprint('case_ioc_rest_v2',
                                  __name__,

--- a/source/app/blueprints/rest/v2/case/api_v2_ioc_routes.py
+++ b/source/app/blueprints/rest/v2/case/api_v2_ioc_routes.py
@@ -41,6 +41,7 @@ api_v2_ioc_blueprint = Blueprint('case_ioc_rest_v2',
                                  __name__,
                                  url_prefix='/api/v2')
 
+
 @api_v2_ioc_blueprint.route('/cases/<int:identifier>/iocs', methods=['GET'])
 @ac_api_requires()
 def list_ioc(identifier):
@@ -80,8 +81,7 @@ def list_ioc(identifier):
 
     iocs = {
         'total': filtered_iocs.total,
-        # TODO should maybe really uniform all return types of paginated list and replace field iocs by field data
-        'iocs': iocs,
+        'data': iocs,
         'last_page': filtered_iocs.pages,
         'current_page': filtered_iocs.page,
         'next_page': filtered_iocs.next_num if filtered_iocs.has_next else None,

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -20,6 +20,7 @@ from flask_login import current_user
 from marshmallow.exceptions import ValidationError
 
 from app.business.errors import BusinessProcessingError
+from app.business.errors import ObjectNotFoundError
 from app.models import CaseAssets
 from app.datamgmt.case.case_assets_db import get_asset
 from app.datamgmt.case.case_assets_db import case_assets_db_exists
@@ -73,7 +74,7 @@ def assets_delete(asset: CaseAssets):
 def assets_get(identifier) -> CaseAssets:
     asset = get_asset(identifier)
     if not asset:
-        raise BusinessProcessingError('Invalid asset ID for this case')
+        raise ObjectNotFoundError()
 
     return asset
 

--- a/source/app/business/cases.py
+++ b/source/app/business/cases.py
@@ -39,6 +39,7 @@ from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.iris_engine.access_control.utils import ac_set_new_case_access
 
+from app.datamgmt.case.case_db import case_db_exists
 from app.datamgmt.case.case_db import save_case_tags
 from app.datamgmt.case.case_db import register_case_protagonists
 from app.datamgmt.case.case_db import get_review_id_from_name
@@ -72,6 +73,10 @@ def _load(request_data, **kwargs):
 
 def cases_get_by_identifier(case_identifier):
     return get_case(case_identifier)
+
+
+def cases_exists(identifier):
+    return case_db_exists(identifier)
 
 
 def cases_create(request_json):

--- a/source/app/datamgmt/case/case_db.py
+++ b/source/app/datamgmt/case/case_db.py
@@ -51,7 +51,7 @@ def get_case(caseid) -> Cases:
     return Cases.query.filter(Cases.case_id == caseid).first()
 
 
-def case_exists(caseid):
+def case_db_exists(caseid):
     return Cases.query.filter(Cases.case_id == caseid).count()
 
 

--- a/source/app/datamgmt/manage/manage_access_control_db.py
+++ b/source/app/datamgmt/manage/manage_access_control_db.py
@@ -14,6 +14,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 from app import ac_current_user_has_permission
 from app.models import Cases
 from app.models.authorization import Group
@@ -25,6 +26,9 @@ from app.models.authorization import Organisation
 from app.models.authorization import OrganisationCaseAccess
 from app.models.authorization import User
 from app.models.authorization import UserCaseAccess
+from app.datamgmt.case.case_db import case_db_exists
+
+from typing import Optional
 
 
 def manage_ac_audit_users_db():
@@ -73,7 +77,7 @@ def manage_ac_audit_users_db():
     return ret
 
 
-def check_ua_case_client(user_id: int, case_id: int) -> UserClient:
+def check_ua_case_client(user_id: int, case_id: int) -> Optional[UserClient]:
     """Check if the user has access to the case, through the customer of the case
        (in other words, check that the customer of the case is assigned to the user)
 

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -34,7 +34,6 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import hmac
 from flask import request
-from flask import url_for
 from flask_login import current_user
 from pathlib import Path
 from pyunpack import Archive
@@ -177,17 +176,6 @@ def get_urlcasename():
                                         case.client.name)
 
     return [case_name, case_info, caseid]
-
-
-def not_authenticated_redirection_url(request_url: str):
-    redirection_mapper = {
-        "oidc_proxy": lambda: app.config.get("AUTHENTICATION_PROXY_LOGOUT_URL"),
-        "local": lambda: url_for('login.login', next=request_url),
-        "ldap": lambda: url_for('login.login', next=request_url),
-        "oidc": lambda: url_for('login.login', next=request_url,)
-    }
-
-    return redirection_mapper.get(app.config.get("AUTHENTICATION_TYPE"))()
 
 
 def decompress_7z(filename: Path, output_dir):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -22,14 +22,11 @@ import base64
 import datetime
 import decimal
 import hashlib
-import json
 import logging as log
 import marshmallow
-import pickle
 import random
 import shutil
 import string
-import uuid
 import weakref
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
@@ -38,48 +35,11 @@ from flask import request
 from flask_login import current_user
 from pathlib import Path
 from pyunpack import Archive
-from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.orm.attributes import flag_modified
 
 from app import app
 from app import db
 from app.models import Cases
-
-
-class AlchemyEncoder(json.JSONEncoder):
-
-    def default(self, obj):
-        if isinstance(obj.__class__, DeclarativeMeta):
-            # an SQLAlchemy class
-            fields = {}
-            for field in [x for x in dir(obj) if not x.startswith('_') and x != 'metadata'
-                                                 and x != 'query' and x != 'query_class']:
-                data = obj.__getattribute__(field)
-                try:
-                    json.dumps(data)  # this will fail on non-encodable values, like other classes
-                    fields[field] = data
-                except TypeError:
-                    fields[field] = None
-            # a json-encodable dict
-            return fields
-
-        if isinstance(obj, decimal.Decimal):
-            return str(obj)
-
-        if isinstance(obj, datetime.datetime) or isinstance(obj, datetime.date):
-            return obj.isoformat()
-
-        if isinstance(obj, uuid.UUID):
-            return str(obj)
-
-        else:
-            if obj.__class__ == bytes:
-                try:
-                    return pickle.load(obj)
-                except Exception:
-                    return str(obj)
-
-        return json.JSONEncoder.default(self, obj)
 
 
 def DictDatetime(t):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -48,7 +48,6 @@ from sqlalchemy.orm.attributes import flag_modified
 from app import TEMPLATE_PATH
 from app import app
 from app import db
-from app.datamgmt.case.case_db import get_case
 from app.models import Cases
 
 
@@ -191,18 +190,6 @@ class FileRemover(object):
 def log_exception_and_error(e):
     log.exception(e)
     log.error(traceback.print_exc())
-
-
-def update_current_case(caseid, restricted_access):
-    if session['current_case']['case_id'] != caseid:
-        case = get_case(caseid)
-        if case:
-            session['current_case'] = {
-                'case_name': "{}".format(case.name),
-                'case_info': "(#{} - {})".format(caseid, case.client.name),
-                'case_id': caseid,
-                'access': restricted_access
-            }
 
 
 def get_urlcasename():

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -45,20 +45,6 @@ from app import db
 from app.models import Cases
 
 
-def g_db_commit():
-    db.session.commit()
-
-
-def g_db_add(obj):
-    if obj:
-        db.session.add(obj)
-
-
-def g_db_del(obj):
-    if obj:
-        db.session.delete(obj)
-
-
 class PgEncoder(json.JSONEncoder):
 
     def default(self, o):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -346,10 +346,6 @@ def not_authenticated_redirection_url(request_url: str):
     return redirection_mapper.get(app.config.get("AUTHENTICATION_TYPE"))()
 
 
-def is_authentication_local():
-    return app.config.get("AUTHENTICATION_TYPE") == "local"
-
-
 def is_authentication_ldap():
     return app.config.get('AUTHENTICATION_TYPE') == "ldap"
 

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -47,12 +47,6 @@ from app import db
 from app.models import Cases
 
 
-def response(status, data=None):
-    if data is not None:
-        data = json.dumps(data, cls=AlchemyEncoder)
-    return app.response_class(response=data, status=status, mimetype='application/json')
-
-
 def g_db_commit():
     db.session.commit()
 

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -42,7 +42,7 @@ from app import db
 from app.models import Cases
 
 
-def return_task(success, user, initial, logs, data, case_name, imported_files):
+def _return_task(success, user, initial, logs, data, case_name, imported_files):
     ret = {
         'success': success,
         'user': user,
@@ -56,11 +56,11 @@ def return_task(success, user, initial, logs, data, case_name, imported_files):
 
 
 def task_success(user=None, initial=None, logs=None, data=None, case_name=None, imported_files=None):
-    return return_task(True, user, initial, logs, data, case_name, imported_files)
+    return _return_task(True, user, initial, logs, data, case_name, imported_files)
 
 
 def task_failure(user=None, initial=None, logs=None, data=None, case_name=None, imported_files=None):
-    return return_task(False, user, initial, logs, data, case_name, imported_files)
+    return _return_task(False, user, initial, logs, data, case_name, imported_files)
 
 
 class FileRemover(object):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -53,15 +53,6 @@ def response(status, data=None):
     return app.response_class(response=data, status=status, mimetype='application/json')
 
 
-def response_success(msg='', data=None):
-    content = {
-        "status": "success",
-        "message": msg,
-        "data": data if data is not None else []
-    }
-    return response(200, data=content)
-
-
 def g_db_commit():
     db.session.commit()
 

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -22,12 +22,10 @@ import datetime
 import decimal
 import hashlib
 import json
-import jwt
 import logging as log
 import marshmallow
 import pickle
 import random
-import requests
 import shutil
 import string
 import traceback
@@ -36,18 +34,14 @@ import weakref
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import hmac
-from flask import Request
 from flask import render_template
 from flask import request
 from flask import session
 from flask import url_for
 from flask_login import current_user
-from flask_login import login_user
 from functools import wraps
-from jwt import PyJWKClient
 from pathlib import Path
 from pyunpack import Archive
-from requests.auth import HTTPBasicAuth
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -55,9 +49,6 @@ from app import TEMPLATE_PATH
 from app import app
 from app import db
 from app.datamgmt.case.case_db import get_case
-from app.datamgmt.manage.manage_users_db import get_user
-from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
-from app.iris_engine.utils.tracker import track_activity
 from app.models import Cases
 
 
@@ -233,106 +224,6 @@ def get_urlcasename():
                                         case.client.name)
 
     return [case_name, case_info, caseid]
-
-
-def _local_authentication_process(incoming_request: Request):
-    return current_user.is_authenticated
-
-
-def _authenticate_with_email(user_email):
-    user = get_user(user_email, id_key="email")
-    if not user:
-        log.error(f'User with email {user_email} is not registered in the IRIS')
-        return False
-
-    login_user(user)
-    track_activity(f"User '{user.id}' successfully logged-in", ctx_less=True)
-
-    caseid = user.ctx_case
-    session['permissions'] = ac_get_effective_permissions_of_user(user)
-
-    if caseid is None:
-        case = Cases.query.order_by(Cases.case_id).first()
-        user.ctx_case = case.case_id
-        user.ctx_human_case = case.name
-        db.session.commit()
-
-    session['current_case'] = {
-        'case_name': user.ctx_human_case,
-        'case_info': "",
-        'case_id': user.ctx_case
-    }
-
-    return True
-
-
-def _oidc_proxy_authentication_process(incoming_request: Request):
-    # Get the OIDC JWT authentication token from the request header
-    authentication_token = incoming_request.headers.get('X-Forwarded-Access-Token', '')
-
-    if app.config.get("AUTHENTICATION_TOKEN_VERIFY_MODE") == 'lazy':
-        user_email = incoming_request.headers.get('X-Email')
-
-        if user_email:
-            return _authenticate_with_email(user_email.split(',')[0])
-
-    elif app.config.get("AUTHENTICATION_TOKEN_VERIFY_MODE") == 'introspection':
-        # Use the authentication server's token introspection endpoint in order to determine if the request is valid /
-        # authenticated. The TLS_ROOT_CA is used to validate the authentication server's certificate.
-        # The other solution was to skip the certificate verification, BUT as the authentication server might be
-        # located on another server, this check is necessary.
-
-        introspection_body = {"token": authentication_token}
-        introspection = requests.post(
-            app.config.get("AUTHENTICATION_TOKEN_INTROSPECTION_URL"),
-            auth=HTTPBasicAuth(app.config.get('AUTHENTICATION_CLIENT_ID'), app.config.get('AUTHENTICATION_CLIENT_SECRET')),
-            data=introspection_body,
-            verify=app.config.get("TLS_ROOT_CA")
-        )
-        if introspection.status_code == 200:
-            response_json = introspection.json()
-
-            if response_json.get("active", False) is True:
-                user_email = response_json.get("sub")
-                return _authenticate_with_email(user_email=user_email)
-
-            else:
-                log.info("USER IS NOT AUTHENTICATED")
-                return False
-
-    elif app.config.get("AUTHENTICATION_TOKEN_VERIFY_MODE") == 'signature':
-        # Use the JWKS urls provided by the OIDC discovery to fetch the signing keys
-        # and check the signature of the token
-        try:
-            jwks_client = PyJWKClient(app.config.get("AUTHENTICATION_JWKS_URL"))
-            signing_key = jwks_client.get_signing_key_from_jwt(authentication_token)
-
-            try:
-
-                data = jwt.decode(
-                    authentication_token,
-                    signing_key.key,
-                    algorithms=["RS256"],
-                    audience=app.config.get("AUTHENTICATION_AUDIENCE"),
-                    options={"verify_exp": app.config.get("AUTHENTICATION_VERIFY_TOKEN_EXP")},
-                )
-
-            except jwt.ExpiredSignatureError:
-                log.error("Provided token has expired")
-                return False
-
-        except Exception as e:
-            log.error(f"Error decoding JWT. {e.__str__()}")
-            return False
-
-        # Extract the user email
-        user_email = data.get("sub")
-
-        return _authenticate_with_email(user_email)
-
-    else:
-        log.error("ERROR DURING TOKEN INTROSPECTION PROCESS")
-        return False
 
 
 def not_authenticated_redirection_url(request_url: str):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -380,19 +380,6 @@ def regenerate_session():
     session.modified = True
 
 
-# TODO should move this method into an util file at the root of the blueprint namespace
-def ac_api_return_access_denied(caseid: int = None):
-    error_uuid = uuid.uuid4()
-    log.warning(f"EID {error_uuid} - Access denied with case #{caseid} for user ID {current_user.id} "
-                f"accessing URI {request.full_path}")
-    data = {
-        'user_id': current_user.id,
-        'case_id': caseid,
-        'error_uuid': error_uuid
-    }
-    return response_error('Permission denied', data=data, status=403)
-
-
 def endpoint_removed(message, version):
     def inner_wrap(f):
         @wraps(f)

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -34,7 +34,6 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import hmac
 from flask import request
-from flask import session
 from flask import url_for
 from flask_login import current_user
 from pathlib import Path
@@ -193,10 +192,6 @@ def not_authenticated_redirection_url(request_url: str):
 
 def is_authentication_ldap():
     return app.config.get('AUTHENTICATION_TYPE') == "ldap"
-
-
-def is_authentication_oidc():
-    return app.config.get('AUTHENTICATION_TYPE') == "oidc"
 
 
 def decompress_7z(filename: Path, output_dir):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -55,7 +55,6 @@ from app import TEMPLATE_PATH
 from app import app
 from app import db
 from app.datamgmt.case.case_db import get_case
-from app.datamgmt.manage.manage_access_control_db import user_has_client_access
 from app.datamgmt.manage.manage_users_db import get_user
 from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
 from app.iris_engine.utils.tracker import track_activity
@@ -385,19 +384,6 @@ def endpoint_removed(message, version):
         @wraps(f)
         def wrap(*args, **kwargs):
             return response_error(f"Endpoint deprecated in {version}. {message}.", status=410)
-        return wrap
-    return inner_wrap
-
-
-def ac_api_requires_client_access():
-    def inner_wrap(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            client_id = kwargs.get('client_id')
-            if not user_has_client_access(current_user.id, client_id):
-                return response_error("Permission denied", status=403)
-
-            return f(*args, **kwargs)
         return wrap
     return inner_wrap
 

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -33,7 +33,6 @@ import weakref
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import hmac
-from flask import render_template
 from flask import request
 from flask import session
 from flask import url_for
@@ -44,7 +43,6 @@ from pyunpack import Archive
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.orm.attributes import flag_modified
 
-from app import TEMPLATE_PATH
 from app import app
 from app import db
 from app.models import Cases
@@ -296,16 +294,6 @@ def add_obj_history_entry(obj, action, commit=False):
         db.session.commit()
 
     return obj
-
-
-# Set basic 404
-@app.errorhandler(404)
-def page_not_found(e):
-    # note that we set the 404 status explicitly
-    if request.content_type and 'application/json' in request.content_type:
-        return response_error("Resource not found", status=404)
-
-    return render_template('pages/error-404.html', template_folder=TEMPLATE_PATH), 404
 
 
 def file_sha256sum(file_path):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -20,7 +20,6 @@
 
 import base64
 import datetime
-import decimal
 import hashlib
 import logging as log
 import marshmallow
@@ -40,27 +39,6 @@ from sqlalchemy.orm.attributes import flag_modified
 from app import app
 from app import db
 from app.models import Cases
-
-
-def _return_task(success, user, initial, logs, data, case_name, imported_files):
-    ret = {
-        'success': success,
-        'user': user,
-        'initial': initial,
-        'logs': logs,
-        'data': data,
-        'case_name': case_name,
-        'imported_files': imported_files
-    }
-    return ret
-
-
-def task_success(user=None, initial=None, logs=None, data=None, case_name=None, imported_files=None):
-    return _return_task(True, user, initial, logs, data, case_name, imported_files)
-
-
-def task_failure(user=None, initial=None, logs=None, data=None, case_name=None, imported_files=None):
-    return _return_task(False, user, initial, logs, data, case_name, imported_files)
 
 
 class FileRemover(object):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -346,17 +346,6 @@ def not_authenticated_redirection_url(request_url: str):
     return redirection_mapper.get(app.config.get("AUTHENTICATION_TYPE"))()
 
 
-def is_user_authenticated(incoming_request: Request):
-    authentication_mapper = {
-        "oidc_proxy": _oidc_proxy_authentication_process,
-        "local": _local_authentication_process,
-        "ldap": _local_authentication_process,
-        "oidc": _local_authentication_process,
-    }
-
-    return authentication_mapper.get(app.config.get("AUTHENTICATION_TYPE"))(incoming_request)
-
-
 def is_authentication_local():
     return app.config.get("AUTHENTICATION_TYPE") == "local"
 

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -42,22 +42,6 @@ from app import db
 from app.models import Cases
 
 
-def DictDatetime(t):
-    dl = ['Y', 'm', 'd', 'H', 'M', 'S', 'f']
-    if type(t) is datetime.datetime:
-        return {a: t.strftime('%{}'.format(a)) for a in dl}
-    elif type(t) is dict:
-        return datetime.datetime.strptime(''.join(t[a] for a in dl), '%Y%m%d%H%M%S%f')
-
-
-def AlchemyFnCode(obj):
-    """JSON encoder function for SQLAlchemy special classes."""
-    if isinstance(obj, datetime.date):
-        return obj.isoformat()
-    elif isinstance(obj, decimal.Decimal):
-        return float(obj)
-
-
 def return_task(success, user, initial, logs, data, case_name, imported_files):
     ret = {
         'success': success,

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -53,15 +53,6 @@ def response(status, data=None):
     return app.response_class(response=data, status=status, mimetype='application/json')
 
 
-def response_error(msg, data=None, status=400):
-    content = {
-        'status': 'error',
-        'message': msg,
-        'data': data if data is not None else []
-    }
-    return response(status, data=content)
-
-
 def response_success(msg='', data=None):
     content = {
         "status": "success",

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -17,6 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 import base64
 import datetime
 import decimal
@@ -43,18 +44,6 @@ from sqlalchemy.orm.attributes import flag_modified
 from app import app
 from app import db
 from app.models import Cases
-
-
-class PgEncoder(json.JSONEncoder):
-
-    def default(self, o):
-        if isinstance(o, datetime.datetime):
-            return DictDatetime(o)
-
-        if isinstance(o, decimal.Decimal):
-            return str(o)
-
-        return json.JSONEncoder.default(self, o)
 
 
 class AlchemyEncoder(json.JSONEncoder):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -199,16 +199,6 @@ def is_authentication_oidc():
     return app.config.get('AUTHENTICATION_TYPE') == "oidc"
 
 
-def regenerate_session():
-    user_data = session.get('user_data', {})
-
-    session.clear()
-
-    session['user_data'] = user_data
-
-    session.modified = True
-
-
 def decompress_7z(filename: Path, output_dir):
     """
     Decompress a 7z file in specified output directory

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -28,7 +28,6 @@ import pickle
 import random
 import shutil
 import string
-import traceback
 import uuid
 import weakref
 from cryptography.exceptions import InvalidSignature
@@ -185,11 +184,6 @@ class FileRemover(object):
     def _do_cleanup(self, wr):
         filepath = self.weak_references[wr]
         shutil.rmtree(filepath, ignore_errors=True)
-
-
-def log_exception_and_error(e):
-    log.exception(e)
-    log.error(traceback.print_exc())
 
 
 def get_urlcasename():

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -37,7 +37,6 @@ from flask import request
 from flask import session
 from flask import url_for
 from flask_login import current_user
-from functools import wraps
 from pathlib import Path
 from pyunpack import Archive
 from sqlalchemy.ext.declarative import DeclarativeMeta
@@ -232,15 +231,6 @@ def regenerate_session():
     session['user_data'] = user_data
 
     session.modified = True
-
-
-def endpoint_removed(message, version):
-    def inner_wrap(f):
-        @wraps(f)
-        def wrap(*args, **kwargs):
-            return response_error(f"Endpoint deprecated in {version}. {message}.", status=410)
-        return wrap
-    return inner_wrap
 
 
 def decompress_7z(filename: Path, output_dir):

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -54,27 +54,6 @@ class FileRemover(object):
         shutil.rmtree(filepath, ignore_errors=True)
 
 
-def get_urlcasename():
-    caseid = request.args.get('cid', default=None, type=int)
-    if not caseid:
-        try:
-            caseid = current_user.ctx_case
-        except:
-            return ["", ""]
-
-    case = Cases.query.filter(Cases.case_id == caseid).first()
-
-    if case is None:
-        case_name = "CASE NOT FOUND"
-        case_info = "Error"
-    else:
-        case_name = "{}".format(case.name)
-        case_info = "(#{} - {})".format(caseid,
-                                        case.client.name)
-
-    return [case_name, case_info, caseid]
-
-
 def decompress_7z(filename: Path, output_dir):
     """
     Decompress a 7z file in specified output directory

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -190,10 +190,6 @@ def not_authenticated_redirection_url(request_url: str):
     return redirection_mapper.get(app.config.get("AUTHENTICATION_TYPE"))()
 
 
-def is_authentication_ldap():
-    return app.config.get('AUTHENTICATION_TYPE') == "ldap"
-
-
 def decompress_7z(filename: Path, output_dir):
     """
     Decompress a 7z file in specified output directory

--- a/source/app/views.py
+++ b/source/app/views.py
@@ -99,6 +99,7 @@ from app.blueprints.rest.search_routes import search_rest_blueprint
 from app.blueprints.graphql.graphql_route import graphql_blueprint
 from app.blueprints.rest.v2.case.api_v2_assets_routes import api_v2_assets_blueprint
 from app.blueprints.rest.v2.case.api_v2_ioc_routes import api_v2_ioc_blueprint
+from app.blueprints.rest.v2.case.api_v2_case_tasks_routes import api_v2_tasks_blueprint
 from app.models.authorization import User
 from app.post_init import run_post_init
 
@@ -186,6 +187,7 @@ app.register_blueprint(demo_blueprint)
 
 app.register_blueprint(api_v2_ioc_blueprint)
 app.register_blueprint(api_v2_assets_blueprint)
+app.register_blueprint(api_v2_tasks_blueprint)
 
 try:
 

--- a/tests/iris.py
+++ b/tests/iris.py
@@ -75,7 +75,7 @@ class Iris:
 
     def clear_database(self):
         cases = self.get('/api/v2/cases', query_parameters={'per_page': 1000000000}).json()
-        for case in cases['cases']:
+        for case in cases['data']:
             identifier = case['case_id']
             self.delete(f'/api/v2/cases/{identifier}')
         groups = self.get('/manage/groups/list').json()

--- a/tests/iris.py
+++ b/tests/iris.py
@@ -28,6 +28,7 @@ _API_KEY = 'B8BA5D730210B50F41C06941582D7965D57319D5685440587F98DFDC45A01594'
 _IRIS_PATH = Path('..')
 _TEST_DATA_PATH = Path('./data')
 _ADMINISTRATOR_USER_IDENTIFIER = 1
+_INITIAL_DEMO_CASE_IDENTIFIER = 1
 
 
 class Iris:
@@ -77,12 +78,10 @@ class Iris:
         cases = self.get('/api/v2/cases', query_parameters={'per_page': 1000000000}).json()
         for case in cases['data']:
             identifier = case['case_id']
+            if identifier == _INITIAL_DEMO_CASE_IDENTIFIER:
+                continue
             self.delete(f'/api/v2/cases/{identifier}')
         groups = self.get('/manage/groups/list').json()
         for group in groups['data']:
             identifier = group['group_id']
             self.create(f'/manage/groups/delete/{identifier}', {})
-        customers = self.get('/manage/customers/list').json()
-        for customer in customers['data']:
-            identifier = customer['customer_id']
-            self.create(f'/manage/customers/delete/{identifier}', {})

--- a/tests/iris.py
+++ b/tests/iris.py
@@ -85,3 +85,8 @@ class Iris:
         for group in groups['data']:
             identifier = group['group_id']
             self.create(f'/manage/groups/delete/{identifier}', {})
+        users = self.get('/manage/users/list').json()
+        for user in users['data']:
+            identifier = user['user_id']
+            self.get(f'/manage/users/deactivate/{identifier}')
+            self.create(f'/manage/users/delete/{identifier}', {})

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -19,8 +19,7 @@
 from unittest import TestCase
 from iris import Iris
 
-# TODO should change None into 123456789 and maybe fix...
-_IDENTIFIER_FOR_NONEXISTENT_OBJECT = None
+_IDENTIFIER_FOR_NONEXISTENT_OBJECT = 123456789
 
 
 class TestsRestAssets(TestCase):

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -31,7 +31,6 @@ class TestsRestAssets(TestCase):
     def tearDown(self):
         self._subject.clear_database()
 
-
     def test_delete_asset_should_return_204(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -21,7 +21,7 @@ from iris import Iris
 
 
 def _get_case_with_identifier(response, identifier):
-    for case in response['cases']:
+    for case in response['data']:
         if identifier == case['case_id']:
             return case
     raise ValueError('Case not found')
@@ -69,10 +69,10 @@ class TestsRestCases(TestCase):
 
     def test_create_case_should_add_a_new_case(self):
         response = self._subject.get('/api/v2/cases').json()
-        initial_case_count = len(response['cases'])
+        initial_case_count = len(response['data'])
         self._subject.create_dummy_case()
         response = self._subject.get('/api/v2/cases').json()
-        case_count = len(response['cases'])
+        case_count = len(response['data'])
         self.assertEqual(initial_case_count + 1, case_count)
 
     def test_get_case_should_return_case_data(self):
@@ -129,7 +129,7 @@ class TestsRestCases(TestCase):
         filters = {'case_name': 'test_get_cases_should_filter_on_case_name'}
         response = self._subject.get('/api/v2/cases', query_parameters=filters).json()
         identifiers = []
-        for case in response['cases']:
+        for case in response['data']:
             identifiers.append(case['case_id'])
         self.assertIn(case_identifier, identifiers)
 
@@ -139,7 +139,7 @@ class TestsRestCases(TestCase):
         filters = {'is_open': 'true'}
         response = self._subject.get('/api/v2/cases', query_parameters=filters).json()
         identifiers = []
-        for case in response['cases']:
+        for case in response['data']:
             identifiers.append(case['case_id'])
         self.assertNotIn(case_identifier, identifiers)
 

--- a/tests/tests_rest_customers.py
+++ b/tests/tests_rest_customers.py
@@ -34,6 +34,10 @@ class TestsRestCustomers(TestCase):
             identifier = user['user_id']
             body = {'customers_membership': [_IRIS_INITIAL_CLIENT_IDENTIFIER]}
             self._subject.create(f'/manage/users/{identifier}/customers/update', body)
+        customers = self._subject.get('/manage/customers/list').json()
+        for customer in customers['data']:
+            identifier = customer['customer_id']
+            self._subject.create(f'/manage/customers/delete/{identifier}', {})
         self._subject.clear_database()
 
     def test_create_customer_should_return_200_when_user_has_customer_write_right(self):

--- a/tests/tests_rest_customers.py
+++ b/tests/tests_rest_customers.py
@@ -29,6 +29,7 @@ class TestsRestCustomers(TestCase):
         self._subject = Iris()
 
     def tearDown(self):
+        self._subject.clear_database()
         users = self._subject.get('/manage/users/list').json()
         for user in users['data']:
             identifier = user['user_id']
@@ -38,7 +39,6 @@ class TestsRestCustomers(TestCase):
         for customer in customers['data']:
             identifier = customer['customer_id']
             self._subject.create(f'/manage/customers/delete/{identifier}', {})
-        self._subject.clear_database()
 
     def test_create_customer_should_return_200_when_user_has_customer_write_right(self):
         body = {

--- a/tests/tests_rest_customers.py
+++ b/tests/tests_rest_customers.py
@@ -20,6 +20,7 @@ from unittest import TestCase
 from iris import Iris
 
 _PERMISSION_CUSTOMERS_WRITE = 0x80
+_IRIS_INITIAL_CLIENT_IDENTIFIER = 1
 
 
 class TestsRestCustomers(TestCase):
@@ -28,6 +29,11 @@ class TestsRestCustomers(TestCase):
         self._subject = Iris()
 
     def tearDown(self):
+        users = self._subject.get('/manage/users/list').json()
+        for user in users['data']:
+            identifier = user['user_id']
+            body = {'customers_membership': [_IRIS_INITIAL_CLIENT_IDENTIFIER]}
+            self._subject.create(f'/manage/users/{identifier}/customers/update', body)
         self._subject.clear_database()
 
     def test_create_customer_should_return_200_when_user_has_customer_write_right(self):

--- a/tests/tests_rest_iocs.py
+++ b/tests/tests_rest_iocs.py
@@ -35,7 +35,7 @@ class TestsRestIocs(TestCase):
         response = self._subject.get('/case/ioc/list').json()
         self.assertEqual('success', response['status'])
 
-    def test_create_ioc_should_return_good_ioc_type_id(self):
+    def test_create_ioc_should_return_correct_ioc_type_id(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'ioc_type_id': 1, 'ioc_tlp_id': 2, 'ioc_value': '8.8.8.8', 'ioc_description': 'rewrw', 'ioc_tags': ''}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/iocs', body).json()
@@ -103,7 +103,7 @@ class TestsRestIocs(TestCase):
         filters = {'ioc_value': 'test_get_iocs_should_filter_on_ioc_value'}
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/iocs',  query_parameters=filters).json()
         identifiers = []
-        for ioc in response['iocs']:
+        for ioc in response['data']:
             identifiers.append(ioc['ioc_type_id'])
         self.assertIn(ioc_type_identifier, identifiers)
 
@@ -125,7 +125,7 @@ class TestsRestIocs(TestCase):
         body = {'ioc_type_id': 1, 'ioc_tlp_id': tlp_identifier, 'ioc_value': '8.8.8.8', 'ioc_description': 'rewrw', 'ioc_tags': ''}
         self._subject.create(f'/api/v2/cases/{case_identifier}/iocs', body).json()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/iocs').json()
-        self.assertEqual(tlp_identifier, response['iocs'][0]['tlp']['tlp_id'])
+        self.assertEqual(tlp_identifier, response['data'][0]['tlp']['tlp_id'])
 
     def test_get_iocs_should_include_link_to_other_cases_with_same_value_type_ioc(self):
         case_identifier1 = self._subject.create_dummy_case()
@@ -135,7 +135,7 @@ class TestsRestIocs(TestCase):
         body = {'ioc_type_id': 1, 'ioc_tlp_id': 1, 'ioc_value': '8.8.8.8', 'ioc_description': 'another', 'ioc_tags': ''}
         self._subject.create(f'/api/v2/cases/{case_identifier2}/iocs', body).json()
         response = self._subject.get(f'/api/v2/cases/{case_identifier2}/iocs').json()
-        self.assertEqual(case_identifier1, response['iocs'][0]['link'][0]['case_id'])
+        self.assertEqual(case_identifier1, response['data'][0]['link'][0]['case_id'])
 
     def test_create_ioc_should_include_field_link(self):
         case_identifier = self._subject.create_dummy_case()

--- a/tests/tests_rest_iocs.py
+++ b/tests/tests_rest_iocs.py
@@ -19,8 +19,7 @@
 from unittest import TestCase
 from iris import Iris
 
-# TODO should change None into 123456789 and maybe fix...
-_IDENTIFIER_FOR_NONEXISTENT_OBJECT = None
+_IDENTIFIER_FOR_NONEXISTENT_OBJECT = 123456789
 
 
 class TestsRestIocs(TestCase):
@@ -108,7 +107,7 @@ class TestsRestIocs(TestCase):
         self.assertIn(ioc_type_identifier, identifiers)
 
     def test_get_ioc_should_return_404_when_not_present(self):
-        response = self._subject.get(f'/api/v2/iocs/137')
+        response = self._subject.get(f'/api/v2/iocs/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)
 
     def test_get_ioc_should_return_200_on_success(self):

--- a/tests/tests_rest_tasks.py
+++ b/tests/tests_rest_tasks.py
@@ -19,8 +19,7 @@
 from unittest import TestCase
 from iris import Iris
 
-# TODO should change None into 123456789 and maybe fix...
-_IDENTIFIER_FOR_NONEXISTENT_OBJECT = None
+_IDENTIFIER_FOR_NONEXISTENT_OBJECT = 123456789
 
 
 class TestsRestTasks(TestCase):

--- a/ui/src/pages/case.ioc.js
+++ b/ui/src/pages/case.ioc.js
@@ -148,7 +148,7 @@ function get_case_ioc() {
         }
 
         Table.clear();
-        Table.rows.add(data.iocs);
+        Table.rows.add(data.data);
 
         $('#ioc_table_wrapper').on('click', function(e){
             if($('.popover').length>1)

--- a/ui/src/pages/manage.customers.js
+++ b/ui/src/pages/manage.customers.js
@@ -18,7 +18,9 @@ function add_customer() {
             has_error = ret[0].length > 0;
             attributes = ret[1];
 
-            if (has_error){return false;}
+            if (has_error) {
+                return false;
+            }
 
             form['custom_attributes'] = attributes;
 

--- a/ui/src/pages/manage.customers.js
+++ b/ui/src/pages/manage.customers.js
@@ -24,7 +24,7 @@ function add_customer() {
 
             form['custom_attributes'] = attributes;
 
-            post_request_api('customers/add', JSON.stringify(form), true)
+            post_request_api('/manage/customers/add', JSON.stringify(form), true)
             .done((data) => {
                  if(notify_auto_api(data)) {
                     refresh_customer_table();

--- a/ui/src/pages/view.customers.js
+++ b/ui/src/pages/view.customers.js
@@ -288,7 +288,7 @@ $(document).ready(function() {
                 // since there are no filters on this table, it should be OK
                 json.recordsFiltered = json.total;
 
-                return json.cases;
+                return json.data;
             }
         }
     });


### PR DESCRIPTION
* endpoint GET /api/v2/cases, changed field `cases` into `data`, so that endpoints which return paginated lists are standardized
* endpoint GET /api/v2/cases/{identifier}/iocs, changed field `iocs` into `data`, so that endpoints which return paginated lists are standardized
* return 404 when trying to delete inexistant task
* return 404 when trying to delete inexistant IOC
* return 404 when trying to delete inexistant asset
* return 404 when trying to create an asset in an inexistant case
* moved code out of utils.py into the blueprints namespace (in access_controls.py and responses.py)
* some cleanups: removed some seemingly dead methods, marked some methods as private (underscore prefix), simple quotes vs. double quotes
