### PR TITLE
[FIX] Issue with and_ conditions in alerts

### DIFF
--- a/source/app/datamgmt/alerts/alerts_db.py
+++ b/source/app/datamgmt/alerts/alerts_db.py
@@ -21,8 +21,7 @@ import json
 from datetime import datetime, timedelta
 from flask_login import current_user
 from functools import reduce
-from operator import and_
-from sqlalchemy import desc, asc, func, tuple_, or_, not_
+from sqlalchemy import desc, asc, func, tuple_, or_, not_, and_
 from sqlalchemy.orm import aliased, make_transient, selectinload
 from typing import List, Tuple, Dict
 


### PR DESCRIPTION
This pull request includes a small but important change to the `alerts_db.py` file. The change modifies the import statements to include the `and_` operator from `sqlalchemy`.

* [`source/app/datamgmt/alerts/alerts_db.py`](diffhunk://#diff-e7692755af8a1fb68669f119e8fe7ff61c43d8543fd5d3ce64d04af257582d85L24-R24): Added `and_` to the list of imported operators from `sqlalchemy`.