### PR TITLE
Temporarily unplug unfinished endpoints

### DIFF
--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -154,8 +154,7 @@ def alerts_list_route() -> Response:
             assets=alert_assets,
             iocs=alert_iocs,
             resolution_status=request.args.get('alert_resolution_id', type=int),
-            current_user_id=current_user.id,
-            fields=fields
+            current_user_id=current_user.id
         )
 
     except Exception as e:

--- a/source/app/blueprints/rest/v2/alerts/__init__.py
+++ b/source/app/blueprints/rest/v2/alerts/__init__.py
@@ -29,8 +29,7 @@ from app.models.authorization import Permissions
 alerts_blueprint = Blueprint('alerts', __name__, url_prefix='/alerts')
 
 
-# TODO put this endpoint back once it adheres to the conventions (return value for paginated data: field alerts should be field data)
-#@alerts_blueprint.get('')
+@alerts_blueprint.get('')
 @ac_api_requires(Permissions.alerts_read)
 def alerts_list_route() -> Response:
     """

--- a/source/app/blueprints/rest/v2/alerts/__init__.py
+++ b/source/app/blueprints/rest/v2/alerts/__init__.py
@@ -29,7 +29,8 @@ from app.models.authorization import Permissions
 alerts_blueprint = Blueprint('alerts', __name__, url_prefix='/alerts')
 
 
-@alerts_blueprint.get('')
+# TODO put this endpoint back once it adheres to the conventions (return value for paginated data: field alerts should be field data)
+#@alerts_blueprint.get('')
 @ac_api_requires(Permissions.alerts_read)
 def alerts_list_route() -> Response:
     """

--- a/source/app/blueprints/rest/v2/auth/__init__.py
+++ b/source/app/blueprints/rest/v2/auth/__init__.py
@@ -38,7 +38,8 @@ from app.schema.marshables import UserSchema
 auth_blueprint = Blueprint('auth', __name__, url_prefix='/auth')
 
 
-@auth_blueprint.post('/login')
+# TODO put this endpoint back after thinking about it (doesn't feel REST)
+#@auth_blueprint.post('/login')
 def login():
     """
     Login endpoint. Handles taking user/pass combo and authenticating a local session or returning an error.
@@ -66,7 +67,8 @@ def login():
     return response_api_success(data=authed_user)
 
 
-@auth_blueprint.get('/logout')
+# TODO put this endpoint back after thinking about it (doesn't feel REST)
+#@auth_blueprint.get('/logout')
 def logout():
     """
     Logout function. Erase its session and redirect to index i.e login
@@ -105,7 +107,8 @@ def logout():
     return redirect(not_authenticated_redirection_url('/'))
 
 
-@auth_blueprint.route('/whoami', methods=['GET'])
+# TODO shouldn't we rather have /api/v2/users/{identifier}?
+#@auth_blueprint.route('/whoami', methods=['GET'])
 def whoami():
     """
     Returns information about the currently authenticated user.

--- a/source/app/blueprints/rest/v2/cases/assets.py
+++ b/source/app/blueprints/rest/v2/cases/assets.py
@@ -38,7 +38,8 @@ case_assets_blueprint = Blueprint('case_assets',
                                   url_prefix='/<int:case_id>/assets')
 
 
-@case_assets_blueprint.get('')
+# TODO put this endpoint back once it adheres to the conventions (return value for paginated data: field assets should be field data, spurious field state, missing total, last_page, current_page and next_page)
+#@case_assets_blueprint.get('')
 @ac_api_requires()
 def case_list_assets(case_id):
     """

--- a/source/app/blueprints/rest/v2/context/api_v2_context_routes.py
+++ b/source/app/blueprints/rest/v2/context/api_v2_context_routes.py
@@ -29,7 +29,8 @@ from app.models.models import Client
 api_v2_context_blueprint = Blueprint('context_api_v2', __name__, url_prefix='/api/v2')
 
 
