### PR TITLE
Issue 678 api v2 cases put

### DIFF
--- a/source/app/blueprints/graphql/cases.py
+++ b/source/app/blueprints/graphql/cases.py
@@ -103,7 +103,7 @@ class CaseCreate(Mutation):
             request['case_soc_id'] = soc_id
         if classification_id:
             request['classification_id'] = classification_id
-        case, _ = cases_create(request)
+        case = cases_create(request)
         return CaseCreate(case=case)
 
 

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -249,8 +249,8 @@ def api_add_case():
     case_schema = CaseSchema()
 
     try:
-        case, msg = cases_create(request.get_json())
-        return response_success(msg, data=case_schema.dump(case))
+        case = cases_create(request.get_json())
+        return response_success('Case created', data=case_schema.dump(case))
     except BusinessProcessingError as e:
         return response_error(e.get_message(), data=e.get_data())
 

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -264,6 +264,7 @@ def api_list_case():
 
 
 @manage_cases_rest_blueprint.route('/manage/cases/update/<int:cur_id>', methods=['POST'])
+@endpoint_deprecated('PUT', '/api/v2/cases/<int:identifier>')
 @ac_api_requires(Permissions.standard_user)
 def update_case_info(cur_id):
     if not ac_fast_check_current_user_has_case_access(cur_id, [CaseAccessLevel.full_access]):

--- a/source/app/blueprints/rest/v2/__init__.py
+++ b/source/app/blueprints/rest/v2/__init__.py
@@ -10,14 +10,14 @@ from app.blueprints.rest.v2.cases import cases_blueprint
 
 
 # Create root /api/v2 blueprint
-rest_v2_bp = Blueprint("rest_v2", __name__, url_prefix="/api/v2")
+rest_v2_blueprint = Blueprint("rest_v2", __name__, url_prefix="/api/v2")
 
 
 # Register child blueprints
-rest_v2_bp.register_blueprint(cases_blueprint)
-rest_v2_bp.register_blueprint(auth_blueprint)
-rest_v2_bp.register_blueprint(tasks_blueprint)
-rest_v2_bp.register_blueprint(iocs_blueprint)
-rest_v2_bp.register_blueprint(assets_blueprint)
-rest_v2_bp.register_blueprint(alerts_blueprint)
-rest_v2_bp.register_blueprint(dashboard_blueprint)
+rest_v2_blueprint.register_blueprint(cases_blueprint)
+rest_v2_blueprint.register_blueprint(auth_blueprint)
+rest_v2_blueprint.register_blueprint(tasks_blueprint)
+rest_v2_blueprint.register_blueprint(iocs_blueprint)
+rest_v2_blueprint.register_blueprint(assets_blueprint)
+rest_v2_blueprint.register_blueprint(alerts_blueprint)
+rest_v2_blueprint.register_blueprint(dashboard_blueprint)

--- a/source/app/blueprints/rest/v2/auth/__init__.py
+++ b/source/app/blueprints/rest/v2/auth/__init__.py
@@ -26,13 +26,12 @@ from app import app
 from app import db
 from app import oidc_client
 from app.blueprints.access_controls import is_authentication_ldap
-from app.blueprints.access_controls import is_authentication_oidc, \
-    not_authenticated_redirection_url
+from app.blueprints.access_controls import is_authentication_oidc
+from app.blueprints.access_controls import not_authenticated_redirection_url
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_success
 from app.business.auth import validate_ldap_login, validate_local_login
 from app.iris_engine.utils.tracker import track_activity
-from app.models.authorization import User
 from app.schema.marshables import UserSchema
 
 

--- a/source/app/blueprints/rest/v2/cases/__init__.py
+++ b/source/app/blueprints/rest/v2/cases/__init__.py
@@ -55,7 +55,7 @@ cases_blueprint.register_blueprint(case_tasks_blueprint)
 
 
 # Routes
-@cases_blueprint.post('', strict_slashes=False)
+@cases_blueprint.post('')
 @ac_api_requires(Permissions.standard_user)
 def create_case():
     """
@@ -69,7 +69,7 @@ def create_case():
         return response_api_error(e.get_message(), e.get_data())
 
 
-@cases_blueprint.get('', strict_slashes=False)
+@cases_blueprint.get('')
 @ac_api_requires()
 def get_cases() -> Response:
     """

