### PR TITLE
fix(#636): upgraded `psycopg2` to latest version to avoid the issue "SCRAM authentication"

### DIFF
--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -11,7 +11,7 @@ Flask-Caching==1.10.1
 marshmallow==3.20.1
 marshmallow-sqlalchemy==0.30.0
 gunicorn==20.1.0
-psycopg2-binary==2.9.1
+psycopg2-binary==2.9.10
 pyunpack==0.2.2
 packaging==21.3
 requests==2.31.0


### PR DESCRIPTION
[636](https://github.com/dfir-iris/iris-web/issues/636)