-@api_v2_context_blueprint.route('/context/search-cases', methods=['GET'])
+# TODO put this endpoint back once it adheres to the conventions (verb in URL)
+#@api_v2_context_blueprint.route('/context/search-cases', methods=['GET'])
 @ac_api_requires()
 def cases_context_search_v2():
     """
@@ -40,7 +41,8 @@ def cases_context_search_v2():
     return response_api_success(data=data)
 
 
-@api_v2_context_blueprint.route('/context/set', methods=['POST'])
+# TODO put this endpoint back once it adheres to the conventions (verb in URL)
+#@api_v2_context_blueprint.route('/context/set', methods=['POST'])
 @ac_api_requires()
 def set_ctx_v2():
     """

--- a/source/app/blueprints/rest/v2/dashboard/__init__.py
+++ b/source/app/blueprints/rest/v2/dashboard/__init__.py
@@ -28,7 +28,9 @@ dashboard_blueprint = Blueprint('dashboard',
                                 url_prefix='/dashboard')
 
 
-@dashboard_blueprint.route('/cases/list', methods=['GET'])
+# TODO this endpoint does not adhere to the conventions (verb in URL).
+#      Prefer to use GET /api/v2/cases. Check it is possible. If not, evolve /api/v2/cases
+#@dashboard_blueprint.route('/cases/list', methods=['GET'])
 @ac_api_requires()
 def list_own_cases():
     cases = list_user_cases(
@@ -38,14 +40,18 @@ def list_own_cases():
     return response_api_success(data=CaseDetailsSchema(many=True).dump(cases))
 
 
-@dashboard_blueprint.route('/tasks/list', methods=['GET'])
+# TODO this endpoint does not adhere to the conventions (verb in URL).
+#      We should rather have /api/v2/tasks?
+#@dashboard_blueprint.route('/tasks/list', methods=['GET'])
 @ac_api_requires()
 def list_own_tasks():
     ct = list_user_tasks()
     return response_api_success(data=CaseTaskSchema(many=True).dump(ct))
 
 
-@dashboard_blueprint.route('/reviews/list', methods=['GET'])
+# TODO this endpoint does not adhere to the conventions (verb in URL).
+#      We should rather have /api/v2/reviews?
+#@dashboard_blueprint.route('/reviews/list', methods=['GET'])
 @ac_api_requires()
 def list_own_reviews():
     reviews = list_user_reviews()

--- a/source/app/datamgmt/alerts/alerts_db.py
+++ b/source/app/datamgmt/alerts/alerts_db.py
@@ -158,8 +158,7 @@ def get_filtered_alerts(
         sort: str = 'desc',
         current_user_id: int = None,
         source_reference=None,
-        custom_conditions: List[dict] = None,
-        fields: List[str] = None):
+        custom_conditions: List[dict] = None):
     """
     Get a list of alerts that match the given filter conditions
 

--- a/source/app/datamgmt/alerts/alerts_db.py
+++ b/source/app/datamgmt/alerts/alerts_db.py
@@ -339,16 +339,6 @@ def get_filtered_alerts(
 
     order_func = desc if sort == "desc" else asc
 
-    # If fields are provided, use them in the schema
-    if fields:
-        try:
-            alert_schema = AlertSchema(only=fields)
-        except Exception as e:
-            app.app.logger.exception(f"Error selecting fields in AlertSchema: {str(e)}")
-            alert_schema = AlertSchema()
-    else:
-        alert_schema = AlertSchema()
-
     try:
         # Query the alerts using the filter conditions
 
@@ -359,13 +349,7 @@ def get_filtered_alerts(
             order_func(Alert.alert_source_event_time)
         ).paginate(page=page, per_page=per_page, error_out=False)
 
-        return {
-            'total': filtered_alerts.total,
-            'alerts': alert_schema.dump(filtered_alerts, many=True),
-            'last_page': filtered_alerts.pages,
-            'current_page': filtered_alerts.page,
-            'next_page': filtered_alerts.next_num if filtered_alerts.has_next else None,
-        }
+        return filtered_alerts
 
     except Exception as e:
         app.app.logger.exception(f"Error getting alerts: {str(e)}")

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -28,6 +28,10 @@ class TestsRestAlerts(TestCase):
 
     def tearDown(self):
         self._subject.clear_database()
+        response = self._subject.get('api/v2/alerts').json()
+        for alert in response['alerts']:
+            identifier = alert['alert_id']
+            self._subject.create(f'/alerts/delete/{identifier}', {})
 
     def test_create_alert_should_not_fail(self):
         body = {
@@ -58,6 +62,11 @@ class TestsRestAlerts(TestCase):
         self._subject.create('/alerts/add', body)
         response = self._subject.get('/api/v2/alerts', query_parameters={'alert_title': alert_title}).json()
         self.assertEqual(1, response['total'])
+
+    def test_get_alerts_should_return_field_data(self):
+        response = self._subject.get('/api/v2/alerts').json()
+        # TODO should be data
+        self.assertEqual([], response['alerts'])
 
     def test_merge_alert_into_a_case_should_not_fail(self):
         case_identifier = self._subject.create_dummy_case()

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -39,13 +39,25 @@ class TestsRestAlerts(TestCase):
         response = self._subject.create('/alerts/add', body)
         self.assertEqual(200, response.status_code)
 
-    def test_alerts_filter_with_alerts_filter_should_not_fail(self):
+    def test_alerts_with_filter_alerts_assets_should_not_fail(self):
         response = self._subject.get('/api/v2/alerts', query_parameters={'alert_assets': 'some assert name'})
         self.assertEqual(200, response.status_code)
 
-    def test_alerts_filter_with_iocs_filter_should_not_fail(self):
+    def test_alerts_filter_with_filter_alert_iocs_should_not_fail(self):
         response = self._subject.get('api/v2/alerts', query_parameters={'alert_iocs': 'some ioc value'})
         self.assertEqual(200, response.status_code)
+
+    def test_get_alerts_filter_should_show_newly_created_alert_for_administrator(self):
+        alert_title = f'title{uuid4()}'
+        body = {
+            'alert_title': alert_title,
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        self._subject.create('/alerts/add', body)
+        response = self._subject.get('/api/v2/alerts', query_parameters={'alert_title': alert_title}).json()
+        self.assertEqual(1, response['total'])
 
     def test_merge_alert_into_a_case_should_not_fail(self):
         case_identifier = self._subject.create_dummy_case()
@@ -65,16 +77,3 @@ class TestsRestAlerts(TestCase):
         response = self._subject.create(f'/alerts/merge/{alert_identifier}', body)
         # TODO should be 201
         self.assertEqual(200, response.status_code)
-
-    def test_get_alerts_filter_should_show_newly_created_alert_for_administrator(self):
-        alert_title = f'title{uuid4()}'
-        body = {
-            'alert_title': alert_title,
-            'alert_severity_id': 4,
-            'alert_status_id': 3,
-            'alert_customer_id': 1
-        }
-        self._subject.create('/alerts/add', body)
-        response = self._subject.get('/api/v2/alerts', query_parameters={'alert_title': alert_title}).json()
-        self.assertEqual(1, response['total'])
-

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -29,7 +29,7 @@ class TestsRestAlerts(TestCase):
     def tearDown(self):
         self._subject.clear_database()
         response = self._subject.get('api/v2/alerts').json()
-        for alert in response['alerts']:
+        for alert in response['data']:
             identifier = alert['alert_id']
             self._subject.create(f'/alerts/delete/{identifier}', {})
 
@@ -65,8 +65,7 @@ class TestsRestAlerts(TestCase):
 
     def test_get_alerts_should_return_field_data(self):
         response = self._subject.get('/api/v2/alerts').json()
-        # TODO should be data
-        self.assertEqual([], response['alerts'])
+        self.assertEqual([], response['data'])
 
     def test_merge_alert_into_a_case_should_not_fail(self):
         case_identifier = self._subject.create_dummy_case()


### PR DESCRIPTION
Commented out all new API v2 endpoints which do not completely adhere to the design rules (and which are not documented yet).
I just left GET /api/v2/alerts (because they were tests failing otherwise and I didn't want to remove them: it felt like losing ground), but changed field name `alerts` to `data` to be uniform with the other endpoints returning paginated lists. Added a test. (I will however not document this endpoint yet: I wait till we work on all the alerts endpoint, because there might be some changes in the values returned)

Once, this PR is merged, v2.5.0-beta-1 can be tagged.