### PR TITLE
 Preload hooks for delete case and task

### DIFF
--- a/source/app/blueprints/case/case_tasks_routes.py
+++ b/source/app/blueprints/case/case_tasks_routes.py
@@ -256,10 +256,10 @@ def case_edit_task(cur_id, caseid):
 @case_tasks_blueprint.route('/case/tasks/delete/<int:cur_id>', methods=['POST'])
 @ac_api_case_requires(CaseAccessLevel.full_access)
 def case_delete_task(cur_id, caseid):
-    call_modules_hook('on_preload_task_delete', data=cur_id, caseid=caseid)
     task = get_task_with_assignees(task_id=cur_id, case_id=caseid)
     if not task:
         return response_error("Invalid task ID for this case")
+    call_modules_hook('on_preload_task_delete', data=task, caseid=caseid)
 
     delete_task(task.id)
 

--- a/source/app/business/cases.py
+++ b/source/app/business/cases.py
@@ -131,7 +131,7 @@ def delete(case_identifier):
         raise BusinessProcessingError('Cannot delete a primary case to keep consistency')
 
     try:
-        call_modules_hook('on_preload_case_delete', data=case_identifier, caseid=case_identifier)
+        call_modules_hook('on_preload_case_delete', data=get_case(case_identifier), caseid=case_identifier)
         if not delete_case(case_identifier):
             track_activity(f'tried to delete case {case_identifier}, but it doesn\'t exist',
                            caseid=case_identifier, ctx_less=True)


### PR DESCRIPTION
Small fixes for correct work **on_preload_task_delete** and **on_preload_case_delete** hooks.
There are problems with registering hooks. Need iris-webhooks-module update [FIX](https://github.com/dfir-iris/iris-webhooks-module/pull/10)