### PR TITLE
Api v2 create note

### DIFF
--- a/source/app/__init__.py
+++ b/source/app/__init__.py
@@ -65,6 +65,7 @@ LOG_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 logger.basicConfig(level=logger.INFO, format=LOG_FORMAT, datefmt=LOG_TIME_FORMAT)
 
+ma = Marshmallow()
 celery = make_celery(__name__)
 app = Flask(__name__, static_folder='../static')
 
@@ -123,11 +124,11 @@ bc = Bcrypt(app)  # flask-bcrypt
 lm = LoginManager()  # flask-loginmanager
 lm.init_app(app)  # init the login manager
 
-ma = Marshmallow(app) # Init marshmallow
+from app.post_init import run_post_init
+ma.init_app(app)
 
 dropzone = Dropzone(app)
 
-from app.post_init import run_post_init
 set_celery_flask_context(celery, app)
 
 # store = HttpExposedFileSystemStore(

--- a/source/app/__init__.py
+++ b/source/app/__init__.py
@@ -65,6 +65,7 @@ LOG_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 logger.basicConfig(level=logger.INFO, format=LOG_FORMAT, datefmt=LOG_TIME_FORMAT)
 
+bc = Bcrypt()  # flask-bcrypt
 ma = Marshmallow()
 celery = make_celery(__name__)
 app = Flask(__name__, static_folder='../static')
