### PR TITLE
Deleted asset should not be accessible via REST

### DIFF
--- a/source/app/blueprints/rest/v2/case/api_v2_assets_routes.py
+++ b/source/app/blueprints/rest/v2/case/api_v2_assets_routes.py
@@ -18,6 +18,7 @@
 
 from flask import Blueprint
 from flask import request
+from kombu.abstract import Object
 
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import response_api_created
@@ -68,6 +69,8 @@ def asset_view(identifier):
             return ac_api_return_access_denied(caseid=asset.case_id)
 
         return response_api_success(asset_schema.dump(asset))
+    except ObjectNotFoundError:
+        return response_api_not_found()
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
 

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -66,7 +66,7 @@ def assets_create(case_identifier, request_json):
 def assets_delete(asset: CaseAssets):
     call_modules_hook('on_preload_asset_delete', data=asset.asset_id)
     # Deletes an asset and the potential links with the IoCs from the database
-    delete_asset(asset.asset_id, asset.case_id)
+    delete_asset(asset.asset_id)
     call_modules_hook('on_postload_asset_delete', data=asset.asset_id, caseid=asset.case_id)
     track_activity(f'removed asset ID {asset.asset_name}', caseid=asset.case_id)
 

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -66,7 +66,7 @@ def assets_create(case_identifier, request_json):
 def assets_delete(asset: CaseAssets):
     call_modules_hook('on_preload_asset_delete', data=asset.asset_id)
     # Deletes an asset and the potential links with the IoCs from the database
-    delete_asset(asset.asset_id)
+    delete_asset(asset)
     call_modules_hook('on_postload_asset_delete', data=asset.asset_id, caseid=asset.case_id)
     track_activity(f'removed asset ID {asset.asset_name}', caseid=asset.case_id)
 

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -146,7 +146,7 @@ def delete_asset(asset_id):
     com_ids = AssetComments.query.with_entities(
         AssetComments.comment_id
     ).filter(
-        AssetComments.comment_asset_id == asset_id,
+        AssetComments.comment_asset_id == asset_id
     ).all()
 
     com_ids = [c.comment_id for c in com_ids]
@@ -156,15 +156,11 @@ def delete_asset(asset_id):
         Comments.comment_id.in_(com_ids)
     ).delete()
 
-    # Directly delete the relevant records from the CaseAssets table
-    CaseAssets.query.filter(
-        CaseAssets.asset_id == asset_id
-    ).delete()
+    db.session.delete(case_asset)
 
-    update_assets_state(case_asset.asset_id)
+    update_assets_state(case_asset.case_id)
 
     db.session.commit()
-    return
 
 
 def get_assets_types():

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -141,7 +141,13 @@ def delete_asset(asset_id, caseid):
             case_asset.asset_id == CaseEventsAssets.asset_id
         ).delete()
 
-        case_asset.case_id = None
+        CaseAssets.query.filter(
+            CaseAssets.asset_id == asset_id,
+            CaseAssets.case_id == caseid
+        ).delete()
+
+        update_assets_state(caseid=caseid)
+
         db.session.commit()
         return
 

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -153,6 +153,10 @@ def delete_asset(asset_id, caseid):
         com_ids = [c.comment_id for c in com_ids]
         AssetComments.query.filter(AssetComments.comment_id.in_(com_ids)).delete()
 
