### PR TITLE
[#722][IMP]Fix date parsing bug in case timeline (time badge)

### DIFF
--- a/ui/src/pages/case.timeline.js
+++ b/ui/src/pages/case.timeline.js
@@ -623,8 +623,10 @@ function buildEvent(event_data, compact, comments_map, tree, tesk, tmb, idx, rea
 
     let day = dta[0];
     // Transform the date to the user's system format. day is in the format YYYY-MM-DD. We want our date in the user's host format, without the minutes and seconds.
-    // First parse the date to a Date object
-    let date = new Date(day);
+    // First extract the year, month, and day from the date
+    let [event_year, event_month, event_day] = day.split('-');
+    // Then parse the date to a Date object
+    let date = new Date(event_year, parseInt(event_month)-1, event_day);
     // Then use the toLocaleDateString method to get the date in the user's host format
     day = date.toLocaleDateString();
 


### PR DESCRIPTION
Resolve an off-by-one bug in the case timeline view by passing individual date parts to the Date() constructor.