@@ -119,12 +120,12 @@ SQLALCHEMY_ENGINE_OPTIONS = {
 
 db = SQLAlchemy(app, engine_options=SQLALCHEMY_ENGINE_OPTIONS)  # flask-sqlalchemy
 
-bc = Bcrypt(app)  # flask-bcrypt
+from app.post_init import run_post_init
+bc.init_app(app)
 
 lm = LoginManager()  # flask-loginmanager
 lm.init_app(app)  # init the login manager
 
-from app.post_init import run_post_init
 ma.init_app(app)
 
 dropzone = Dropzone(app)
@@ -145,7 +146,7 @@ alerts_namespace = AlertsNamespace('/alerts')
 socket_io.on_namespace(alerts_namespace)
 
 oidc_client = None
-if app.config.get('AUTHENTICATION_TYPE') == "oidc":
+if app.config.get('AUTHENTICATION_TYPE') == 'oidc':
     oidc_client = get_oidc_client(app.config, app.logger)
 from app.views import register_blueprints
 from app.views import load_user

--- a/source/app/__init__.py
+++ b/source/app/__init__.py
@@ -157,11 +157,11 @@ def after_request(response):
     return response
 
 
-from app.views import register_blusprints
+from app.views import register_blueprints
 from app.views import load_user
 from app.views import load_user_from_request
 
-register_blusprints(app)
+register_blueprints(app)
 
 from app.post_init import run_post_init
 

--- a/source/app/__init__.py
+++ b/source/app/__init__.py
@@ -141,7 +141,8 @@ socket_io.on_namespace(alerts_namespace)
 
 oidc_client = None
 if app.config.get('AUTHENTICATION_TYPE') == "oidc":
-    oidc_client = get_oidc_client(app)
+    oidc_client = get_oidc_client(app.config, app.logger)
+from app.views import register_blueprints
 
 @app.teardown_appcontext
 def shutdown_session(exception=None):
@@ -157,7 +158,6 @@ def after_request(response):
     return response
 
 
-from app.views import register_blueprints
 from app.views import load_user
 from app.views import load_user_from_request
 

--- a/source/app/__init__.py
+++ b/source/app/__init__.py
@@ -125,6 +125,7 @@ ma = Marshmallow(app) # Init marshmallow
 dropzone = Dropzone(app)
 
 celery = make_celery(app)
+from app.post_init import run_post_init
 
 # store = HttpExposedFileSystemStore(
 #     path='images',
@@ -143,6 +144,8 @@ oidc_client = None
 if app.config.get('AUTHENTICATION_TYPE') == "oidc":
     oidc_client = get_oidc_client(app.config, app.logger)
 from app.views import register_blueprints
+from app.views import load_user
+from app.views import load_user_from_request
 
 @app.teardown_appcontext
 def shutdown_session(exception=None):
@@ -158,12 +161,7 @@ def after_request(response):
     return response
 
 
-from app.views import load_user
-from app.views import load_user_from_request
-
 register_blueprints(app)
-
-from app.post_init import run_post_init
 
 try:
 

--- a/source/app/alembic/env.py
+++ b/source/app/alembic/env.py
@@ -1,7 +1,10 @@
+import os
 from alembic import context
 from logging.config import fileConfig
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
+from app.configuration import SQLALCHEMY_BASE_ADMIN_URI
+from app.configuration import PG_DB_
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -11,10 +14,7 @@ config = context.config
 # This line sets up loggers basically.
 fileConfig(config.config_file_name)
 
-import os
 os.environ["ALEMBIC"] = "1"
-
-from app.configuration import SQLALCHEMY_BASE_ADMIN_URI, PG_DB_
 
 config.set_main_option('sqlalchemy.url', SQLALCHEMY_BASE_ADMIN_URI + PG_DB_)
 

--- a/source/app/blueprints/graphql/graphql_route.py
+++ b/source/app/blueprints/graphql/graphql_route.py
@@ -55,8 +55,7 @@ from app.blueprints.graphql.permissions import permissions_check_current_user_ha
 import warnings
 
 # Ignore all UserWarnings
-warnings.filterwarnings("ignore", category=UserWarning)
-
+warnings.filterwarnings('ignore', category=UserWarning)
 
 
 class Query(ObjectType):

--- a/source/app/blueprints/pages/login/login_routes.py
+++ b/source/app/blueprints/pages/login/login_routes.py
@@ -40,7 +40,7 @@ from app.blueprints.access_controls import is_authentication_oidc
 from app.blueprints.access_controls import is_authentication_ldap
 from app.blueprints.responses import response_error
 from app.business.auth import validate_ldap_login
-from app.business.auth import retrieve_user_by_username
+from app.business.users import retrieve_user_by_username
 from app.business.auth import wrap_login_user
 from app.datamgmt.manage.manage_users_db import create_user
 from app.datamgmt.manage.manage_users_db import get_user

--- a/source/app/blueprints/pages/login/login_routes.py
+++ b/source/app/blueprints/pages/login/login_routes.py
@@ -36,9 +36,12 @@ from app import app
 from app import bc
 from app import db
 from app import oidc_client
-from app.blueprints.access_controls import is_authentication_oidc, is_authentication_ldap
+from app.blueprints.access_controls import is_authentication_oidc
+from app.blueprints.access_controls import is_authentication_ldap
 from app.blueprints.responses import response_error
-from app.business.auth import validate_ldap_login, _retrieve_user_by_username, wrap_login_user
+from app.business.auth import validate_ldap_login
+from app.business.auth import _retrieve_user_by_username
+from app.business.auth import wrap_login_user
 from app.datamgmt.manage.manage_users_db import create_user
 from app.datamgmt.manage.manage_users_db import get_user
 from app.forms import LoginForm, MFASetupForm

--- a/source/app/blueprints/pages/login/login_routes.py
+++ b/source/app/blueprints/pages/login/login_routes.py
@@ -40,7 +40,7 @@ from app.blueprints.access_controls import is_authentication_oidc
 from app.blueprints.access_controls import is_authentication_ldap
 from app.blueprints.responses import response_error
 from app.business.auth import validate_ldap_login
-from app.business.auth import _retrieve_user_by_username
+from app.business.auth import retrieve_user_by_username
 from app.business.auth import wrap_login_user
 from app.datamgmt.manage.manage_users_db import create_user
 from app.datamgmt.manage.manage_users_db import get_user
@@ -71,7 +71,7 @@ def _render_template_login(form, msg):
 
 
 def _validate_local_login(username, password):
-    user = _retrieve_user_by_username(username)
+    user = retrieve_user_by_username(username)
     if not user:
         return None
 
@@ -96,7 +96,7 @@ def _authenticate_ldap(form, username, password, local_fallback=True):
 
 
 def _authenticate_password(form, username, password):
-    user = _retrieve_user_by_username(username)
+    user = retrieve_user_by_username(username)
     if not user or user.is_service_account:
         return _render_template_login(form, 'Wrong credentials. Please try again.')
 
@@ -226,7 +226,7 @@ if is_authentication_oidc():
 
 @app.route('/auth/mfa-setup', methods=['GET', 'POST'])
 def mfa_setup():
-    user = _retrieve_user_by_username(username=session['username'])
+    user = retrieve_user_by_username(username=session['username'])
     form = MFASetupForm()
 
     if form.submit() and form.validate():
@@ -278,7 +278,7 @@ def mfa_verify():
 
         return redirect(url_for('login.login'))
 
-    user = _retrieve_user_by_username(username=session['username'])
+    user = retrieve_user_by_username(username=session['username'])
 
     # Redirect user to MFA setup if MFA is not fully set up
     if not user.mfa_secrets or not user.mfa_setup_complete:

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -27,6 +27,7 @@ from sqlalchemy import and_
 from app import db
 from app import app
 from app.blueprints.rest.case_comments import case_comment_update
+from app.blueprints.rest.endpoints import endpoint_deprecated
 from app.business.errors import BusinessProcessingError
 from app.business.notes import notes_create
 from app.business.notes import notes_list_revisions
@@ -200,6 +201,7 @@ def case_note_revision_delete(cur_id, revision_id, caseid):
 
 
 @case_notes_rest_blueprint.route('/case/notes/add', methods=['POST'])
+@endpoint_deprecated('POST', '/api/v2/cases/<int:identifier>/notes')
 @ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_note_add(caseid):

--- a/source/app/blueprints/rest/v2/cases/__init__.py
+++ b/source/app/blueprints/rest/v2/cases/__init__.py
@@ -32,6 +32,7 @@ from app.blueprints.rest.endpoints import response_api_paginated
 from app.blueprints.rest.parsing import parse_pagination_parameters
 from app.blueprints.rest.v2.cases.assets import case_assets_blueprint
 from app.blueprints.rest.v2.cases.iocs import case_iocs_blueprint
+from app.blueprints.rest.v2.cases.notes import case_notes_blueprint
 from app.blueprints.rest.v2.cases.tasks import case_tasks_blueprint
 from app.business.cases import cases_create
 from app.business.cases import cases_delete
@@ -53,6 +54,7 @@ cases_blueprint = Blueprint('cases',
                             url_prefix='/cases')
 cases_blueprint.register_blueprint(case_assets_blueprint)
 cases_blueprint.register_blueprint(case_iocs_blueprint)
+cases_blueprint.register_blueprint(case_notes_blueprint)
 cases_blueprint.register_blueprint(case_tasks_blueprint)
 
 

--- a/source/app/blueprints/rest/v2/cases/assets.py
+++ b/source/app/blueprints/rest/v2/cases/assets.py
@@ -20,11 +20,13 @@ from flask import Blueprint
 from flask import request
 
 from app.blueprints.access_controls import ac_api_requires
-from app.blueprints.rest.endpoints import response_api_created, response_api_deleted
+from app.blueprints.rest.endpoints import response_api_created
+from app.blueprints.rest.endpoints import response_api_deleted
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_paginated
 from app.blueprints.rest.endpoints import response_api_not_found
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.blueprints.rest.parsing import parse_pagination_parameters
 from app.business.cases import cases_exists
 from app.business.assets import assets_create
@@ -37,7 +39,6 @@ from app.business.errors import ObjectNotFoundError
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
-from app.blueprints.access_controls import ac_api_return_access_denied
 
 case_assets_blueprint = Blueprint('case_assets',
                                   __name__,
@@ -80,7 +81,7 @@ def add_asset(case_identifier):
         _, asset = assets_create(case_identifier, request.get_json())
         return response_api_created(asset_schema.dump(asset))
     except BusinessProcessingError as e:
-        return response_api_error(e.get_message(), e.get_data())
+        return response_api_error(e.get_message(), data=e.get_data())
 
 
 @case_assets_blueprint.get('/<int:identifier>')

--- a/source/app/blueprints/rest/v2/cases/notes.py
+++ b/source/app/blueprints/rest/v2/cases/notes.py
@@ -22,11 +22,13 @@ from flask import request
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.endpoints import response_api_error
+from app.blueprints.rest.endpoints import response_api_not_found
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.schema.marshables import CaseNoteSchema
 from app.models.authorization import CaseAccessLevel
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.business.notes import notes_create
+from app.business.cases import cases_exists
 from app.business.errors import BusinessProcessingError
 
 
@@ -38,6 +40,9 @@ case_notes_blueprint = Blueprint('case_notes',
 @case_notes_blueprint.post('')
 @ac_api_requires()
 def create_note(case_identifier):
+    if not cases_exists(case_identifier):
+        return response_api_not_found()
+
     if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=case_identifier)
 

--- a/source/app/blueprints/rest/v2/cases/notes.py
+++ b/source/app/blueprints/rest/v2/cases/notes.py
@@ -1,0 +1,51 @@
+#  IRIS Source Code
+#  Copyright (C) 2024 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from flask import Blueprint
+from flask import request
+
+from app.blueprints.access_controls import ac_api_requires
+from app.blueprints.rest.endpoints import response_api_created
+from app.blueprints.rest.endpoints import response_api_error
+from app.blueprints.access_controls import ac_api_return_access_denied
+from app.schema.marshables import CaseNoteSchema
+from app.models.authorization import CaseAccessLevel
+from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
+from app.business.notes import notes_create
+from app.business.errors import BusinessProcessingError
+
+
+case_notes_blueprint = Blueprint('case_notes',
+                                 __name__,
+                                 url_prefix='/<int:case_identifier>/notes')
+
+
+@case_notes_blueprint.post('')
+@ac_api_requires()
+def create_note(case_identifier):
+    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=case_identifier)
+
+    note_schema = CaseNoteSchema()
+    try:
+        note = notes_create(request_json=request.get_json(), case_identifier=case_identifier)
+
+        return response_api_created(note_schema.dump(note))
+
+    except BusinessProcessingError as e:
+        return response_api_error(e.get_message(), data=e.get_data())

--- a/source/app/business/auth.py
+++ b/source/app/business/auth.py
@@ -14,7 +14,7 @@ from app.schema.marshables import UserSchema
 
 log = app.logger
 
-def _retrieve_user_by_username(username:str):
+def retrieve_user_by_username(username:str):
     """
     Retrieve the user object by username.
 
@@ -45,7 +45,7 @@ def validate_ldap_login(username: str, password:str, local_fallback: bool = True
             track_activity(f'wrong login password for user \'{username}\' using LDAP auth', ctx_less=True, display_in_ui=False)
             return None
 
-        user = _retrieve_user_by_username(username)
+        user = retrieve_user_by_username(username)
         if not user:
             return None
 
@@ -64,7 +64,7 @@ def validate_local_login(username: str, password: str):
 
     :return: User object if successful, None otherwise
     """
-    user = _retrieve_user_by_username(username)
+    user = retrieve_user_by_username(username)
     if not user:
         return None
 

--- a/source/app/business/auth.py
+++ b/source/app/business/auth.py
@@ -4,8 +4,8 @@ from flask import session, redirect, url_for, request
 from flask_login import login_user
 
 from app import bc, app, db
+from app.business.users import retrieve_user_by_username
 from app.datamgmt.manage.manage_srv_settings_db import get_server_settings_as_dict
-from app.datamgmt.manage.manage_users_db import get_active_user_by_login
 from app.iris_engine.access_control.ldap_handler import ldap_authenticate
 from app.iris_engine.access_control.utils import ac_get_effective_permissions_of_user
 from app.iris_engine.utils.tracker import track_activity
@@ -14,18 +14,6 @@ from app.schema.marshables import UserSchema
 
 log = app.logger
 
-def retrieve_user_by_username(username:str):
-    """
-    Retrieve the user object by username.
-
-    :param username: Username
-    :return: User object if found, None
-    """
-    user = get_active_user_by_login(username)
-    if not user:
-        track_activity(f'someone tried to log in with user \'{username}\', which does not exist',
-                       ctx_less=True, display_in_ui=False)
-    return user
 
 def validate_ldap_login(username: str, password:str, local_fallback: bool = True):
     """

--- a/source/app/business/notes.py
+++ b/source/app/business/notes.py
@@ -31,10 +31,9 @@ from app.schema.marshables import CaseNoteSchema
 from app.util import add_obj_history_entry
 
 
-def _load(request_data, note_schema=None):
+def _load(request_data):
     try:
-        if note_schema is None:
-            note_schema = CaseNoteSchema()
+        note_schema = CaseNoteSchema()
         return note_schema.load(request_data)
     except ValidationError as e:
         raise BusinessProcessingError('Data error', e.messages)

--- a/source/app/business/users.py
+++ b/source/app/business/users.py
@@ -18,6 +18,8 @@
 from app import db
 from app.business.errors import BusinessProcessingError
 from app.datamgmt.manage.manage_users_db import get_active_user
+from app.datamgmt.manage.manage_users_db import get_active_user_by_login
+from app.iris_engine.utils.tracker import track_activity
 
 
 def users_reset_mfa(user_id: int = None):
@@ -33,3 +35,16 @@ def users_reset_mfa(user_id: int = None):
 
     db.session.commit()
 
+
+def retrieve_user_by_username(username:str):
+    """
+    Retrieve the user object by username.
+
+    :param username: Username
+    :return: User object if found, None
+    """
+    user = get_active_user_by_login(username)
+    if not user:
+        track_activity(f'someone tried to log in with user \'{username}\', which does not exist',
+                       ctx_less=True, display_in_ui=False)
+    return user

--- a/source/app/datamgmt/case/case_assets_db.py
+++ b/source/app/datamgmt/case/case_assets_db.py
@@ -109,7 +109,6 @@ def filter_assets(case_identifier, pagination_parameters: PaginationParameters) 
             query = query.order_by(order_func(getattr(CaseAssets, order_by)))
     assets = query.paginate(page=pagination_parameters.get_page(), per_page=pagination_parameters.get_per_page(), error_out=False)
 
-
     return assets
 
 

--- a/source/app/iris_engine/access_control/oidc_handler.py
+++ b/source/app/iris_engine/access_control/oidc_handler.py
@@ -22,27 +22,27 @@ from oic.oic.message import RegistrationResponse
 from oic.oic.message import ProviderConfigurationResponse
 
 
-def get_oidc_client(app) -> Client:
+def get_oidc_client(config, logger) -> Client:
     client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
 
     # retrieve provider configuration dynamically from metadata
     # or fall back to env vars
     try:
-        client.provider_config(app.config.get("OIDC_ISSUER_URL"))
+        client.provider_config(config.get("OIDC_ISSUER_URL"))
     except Exception as e:
-        app.logger.warning(f"Could not read OIDC metadata, using environment variables - error {e}")
+        logger.warning(f"Could not read OIDC metadata, using environment variables - error {e}")
         op_info = ProviderConfigurationResponse(
-            issuer=app.config.get("OIDC_ISSUER_URL"),
-            authorization_endpoint=app.config.get("OIDC_AUTH_ENDPOINT"),
-            token_endpoint=app.config.get("OIDC_TOKEN_ENDPOINT"),
-            end_session_endpoint=app.config.get("OIDC_END_SESSION_ENDPOINT"),
+            issuer=config.get("OIDC_ISSUER_URL"),
+            authorization_endpoint=config.get("OIDC_AUTH_ENDPOINT"),
+            token_endpoint=config.get("OIDC_TOKEN_ENDPOINT"),
+            end_session_endpoint=config.get("OIDC_END_SESSION_ENDPOINT"),
         )
 
         client.handle_provider_config(op_info, op_info['issuer'])
 
     info = {
-        "client_id": app.config.get("OIDC_CLIENT_ID"),
-        "client_secret": app.config.get("OIDC_CLIENT_SECRET")
+        "client_id": config.get("OIDC_CLIENT_ID"),
+        "client_secret": config.get("OIDC_CLIENT_SECRET")
     }
     client_reg = RegistrationResponse(**info)
     client.store_registration_info(client_reg)

--- a/source/app/iris_engine/tasker/celery.py
+++ b/source/app/iris_engine/tasker/celery.py
@@ -17,21 +17,20 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from celery import Celery
+from app.configuration import Config
 
 
-def make_celery(app):
-    celery = Celery(
-        app.import_name,
-        config_source=app.config.get('CELERY')
+def make_celery(name):
+    return Celery(
+        name,
+        config_source=Config.CELERY
     )
 
+
+def set_celery_flask_context(celery: Celery, app):
     class ContextTask(celery.Task):
         def __call__(self, *args, **kwargs):
             with app.app_context():
                 return self.run(*args, **kwargs)
 
-    celery.Task = ContextTask
-
-    return celery
-
-
+    celery.task_cls = ContextTask

--- a/source/app/schema/marshables.py
+++ b/source/app/schema/marshables.py
@@ -459,7 +459,7 @@ class CaseNoteSchema(ma.SQLAlchemyAutoSchema):
 
         """
         assert_type_mml(input_var=data.get('directory_id'),
-                        field_name="directory_id",
+                        field_name='directory_id',
                         type=int)
 
         directory = NoteDirectory.query.filter(

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -161,26 +161,26 @@ def assert_type_mml(input_var: any, field_name: str,  type: type, allow_none: bo
                     max_len: int = None, max_val: int = None, min_val: int = None):
     if input_var is None:
         if allow_none is False:
-            raise marshmallow.ValidationError("Invalid data - non null expected",
-                                            field_name=field_name if field_name else "type")
+            raise marshmallow.ValidationError('Invalid data - non null expected',
+                                              field_name=field_name if field_name else 'type')
         else:
             return True
     
     if isinstance(input_var, type):
         if max_len:
             if len(input_var) > max_len:
-                raise marshmallow.ValidationError("Invalid data - max length exceeded",
-                                                field_name=field_name if field_name else "type")
+                raise marshmallow.ValidationError('Invalid data - max length exceeded',
+                                                  field_name=field_name if field_name else 'type')
 
         if max_val:
             if input_var > max_val:
-                raise marshmallow.ValidationError("Invalid data - max value exceeded",
-                                                field_name=field_name if field_name else "type")
+                raise marshmallow.ValidationError('Invalid data - max value exceeded',
+                                                  field_name=field_name if field_name else 'type')
 
         if min_val:
             if input_var < min_val:
-                raise marshmallow.ValidationError("Invalid data - min value exceeded",
-                                                field_name=field_name if field_name else "type")
+                raise marshmallow.ValidationError('Invalid data - min value exceeded',
+                                                  field_name=field_name if field_name else 'type')
 
         return True
     
@@ -193,5 +193,5 @@ def assert_type_mml(input_var: any, field_name: str,  type: type, allow_none: bo
         log.error(e)
         print(e)
         
-    raise marshmallow.ValidationError("Invalid data type",
-                                      field_name=field_name if field_name else "type")
+    raise marshmallow.ValidationError('Invalid data type',
+                                      field_name=field_name if field_name else 'type')

--- a/source/app/views.py
+++ b/source/app/views.py
@@ -99,7 +99,7 @@ from app.blueprints.graphql.graphql_route import graphql_blueprint
 from app.blueprints.rest.v2 import rest_v2_blueprint
 from app.models.authorization import User
 
-def register_blusprints(app):
+def register_blueprints(app):
     app.register_blueprint(graphql_blueprint)
     app.register_blueprint(dashboard_blueprint)
     app.register_blueprint(dashboard_rest_blueprint)

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -31,7 +31,7 @@ class TestsRestAssets(TestCase):
     def tearDown(self):
         self._subject.clear_database()
 
-    def test_create_asset_should_work(self):
+    def test_create_asset_should_return_201(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'asset_type_id': 1, 'asset_name': 'admin_laptop_test'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body)

--- a/tests/tests_rest_notes.py
+++ b/tests/tests_rest_notes.py
@@ -19,6 +19,8 @@
 from unittest import TestCase
 from iris import Iris
 
+_IDENTIFIER_FOR_NONEXISTENT_OBJECT = 123456789
+
 
 class TestsRestNotes(TestCase):
 
@@ -68,3 +70,11 @@ class TestsRestNotes(TestCase):
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body).json()
         self.assertEqual(parent_directory_identifier, response['directory']['parent_id'])
 
+    def test_create_note_with_missing_case_identifier_should_return_404(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.create(f'/case/notes/directories/add',
+                                        {'name': 'directory_name'}, query_parameters={'cid': case_identifier}).json()
+        directory_identifier = response['data']['id']
+        body = {'directory_id': directory_identifier}
+        response = self._subject.create(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes', body)
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_notes.py
+++ b/tests/tests_rest_notes.py
@@ -78,3 +78,9 @@ class TestsRestNotes(TestCase):
         body = {'directory_id': directory_identifier}
         response = self._subject.create(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes', body)
         self.assertEqual(404, response.status_code)
+
+    def test_create_note_with_missing_directory_should_return_404(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'directory_id': _IDENTIFIER_FOR_NONEXISTENT_OBJECT}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body)
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_notes.py
+++ b/tests/tests_rest_notes.py
@@ -36,3 +36,21 @@ class TestsRestNotes(TestCase):
         body = {'directory_id': directory_identifier}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body)
         self.assertEqual(201, response.status_code)
+
+    def test_create_note_should_accept_field_note_title_with_empty_value(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.create(f'/case/notes/directories/add',
+                                        {'name': 'directory_name'}, query_parameters={'cid': case_identifier}).json()
+        directory_identifier = response['data']['id']
+        body = {'directory_id': directory_identifier, 'note_title': ''}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body).json()
+        self.assertEqual('', response['note_title'])
+
+    def test_create_note_should_accept_field_note_content_with_empty_value(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.create(f'/case/notes/directories/add',
+                                        {'name': 'directory_name'}, query_parameters={'cid': case_identifier}).json()
+        directory_identifier = response['data']['id']
+        body = {'directory_id': directory_identifier, 'note_content': ''}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body).json()
+        self.assertEqual('', response['note_content'])

--- a/tests/tests_rest_notes.py
+++ b/tests/tests_rest_notes.py
@@ -79,8 +79,18 @@ class TestsRestNotes(TestCase):
         response = self._subject.create(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes', body)
         self.assertEqual(404, response.status_code)
 
-    def test_create_note_with_missing_directory_should_return_404(self):
+    def test_create_note_with_missing_directory_should_return_400(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'directory_id': _IDENTIFIER_FOR_NONEXISTENT_OBJECT}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body)
+        self.assertEqual(400, response.status_code)
+
+    def test_create_note_with_directory_from_another_case_should_return_400(self):
+        case_identifier = self._subject.create_dummy_case()
+        case_identifier2 = self._subject.create_dummy_case()
+        response = self._subject.create(f'/case/notes/directories/add',
+                                        {'name': 'directory_name'}, query_parameters={'cid': case_identifier2}).json()
+        directory_identifier = response['data']['id']
+        body = {'directory_id': directory_identifier}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body)
         self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_notes.py
+++ b/tests/tests_rest_notes.py
@@ -1,0 +1,38 @@
+#  IRIS Source Code
+#  Copyright (C) 2023 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from unittest import TestCase
+from iris import Iris
+
+
+class TestsRestNotes(TestCase):
+
+    def setUp(self) -> None:
+        self._subject = Iris()
+
+    def tearDown(self):
+        self._subject.clear_database()
+
+    def test_create_note_should_return_201(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.create(f'/case/notes/directories/add',
+                                        {'name': 'directory_name'}, query_parameters={'cid': case_identifier}).json()
+        directory_identifier = response['data']['id']
+        body = {'directory_id': directory_identifier}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body)
+        self.assertEqual(201, response.status_code)

--- a/tests/tests_rest_notes.py
+++ b/tests/tests_rest_notes.py
@@ -94,3 +94,13 @@ class TestsRestNotes(TestCase):
         body = {'directory_id': directory_identifier}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body)
         self.assertEqual(400, response.status_code)
+
+    def test_create_note_should_return_object_with_field_modification_history(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.create(f'/case/notes/directories/add',
+                                        {'name': 'directory_name'}, query_parameters={'cid': case_identifier}).json()
+        directory_identifier = response['data']['id']
+        body = {'directory_id': directory_identifier}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body).json()
+        first_modification_history = next(iter(response['modification_history'].values()))
+        self.assertEqual({'user': 'administrator', 'user_id': 1, 'action': 'created note'}, first_modification_history)

--- a/tests/tests_rest_notes.py
+++ b/tests/tests_rest_notes.py
@@ -54,3 +54,17 @@ class TestsRestNotes(TestCase):
         body = {'directory_id': directory_identifier, 'note_content': ''}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body).json()
         self.assertEqual('', response['note_content'])