--- a/source/app/blueprints/rest/v2/cases/__init__.py
+++ b/source/app/blueprints/rest/v2/cases/__init__.py
@@ -148,6 +148,19 @@ def case_routes_get(identifier):
     return response_api_success(CaseSchemaForAPIV2().dump(case))
 
 
+@cases_blueprint.put('/<int:identifier>')
+@ac_api_requires(Permissions.standard_user)
+def rest_v2_cases_update(identifier):
+    if not ac_fast_check_current_user_has_case_access(identifier, [CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=identifier)
+
+    try:
+        case, _ = cases_update(identifier, request.get_json())
+        return response_api_success(CaseSchemaForAPIV2().dump(case))
+    except BusinessProcessingError as e:
+        return response_api_error(e.get_message())
+
+
 @cases_blueprint.delete('/<int:identifier>')
 @ac_api_requires(Permissions.standard_user)
 def case_routes_delete(identifier):
@@ -161,17 +174,5 @@ def case_routes_delete(identifier):
     try:
         cases_delete(identifier)
         return response_api_deleted()
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message())
-
-@cases_blueprint.put('/<int:identifier>')
-@ac_api_requires(Permissions.standard_user)
-def rest_v2_cases_update(identifier):
-    if not ac_fast_check_current_user_has_case_access(identifier, [CaseAccessLevel.full_access]):
-        return ac_api_return_access_denied(caseid=identifier)
-
-    try:
-        case, _ = cases_update(identifier, request.get_json())
-        return response_api_success(CaseSchemaForAPIV2().dump(case))
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())

