### PR TITLE
[FIX] UI logout was not working anymore

### DIFF
--- a/e2e/tests/administrator/dashboard.spec.js
+++ b/e2e/tests/administrator/dashboard.spec.js
@@ -12,3 +12,10 @@ test('create case with empty name should present error', async ({ page }) => {
     // FIXME: Locator should be: page.getByRole('alert', { name: 'Invalid data type' });
     await expect(page.getByText('Invalid data type')).toBeVisible();
 });
+
+test('logout should go back to login page', async ({ page }) => {
+    await page.getByRole('link', { name: 'administrator' }).click();
+    await page.getByRole('link', { name: 'Logout' }).click();
+
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+})

--- a/source/app/templates/includes/sidenav.html
+++ b/source/app/templates/includes/sidenav.html
@@ -29,7 +29,7 @@
 										</a>
 									</li>
 									<li>
-										<a href='/api/v2/auth/logout'>
+										<a href={{ url_for('dashboard_rest.logout') }}>
 											<span class="link-collapse">Logout</span>
 										</a>
 									</li>


### PR DESCRIPTION
Logout in the user interface was not working anymore, because the /logout had been moved and renamed into /api/v2/logout and then the new endpoint was commented out.
I put back endpoint /logout and added an end to end test to avoid future regression.