+
+    def test_create_note_in_sub_directory_should_return_directory_parent_id(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.create(f'/case/notes/directories/add',
+                                        {'name': 'parent_directory_name'}, query_parameters={'cid': case_identifier}).json()
+        parent_directory_identifier = response['data']['id']
+        response = self._subject.create(f'/case/notes/directories/add',
+                                        {'name': 'directory_name', 'parent_id': parent_directory_identifier},
+                                        query_parameters={'cid': case_identifier}).json()
+        directory_identifier = response['data']['id']
+        body = {'directory_id': directory_identifier, 'note_content': ''}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes', body).json()
+        self.assertEqual(parent_directory_identifier, response['directory']['parent_id'])
+


### PR DESCRIPTION
Implementation of endpoint POST /api/v2/cases/{case_identifier}/notes to create a note.

* implementation and tests
* deprecated POST /case/notes/add
* quality: removed code that was duplicated in source/app/blueprints/graphql/graphql_route.py
* quality: tried to work on the initialization somewhat, in order to remove cycle and be able to put all imports at the top of the file (this is going to take a long time. So I try to do it a bit at a time.) I would like to activate Ruff rule E402. Doing this, improves the architecture (cycles in dependencies are complex to understand) and reduces adherence to flask. Also, this is better for testability.

Note: this PR goes hand in hand with iris-doc-src [PR#41](https://github.com/dfir-iris/iris-doc-src/pull/41).