--- a/source/app/blueprints/rest/v2/cases/__init__.py
+++ b/source/app/blueprints/rest/v2/cases/__init__.py
@@ -124,7 +124,6 @@ def get_cases() -> Response:
 
     cases = {
         'total': filtered_cases.total,
-        # TODO should maybe really uniform all return types of paginated list and replace field cases by field data
         'data': CaseSchemaForAPIV2().dump(filtered_cases.items, many=True),
         'last_page': filtered_cases.pages,
         'current_page': filtered_cases.page,

--- a/source/app/blueprints/rest/v2/cases/__init__.py
+++ b/source/app/blueprints/rest/v2/cases/__init__.py
@@ -63,7 +63,7 @@ def create_case():
     """
 
     try:
-        case, _ = cases_create(request.get_json())
+        case = cases_create(request.get_json())
         return response_api_created(CaseSchemaForAPIV2().dump(case))
     except BusinessProcessingError as e:
         return response_api_error(e.get_message(), e.get_data())

--- a/source/app/blueprints/rest/v2/cases/assets.py
+++ b/source/app/blueprints/rest/v2/cases/assets.py
@@ -38,7 +38,7 @@ case_assets_blueprint = Blueprint('case_assets',
                                   url_prefix='/<int:case_id>/assets')
 
 
-@case_assets_blueprint.get('', strict_slashes=False)
+@case_assets_blueprint.get('')
 @ac_api_requires()
 def case_list_assets(case_id):
     """
@@ -65,7 +65,7 @@ def case_list_assets(case_id):
         return response_api_error(e.get_message())
 
 
-@case_assets_blueprint.post('', strict_slashes=False)
+@case_assets_blueprint.post('')
 @ac_api_requires()
 def add_asset(case_id):
     """

--- a/source/app/blueprints/rest/v2/cases/iocs.py
+++ b/source/app/blueprints/rest/v2/cases/iocs.py
@@ -37,7 +37,7 @@ case_iocs_blueprint = Blueprint('case_ioc_rest_v2',
                                 url_prefix='/<int:case_id>/iocs')
 
 
-@case_iocs_blueprint.get('', strict_slashes=False)
+@case_iocs_blueprint.get('')
 @ac_api_requires()
 def get_case_iocs(case_id):
     """
@@ -92,7 +92,7 @@ def get_case_iocs(case_id):
     return response_api_success(data=iocs)
 
 
-@case_iocs_blueprint.post('', strict_slashes=False)
+@case_iocs_blueprint.post('')
 @ac_api_requires()
 def add_ioc_to_case(case_id):
     """

--- a/source/app/blueprints/rest/v2/cases/tasks.py
+++ b/source/app/blueprints/rest/v2/cases/tasks.py
@@ -19,13 +19,19 @@
 from flask import Blueprint
 from flask import request
 
-from app.blueprints.rest.endpoints import response_api_error, response_api_not_found, response_api_deleted
+from app.blueprints.rest.endpoints import response_api_error
+from app.blueprints.rest.endpoints import response_api_not_found
+from app.blueprints.rest.endpoints import response_api_deleted
+from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.access_controls import ac_api_requires
 from app.schema.marshables import CaseTaskSchema
-from app.business.errors import BusinessProcessingError, ObjectNotFoundError
-from app.business.tasks import tasks_create, tasks_get, tasks_delete
+from app.business.errors import BusinessProcessingError
+from app.business.errors import ObjectNotFoundError
+from app.business.tasks import tasks_create
+from app.business.tasks import tasks_get
+from app.business.tasks import tasks_delete
 from app.models.authorization import CaseAccessLevel
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 
@@ -74,7 +80,7 @@ def get_case_task(case_id, identifier):
             return ac_api_return_access_denied(caseid=task.task_case_id)
 
         task_schema = CaseTaskSchema()
-        return response_api_created(task_schema.dump(task))
+        return response_api_success(task_schema.dump(task))
     except ObjectNotFoundError:
         return response_api_not_found()
 

--- a/source/app/blueprints/rest/v2/cases/tasks.py
+++ b/source/app/blueprints/rest/v2/cases/tasks.py
@@ -37,23 +37,23 @@ from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_
 
 case_tasks_blueprint = Blueprint('case_tasks',
                                  __name__,
-                                 url_prefix='/<int:case_id>/tasks')
+                                 url_prefix='/<int:case_identifier>/tasks')
 
 @case_tasks_blueprint.post('')
 @ac_api_requires()
-def add_case_task(case_id):
+def add_case_task(case_identifier):
     """
     Add a task to a case.
 
     Args:
-        case_id (int): The Case ID for this task
+        case_identifier (int): The Case ID for this task
     """
-    if not ac_fast_check_current_user_has_case_access(case_id, [CaseAccessLevel.full_access]):
-        return ac_api_return_access_denied(caseid=case_id)
+    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=case_identifier)
 
     task_schema = CaseTaskSchema()
     try:
-        _, case = tasks_create(case_id, request.get_json())
+        _, case = tasks_create(case_identifier, request.get_json())
         return response_api_created(task_schema.dump(case))
     except BusinessProcessingError as e:
         return response_api_error(e.get_message())
@@ -61,19 +61,19 @@ def add_case_task(case_id):
 
 @case_tasks_blueprint.get('/<int:identifier>')
 @ac_api_requires()
-def get_case_task(case_id, identifier):
+def get_case_task(case_identifier, identifier):
     """
     Handles getting a task from a case.
 
     Args:
-        case_id (int): The case ID
+        case_identifier (int): The case ID
         identifier (int): The task ID
     """
 
     try:
         task = tasks_get(identifier)
 
-        if task.task_case_id != case_id:
+        if task.task_case_id != case_identifier:
             raise ObjectNotFoundError()
 
         if not ac_fast_check_current_user_has_case_access(task.task_case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
@@ -87,19 +87,19 @@ def get_case_task(case_id, identifier):
 
 @case_tasks_blueprint.delete('/<int:identifier>')
 @ac_api_requires()
-def delete_case_task(case_id, identifier):
+def delete_case_task(case_identifier, identifier):
     """
     Handle deleting a task from a case
 
     Args:
-        case_id (int): The case ID
+        case_identifier (int): The case ID
         identifier (int): The task ID    
     """
 
     try:
         task = tasks_get(identifier)
 
-        if task.task_case_id != case_id:
+        if task.task_case_id != case_identifier:
             raise ObjectNotFoundError()
 
         if not ac_fast_check_current_user_has_case_access(task.task_case_id, [CaseAccessLevel.full_access]):

--- a/source/app/blueprints/rest/v2/cases/tasks.py
+++ b/source/app/blueprints/rest/v2/cases/tasks.py
@@ -107,4 +107,4 @@ def delete_case_task(case_id, identifier):
         return response_api_error(e.get_message())
 
 
-# TODO: Add task endpoint endpoint
+# TODO: Add task update endpoint

--- a/source/app/blueprints/rest/v2/cases/tasks.py
+++ b/source/app/blueprints/rest/v2/cases/tasks.py
@@ -33,7 +33,7 @@ case_tasks_blueprint = Blueprint('case_tasks',
                                  __name__,
                                  url_prefix='/<int:case_id>/tasks')
 
-@case_tasks_blueprint.post('', strict_slashes=False)
+@case_tasks_blueprint.post('')
 @ac_api_requires()
 def add_case_task(case_id):
     """

--- a/source/app/blueprints/rest/v2/tasks.py
+++ b/source/app/blueprints/rest/v2/tasks.py
@@ -19,7 +19,7 @@
 from flask import Blueprint
 
 from app.blueprints.rest.endpoints import response_api_not_found
-from app.blueprints.rest.endpoints import response_api_created
+from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_deleted
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.access_controls import ac_api_requires
@@ -49,8 +49,7 @@ def get_case_task(identifier):
             return ac_api_return_access_denied(caseid=task.task_case_id)
 
         task_schema = CaseTaskSchema()
-        # TODO should be response_api_success => add a test
-        return response_api_created(task_schema.dump(task))
+        return response_api_success(task_schema.dump(task))
     except ObjectNotFoundError:
         return response_api_not_found()
 

--- a/source/app/business/cases.py
+++ b/source/app/business/cases.py
@@ -78,9 +78,9 @@ def cases_exists(identifier):
     return case_db_exists(identifier)
 
 
-def cases_create(request_json):
+def cases_create(request_data):
     # TODO remove caseid doesn't seems to be useful for call_modules_hook => remove argument
-    request_data = call_modules_hook('on_preload_case_create', request_json, None)
+    request_data = call_modules_hook('on_preload_case_create', request_data, None)
 
     case = _load(request_data)
 
@@ -115,7 +115,7 @@ def cases_create(request_json):
     add_obj_history_entry(case, 'created')
     track_activity(f'new case "{case.name}" created', caseid=case.case_id, ctx_less=False)
 
-    return case, 'Case created'
+    return case
 
 
 def cases_delete(case_identifier):

--- a/source/app/views.py
+++ b/source/app/views.py
@@ -98,7 +98,7 @@ from app.blueprints.rest.reports_route import reports_rest_blueprint
 from app.blueprints.rest.search_routes import search_rest_blueprint
 from app.blueprints.graphql.graphql_route import graphql_blueprint
 
-from app.blueprints.rest.v2 import rest_v2_bp
+from app.blueprints.rest.v2 import rest_v2_blueprint
 from app.models.authorization import User
 from app.post_init import run_post_init
 
@@ -184,7 +184,7 @@ app.register_blueprint(alerts_rest_blueprint)
 app.register_blueprint(rest_api_blueprint)
 app.register_blueprint(demo_blueprint)
 
-app.register_blueprint(rest_v2_bp)
+app.register_blueprint(rest_v2_blueprint)
 
 
 try:

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -184,7 +184,12 @@ class TestsRestCases(TestCase):
         response = self._subject.update(f'/api/v2/cases/{identifier}', { 'case_name': 'new name' })
         self.assertEqual(200, response.status_code)
 
-    def test_update_case_should_update_severity(self):
+    def test_update_case_should_allow_to_update_severity(self):
         identifier = self._subject.create_dummy_case()
         response = self._subject.update(f'/api/v2/cases/{identifier}', { 'severity_id': 5 }).json()
         self.assertEqual(5, response['severity_id'])
+
+    def test_update_case_should_allow_to_update_classification(self):
+        identifier = self._subject.create_dummy_case()
+        response = self._subject.update(f'/api/v2/cases/{identifier}', { 'classification_id': 3 }).json()
+        self.assertEqual(3, response['classification_id'])

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -49,6 +49,15 @@ class TestsRestCases(TestCase):
         })
         self.assertEqual(201, response.status_code)
 
