### PR TITLE
Commented out variables image tags variables in .env.model

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -3,7 +3,7 @@ LOG_LEVEL=info
 
 # -- NGINX
 NGINX_IMAGE_NAME=ghcr.io/dfir-iris/iriswebapp_nginx
-NGINX_IMAGE_TAG=latest
+#NGINX_IMAGE_TAG=latest
 
 SERVER_NAME=iris.app.dev
 KEY_FILENAME=iris_dev_key.pem
@@ -11,7 +11,7 @@ CERT_FILENAME=iris_dev_cert.pem
 
 # -- DATABASE
 DB_IMAGE_NAME=ghcr.io/dfir-iris/iriswebapp_db
-DB_IMAGE_TAG=latest
+#DB_IMAGE_TAG=latest
 
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=__MUST_BE_CHANGED__
@@ -24,7 +24,7 @@ POSTGRES_PORT=5432
 
 # -- IRIS
 APP_IMAGE_NAME=ghcr.io/dfir-iris/iriswebapp_app
-APP_IMAGE_TAG=latest
+#APP_IMAGE_TAG=latest
 
 DOCKERIZED=1
 


### PR DESCRIPTION
In the `.env.model`, these 3 variables are defined to set the docker image version:
```
NGINX_IMAGE_TAG=latest
...
DB_IMAGE_TAG=latest
...
APP_IMAGE_TAG=latest
```
There is a risk for people to unknowingly use the wrong version, as exemplified in this discussion https://github.com/orgs/dfir-iris/discussions/735#discussioncomment-12419489.
So it, to me, seems more user-friendly to comment these lines out.
I am not sure, these variables are really useful. We could also remove them.
