### PR TITLE
Update frontend in dev compose to use env keys

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,7 +45,6 @@ services:
       - ./source/app:/iriswebapp/app
       - ./ui/dist:/iriswebapp/static
     healthcheck:
-      disable: true
       test: curl --head --fail http://localhost:8000 || exit 1
       start_period: 60s
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,7 @@ services:
       - ./source/app:/iriswebapp/app
       - ./ui/dist:/iriswebapp/static
     healthcheck:
+      disable: true
       test: curl --head --fail http://localhost:8000 || exit 1
       start_period: 60s
 
@@ -76,16 +77,16 @@ services:
     container_name: iris_sveltekit_frontend
     working_dir: /app
     environment:
-      - IRIS_SVELTEKIT_FRONTEND_DIR=${IRIS_SVELTEKIT_FRONTEND_DIR:-../frontend}
-      - PUBLIC_EXTERNAL_API_URL=https://127.0.0.1
-      - PUBLIC_INTERNAL_API_URL=http://app:8000
+      - IRIS_SVELTEKIT_FRONTEND_DIR=${IRIS_SVELTEKIT_FRONTEND_DIR:-../iris-frontend}
+      - PUBLIC_EXTERNAL_API_URL=${PUBLIC_EXTERNAL_API_URL:-https://127.0.0.1}
+      - PUBLIC_INTERNAL_API_URL=http://${IRIS_UPSTREAM_SERVER}:${IRIS_UPSTREAM_PORT}
       - PUBLIC_USE_MOCK_API_DATA=false
       - ORIGIN=https://127.0.0.1
       - PROTOCOL_HEADER=x-forwarded-proto
       - HOST_HEADER=x-forwarded-host
       - NODE_ENV=development
     volumes:
-      - ${IRIS_SVELTEKIT_FRONTEND_DIR}:/app # Map the frontend directory dynamically
+      - ${IRIS_SVELTEKIT_FRONTEND_DIR:-../iris-frontend}:/app # Map the frontend directory dynamically
       - /app/node_modules # Ensure `node_modules` is preserved inside the container
     ports:
       - "5173:5173"


### PR DESCRIPTION
Something I ran into while moving my setup over to use the API so I could work on the frontend with the live API. The API configurations are static, but I updated them to match how the entire compose is configured (based on those env keys) so it "just works".