+    def test_create_case_with_spurious_slash_should_return_404(self):
+        response = self._subject.create('/api/v2/cases/', {
+            'case_name': 'name',
+            'case_description': 'description',
+            'case_customer': 1,
+            'case_soc_id': ''
+        })
+        self.assertEqual(404, response.status_code)
+
     def test_create_case_with_missing_name_should_return_400(self):
         response = self._subject.create('/api/v2/cases', {
             'case_description': 'description',

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -204,3 +204,8 @@ class TestsRestCases(TestCase):
         identifier = self._subject.create_dummy_case()
         response = self._subject.update(f'/api/v2/cases/{identifier}', { 'state_id': 2 }).json()
         self.assertEqual(2, response['state']['state_id'])
+
+    def test_update_case_should_allow_to_update_status(self):
+        identifier = self._subject.create_dummy_case()
+        response = self._subject.update(f'/api/v2/cases/{identifier}', { 'status_id': 2 }).json()
+        self.assertEqual(2, response['status_id'])

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -199,3 +199,8 @@ class TestsRestCases(TestCase):
         identifier = self._subject.create_dummy_case()
         response = self._subject.update(f'/api/v2/cases/{identifier}', { 'owner_id': user.get_identifier() }).json()
         self.assertEqual(user.get_identifier(), response['owner']['id'])
+
+    def test_update_case_should_allow_to_update_state(self):
+        identifier = self._subject.create_dummy_case()
+        response = self._subject.update(f'/api/v2/cases/{identifier}', { 'state_id': 2 }).json()
+        self.assertEqual(2, response['state']['state_id'])

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -17,6 +17,7 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from unittest import TestCase
+from uuid import uuid4
 from iris import Iris
 
 
@@ -169,6 +170,11 @@ class TestsRestCases(TestCase):
         response = self._subject.get(f'/api/v2/cases/{case_identifier}').json()
         self.assertIn('case_name', response)
 
+    def test_get_case_should_have_field_case_customer_id(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}').json()
+        self.assertIn('case_customer_id', response)
+
     def test_create_case_should_return_data_with_case_customer_when_case_customer_is_an_empty_string(self):
         body = {
             'case_name': 'case name',
@@ -209,3 +215,10 @@ class TestsRestCases(TestCase):
         identifier = self._subject.create_dummy_case()
         response = self._subject.update(f'/api/v2/cases/{identifier}', { 'status_id': 2 }).json()
         self.assertEqual(2, response['status_id'])
+
+    def test_update_case_should_allow_to_update_customer(self):
+        identifier = self._subject.create_dummy_case()
+        response = self._subject.create('/manage/customers/add', { 'customer_name': f'customer{uuid4()}'}).json()
+        customer_identifier = response['data']['customer_id']
+        response = self._subject.update(f'/api/v2/cases/{identifier}', {'case_customer': customer_identifier}).json()
+        self.assertEqual(customer_identifier, response['case_customer_id'])

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -169,3 +169,8 @@ class TestsRestCases(TestCase):
         }
         response = self._subject.create('/api/v2/cases', body).json()
         self.assertIn('case_customer', response['data'])
+
+    def test_update_case_should_not_fail(self):
+        identifier = self._subject.create_dummy_case()
+        response = self._subject.update(f'/api/v2/cases/{identifier}', { 'case_name': 'new name' })
+        self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -183,3 +183,8 @@ class TestsRestCases(TestCase):
         identifier = self._subject.create_dummy_case()
         response = self._subject.update(f'/api/v2/cases/{identifier}', { 'case_name': 'new name' })
         self.assertEqual(200, response.status_code)
+
+    def test_update_case_should_update_severity(self):
+        identifier = self._subject.create_dummy_case()
+        response = self._subject.update(f'/api/v2/cases/{identifier}', { 'severity_id': 5 }).json()
+        self.assertEqual(5, response['severity_id'])

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -222,3 +222,9 @@ class TestsRestCases(TestCase):
         customer_identifier = response['data']['customer_id']
         response = self._subject.update(f'/api/v2/cases/{identifier}', {'case_customer': customer_identifier}).json()
         self.assertEqual(customer_identifier, response['case_customer_id'])
+
+    def test_update_case_should_allow_to_update_reviewer(self):
+        identifier = self._subject.create_dummy_case()
+        user = self._subject.create_dummy_user()
+        response = self._subject.update(f'/api/v2/cases/{identifier}', {'reviewer_id': user.get_identifier()}).json()
+        self.assertEqual(user.get_identifier(), response['reviewer_id'])

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -193,3 +193,9 @@ class TestsRestCases(TestCase):
         identifier = self._subject.create_dummy_case()
         response = self._subject.update(f'/api/v2/cases/{identifier}', { 'classification_id': 3 }).json()
         self.assertEqual(3, response['classification_id'])
+
+    def test_update_case_should_allow_to_update_owner(self):
+        user = self._subject.create_dummy_user()
+        identifier = self._subject.create_dummy_case()
+        response = self._subject.update(f'/api/v2/cases/{identifier}', { 'owner_id': user.get_identifier() }).json()
+        self.assertEqual(user.get_identifier(), response['owner']['id'])

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -228,3 +228,9 @@ class TestsRestCases(TestCase):
         user = self._subject.create_dummy_user()
         response = self._subject.update(f'/api/v2/cases/{identifier}', {'reviewer_id': user.get_identifier()}).json()
         self.assertEqual(user.get_identifier(), response['reviewer_id'])
+
+    def test_update_case_should_allow_to_update_tags(self):
+        identifier = self._subject.create_dummy_case()
+        response = self._subject.update(f'/api/v2/cases/{identifier}', {'case_tags': 'tag1,tag2'}).json()
+        self.assertEqual('tag1,tag2', response['case_tags'])
+

--- a/tests/tests_rest_tasks.py
+++ b/tests/tests_rest_tasks.py
@@ -44,6 +44,13 @@ class TestsRestTasks(TestCase):
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/tasks', body)
         self.assertEqual(400, response.status_code)
 
+    def test_create_case_with_spurious_slash_should_return_404(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'task_assignees_id': [1], 'task_description': '', 'task_status_id': 1, 'task_tags': '',
+                'task_title': 'dummy title', 'custom_attributes': {}}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/tasks/', body)
+        self.assertEqual(404, response.status_code)
+
     def test_get_task_should_return_201(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'task_assignees_id': [2], 'task_description': '', 'task_status_id': 1, 'task_tags': '',

--- a/tests/tests_rest_tasks.py
+++ b/tests/tests_rest_tasks.py
@@ -51,7 +51,7 @@ class TestsRestTasks(TestCase):
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/tasks/', body)
         self.assertEqual(404, response.status_code)
 
-    def test_get_task_should_return_201(self):
+    def test_get_task_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'task_assignees_id': [2], 'task_description': '', 'task_status_id': 1, 'task_tags': '',
                 'task_title': 'dummy title',
@@ -59,7 +59,7 @@ class TestsRestTasks(TestCase):
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/tasks', body).json()
         task_identifier = response['id']
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/tasks/{task_identifier}')
-        self.assertEqual(201, response.status_code)
+        self.assertEqual(200, response.status_code)
 
     def test_get_task_with_missing_task_identifier_should_return_error(self):
         case_identifier = self._subject.create_dummy_case()


### PR DESCRIPTION
This PR adds endpoint PUT /api/v2/cases/{identifier} to update a case.

Other work done:

* fixed /api/v2/cases/{case_identifier}/tasks/{task_identifier} to return 200 instead of 201 on success (added a test)
* removed strict_slashes=False option to all endpoints that had it (we want to be strict) (added a test)
* changed tuple into a single value for business method cases_create (tuple as return values are a code smell)
* changed last `bp` into `blueprint` and some `id` into `identifier` (avoid abbreviations)
* added several tests about the case update

Remark: I noticed one inconsistency between the cases endpoint. They return case objects, with field `case_customer_id`. However endpoints POST /api/v2/cases and PUT /api/v2/cases/{identifier} expect field `case_customer`. I tried to change everything to `case_customer_id`. But it was too difficult to do, without risking to break past behavior. Maybe we should create an issue to track this and correct later.