+        Comments.query.filter(
+            Comments.comment_id.in_(com_ids)
+        ).delete()
+
         # Directly delete the relevant records from the CaseAssets table
         CaseAssets.query.filter(
             CaseAssets.asset_id == asset_id,

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -135,69 +135,37 @@ def delete_asset(asset_id, caseid):
     if case_asset is None:
         return
 
-    if case_asset.case_id and case_asset.alerts is not None:
-        delete_ioc_asset_link(asset_id)
+    delete_ioc_asset_link(asset_id)
 
-        # Delete the relevant records from the CaseEventsAssets table
-        CaseEventsAssets.query.filter(
-            case_asset.asset_id == CaseEventsAssets.asset_id
-        ).delete()
+    # Delete the relevant records from the CaseEventsAssets table
+    CaseEventsAssets.query.filter(
+        case_asset.asset_id == CaseEventsAssets.asset_id
+    ).delete()
 
-        # Delete the relevant records from the AssetComments table
-        com_ids = AssetComments.query.with_entities(
-            AssetComments.comment_id
-        ).filter(
-            AssetComments.comment_asset_id == asset_id,
-        ).all()
+    # Delete the relevant records from the AssetComments table
+    com_ids = AssetComments.query.with_entities(
+        AssetComments.comment_id
+    ).filter(
+        AssetComments.comment_asset_id == asset_id,
+    ).all()
 
-        com_ids = [c.comment_id for c in com_ids]
-        AssetComments.query.filter(AssetComments.comment_id.in_(com_ids)).delete()
+    com_ids = [c.comment_id for c in com_ids]
+    AssetComments.query.filter(AssetComments.comment_id.in_(com_ids)).delete()
 
-        Comments.query.filter(
-            Comments.comment_id.in_(com_ids)
-        ).delete()
+    Comments.query.filter(
+        Comments.comment_id.in_(com_ids)
+    ).delete()
 
-        # Directly delete the relevant records from the CaseAssets table
-        CaseAssets.query.filter(
-            CaseAssets.asset_id == asset_id,
-            CaseAssets.case_id == caseid
-        ).delete()
+    # Directly delete the relevant records from the CaseAssets table
+    CaseAssets.query.filter(
+        CaseAssets.asset_id == asset_id,
+        CaseAssets.case_id == caseid
+    ).delete()
 
-        update_assets_state(caseid)
+    update_assets_state(caseid)
 
-        db.session.commit()
-        return
-
-    with db.session.begin_nested():
-        delete_ioc_asset_link(asset_id)
-
-        # Delete the relevant records from the CaseEventsAssets table
-        CaseEventsAssets.query.filter(
-            CaseEventsAssets.case_id == caseid,
-            CaseEventsAssets.asset_id == asset_id
-        ).delete()
-
-        # Delete the relevant records from the AssetComments table
-        com_ids = AssetComments.query.with_entities(
-            AssetComments.comment_id
-        ).filter(
-            AssetComments.comment_asset_id == asset_id,
-        ).all()
-
-        com_ids = [c.comment_id for c in com_ids]
-        AssetComments.query.filter(AssetComments.comment_id.in_(com_ids)).delete()
-
-        Comments.query.filter(
-            Comments.comment_id.in_(com_ids)
-        ).delete()
-
-        # Directly delete the relevant records from the CaseAssets table
-        CaseAssets.query.filter(
-            CaseAssets.asset_id == asset_id,
-            CaseAssets.case_id == caseid
-        ).delete()
-
-        update_assets_state(caseid)
+    db.session.commit()
+    return
 
 
 def get_assets_types():

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -130,23 +130,19 @@ def update_asset(asset_name, asset_description, asset_ip, asset_info, asset_doma
     db.session.commit()
 
 
-def delete_asset(asset_id):
-    case_asset = get_asset(asset_id)
-    if case_asset is None:
-        return
-
-    delete_ioc_asset_link(asset_id)
+def delete_asset(asset: CaseAssets):
+    delete_ioc_asset_link(asset.asset_id)
 
     # Delete the relevant records from the CaseEventsAssets table
     CaseEventsAssets.query.filter(
-        case_asset.asset_id == CaseEventsAssets.asset_id
+        asset.asset_id == CaseEventsAssets.asset_id
     ).delete()
 
     # Delete the relevant records from the AssetComments table
     com_ids = AssetComments.query.with_entities(
         AssetComments.comment_id
     ).filter(
-        AssetComments.comment_asset_id == asset_id
+        AssetComments.comment_asset_id == asset.asset_id
     ).all()
 
     com_ids = [c.comment_id for c in com_ids]
@@ -156,9 +152,9 @@ def delete_asset(asset_id):
         Comments.comment_id.in_(com_ids)
     ).delete()
 
-    db.session.delete(case_asset)
+    db.session.delete(asset)
 
-    update_assets_state(case_asset.case_id)
+    update_assets_state(asset.case_id)
 
     db.session.commit()
 

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -136,6 +136,7 @@ def delete_asset(asset_id, caseid):
         return
 
     if case_asset.case_id and case_asset.alerts is not None:
+        delete_ioc_asset_link(asset_id)
 
         CaseEventsAssets.query.filter(
             case_asset.asset_id == CaseEventsAssets.asset_id

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -138,10 +138,22 @@ def delete_asset(asset_id, caseid):
     if case_asset.case_id and case_asset.alerts is not None:
         delete_ioc_asset_link(asset_id)
 
+        # Delete the relevant records from the CaseEventsAssets table
         CaseEventsAssets.query.filter(
             case_asset.asset_id == CaseEventsAssets.asset_id
         ).delete()
 
+        # Delete the relevant records from the AssetComments table
+        com_ids = AssetComments.query.with_entities(
+            AssetComments.comment_id
+        ).filter(
+            AssetComments.comment_asset_id == asset_id,
+        ).all()
+
+        com_ids = [c.comment_id for c in com_ids]
+        AssetComments.query.filter(AssetComments.comment_id.in_(com_ids)).delete()
+
+        # Directly delete the relevant records from the CaseAssets table
         CaseAssets.query.filter(
             CaseAssets.asset_id == asset_id,
             CaseAssets.case_id == caseid

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -147,7 +147,7 @@ def delete_asset(asset_id, caseid):
             CaseAssets.case_id == caseid
         ).delete()
 
-        update_assets_state(caseid=caseid)
+        update_assets_state(caseid)
 
         db.session.commit()
         return
@@ -181,7 +181,7 @@ def delete_asset(asset_id, caseid):
             CaseAssets.case_id == caseid
         ).delete()
 
-        update_assets_state(caseid=caseid)
+        update_assets_state(caseid)
 
 
 def get_assets_types():

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -130,7 +130,7 @@ def update_asset(asset_name, asset_description, asset_ip, asset_info, asset_doma
     db.session.commit()
 
 
-def delete_asset(asset_id, caseid):
+def delete_asset(asset_id):
     case_asset = get_asset(asset_id)
     if case_asset is None:
         return
@@ -158,11 +158,10 @@ def delete_asset(asset_id, caseid):
 
     # Directly delete the relevant records from the CaseAssets table
     CaseAssets.query.filter(
-        CaseAssets.asset_id == asset_id,
-        CaseAssets.case_id == caseid
+        CaseAssets.asset_id == asset_id
     ).delete()
 
-    update_assets_state(caseid)
+    update_assets_state(case_asset.asset_id)
 
     db.session.commit()
     return

--- a/source/app/datamgmt/case/case_iocs_db.py
+++ b/source/app/datamgmt/case/case_iocs_db.py
@@ -86,7 +86,7 @@ def delete_ioc(ioc: Ioc):
 
     db.session.delete(ioc)
 
-    update_ioc_state(caseid=ioc.case_id)
+    update_ioc_state(ioc.case_id)
 
 
 def get_detailed_iocs(caseid):

--- a/source/app/datamgmt/case/case_iocs_db.py
+++ b/source/app/datamgmt/case/case_iocs_db.py
@@ -70,6 +70,20 @@ def update_ioc(ioc_type, ioc_tags, ioc_value, ioc_description, ioc_tlp, userid, 
 
 
 def delete_ioc(ioc: Ioc):
+    # Delete the relevant records from the AssetComments table
+    com_ids = IocComments.query.with_entities(
+        IocComments.comment_id
+    ).filter(
+        IocComments.comment_ioc_id == ioc.ioc_id,
+    ).all()
+
+    com_ids = [c.comment_id for c in com_ids]
+    IocComments.query.filter(IocComments.comment_id.in_(com_ids)).delete()
+
+    Comments.query.filter(
+        Comments.comment_id.in_(com_ids)
+    ).delete()
+
     db.session.delete(ioc)
 
     update_ioc_state(caseid=ioc.case_id)

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -128,5 +128,5 @@ class TestsRestAssets(TestCase):
         comment_identifier = response['data']['comment_id']
         self._subject.delete(f'/api/v2/assets/{asset_identifier}')
         response = self._subject.create(f'/case/assets/{case_identifier}/comments/{comment_identifier}/edit', {'comment_text': 'new comment text'})
-        # TODO should really rather be 404 here
+        # TODO should ideally rather be 404 here
         self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -49,7 +49,7 @@ class TestsRestAssets(TestCase):
         self.assertEqual(201, response.status_code)
 
     def test_get_asset_with_missing_asset_identifier_should_return_404(self):
-        response = self._subject.get('/api/v2/asset/None')
+        response = self._subject.get(f'/api/v2/asset/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)
 
     def test_create_asset_with_missing_case_identifier_should_return_404(self):
@@ -78,3 +78,12 @@ class TestsRestAssets(TestCase):
         asset_identifier = response['asset_id']
         response = self._subject.get(f'/api/v2/assets/{asset_identifier}')
         self.assertEqual(200, response.status_code)
+
+    def test_get_asset_should_return_404_when_it_was_deleted(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
+        asset_identifier = response['asset_id']
+        self._subject.delete(f'/api/v2/assets/{asset_identifier}')
+        response = self._subject.get(f'/api/v2/assets/{asset_identifier}')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -87,3 +87,14 @@ class TestsRestAssets(TestCase):
         self._subject.delete(f'/api/v2/assets/{asset_identifier}')
         response = self._subject.get(f'/api/v2/assets/{asset_identifier}')
         self.assertEqual(404, response.status_code)
+
+    def test_delete_asset_should_increment_asset_state(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
+        asset_identifier = response['asset_id']
+        response = self._subject.get('/case/assets/state', {'cid': case_identifier}).json()
+        state = response['data']['object_state']
+        self._subject.delete(f'/api/v2/assets/{asset_identifier}')
+        response = self._subject.get('/case/assets/state', {'cid': case_identifier}).json()
+        self.assertEqual(state + 1, response['data']['object_state'])

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -79,7 +79,7 @@ class TestsRestAssets(TestCase):
         response = self._subject.get(f'/api/v2/assets/{asset_identifier}')
         self.assertEqual(200, response.status_code)
 
-    def test_get_asset_should_return_404_when_it_was_deleted(self):
+    def test_get_asset_should_return_404_after_it_was_deleted(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -109,3 +109,12 @@ class TestsRestAssets(TestCase):
         asset_identifier = response['asset_id']
         response = self._subject.delete(f'/api/v2/assets/{asset_identifier}')
         self.assertEqual(204, response.status_code)
+
+    def test_delete_asset_should_not_fail_when_it_has_associated_comments(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
+        asset_identifier = response['asset_id']
+        self._subject.create(f'/case/assets/{asset_identifier}/comments/add', {'comment_text': 'comment text'})
+        response = self._subject.delete(f'/api/v2/assets/{asset_identifier}')
+        self.assertEqual(204, response.status_code)

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -98,3 +98,14 @@ class TestsRestAssets(TestCase):
         self._subject.delete(f'/api/v2/assets/{asset_identifier}')
         response = self._subject.get('/case/assets/state', {'cid': case_identifier}).json()
         self.assertEqual(state + 1, response['data']['object_state'])
+
+    def test_delele_asset_should_not_fail_when_it_is_linked_to_an_ioc(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'ioc_type_id': 1, 'ioc_tlp_id': 2, 'ioc_value': '8.8.8.8', 'ioc_description': 'rewrw', 'ioc_tags': ''}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/iocs', body).json()
+        ioc_identifier = response['ioc_id']
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test', 'ioc_links': [ioc_identifier]}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
+        asset_identifier = response['asset_id']
+        response = self._subject.delete(f'/api/v2/assets/{asset_identifier}')
+        self.assertEqual(204, response.status_code)

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -118,3 +118,15 @@ class TestsRestAssets(TestCase):
         self._subject.create(f'/case/assets/{asset_identifier}/comments/add', {'comment_text': 'comment text'})
         response = self._subject.delete(f'/api/v2/assets/{asset_identifier}')
         self.assertEqual(204, response.status_code)
+
+    def test_delete_asset_should_delete_associated_comments(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'asset_type_id': '1', 'asset_name': 'admin_laptop_test'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
+        asset_identifier = response['asset_id']
+        response = self._subject.create(f'/case/assets/{asset_identifier}/comments/add', {'comment_text': 'comment text'}).json()
+        comment_identifier = response['data']['comment_id']
+        self._subject.delete(f'/api/v2/assets/{asset_identifier}')
+        response = self._subject.create(f'/case/assets/{case_identifier}/comments/{comment_identifier}/edit', {'comment_text': 'new comment text'})
+        # TODO should really rather be 404 here
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_iocs.py
+++ b/tests/tests_rest_iocs.py
@@ -156,3 +156,14 @@ class TestsRestIocs(TestCase):
         self._subject.create(f'/api/v2/cases/{case_identifier}/iocs', body)
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/iocs', body)
         self.assertEqual(400, response.status_code)
+
+    def test_delete_ioc_should_not_prevent_case_deletion(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'ioc_type_id': 1, 'ioc_tlp_id': 2, 'ioc_value': '8.8.8.8', 'ioc_description': 'rewrw', 'ioc_tags': ''}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/iocs', body).json()
+        ioc_identifier = response['ioc_id']
+        self._subject.create(f'/case/ioc/{ioc_identifier}/comments/add', {'comment_text': 'comment text'})
+        self._subject.delete(f'/api/v2/iocs/{ioc_identifier}')
+        response = self._subject.delete(f'/api/v2/cases/{case_identifier}')
+        self.assertEqual(204, response.status_code)
+


### PR DESCRIPTION
The goal of this PR was to fix the following regression: after an asset was deleted, it was not anymore in the list of assets of the case, but was still accessible with its identifier.
This problem was made visible because we don't rely on both the asset identifier and case identifier to retrieve an asset anymore. But, there was still some unexpected behavior in the existing code.
More specifically here https://github.com/dfir-iris/iris-web/blob/v2.4.14/source/app/datamgmt/case/case_assets_db.py#L128, case_asset.alerts is always different from None (because it is an empty list), and the asset was never really removed from the assets data table. Only it's case_id was set to null. (the code from here https://github.com/dfir-iris/iris-web/blob/v2.4.14/source/app/datamgmt/case/case_assets_db.py#L138, was never reachable)

I decided to always remove the asset completely. I am not sure this can have side-effects somewhere. I tried to explore all possible scenarios and made multiple tests. I made this fix in an isolated PR, so that you can fix in some other way, if necessary. The test scenarios will still be useful.
Also, this was the occasion to fix a missing case for IOC deletion.

The new tests cover these scenarios:
* test_get_asset_should_return_404_after_it_was_deleted
* test_delete_asset_should_increment_asset_state
* test_delele_asset_should_not_fail_when_it_is_linked_to_an_ioc
* test_delete_asset_should_not_fail_when_it_has_associated_comments
* test_delete_asset_should_delete_associated_comments
* test_delete_ioc_should_not_prevent_case_deletion
