### PR TITLE
Api v2 get paginated evidences

### DIFF
--- a/source/app/blueprints/rest/case/case_evidences_routes.py
+++ b/source/app/blueprints/rest/case/case_evidences_routes.py
@@ -52,6 +52,7 @@ case_evidences_rest_blueprint = Blueprint('case_evidences_rest', __name__)
 
 
 @case_evidences_rest_blueprint.route('/case/evidences/list', methods=['GET'])
+@endpoint_deprecated('GET', '/api/v2/cases/{case_identifier}/evidences')
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_list_rfiles(caseid):

--- a/source/app/blueprints/rest/parsing.py
+++ b/source/app/blueprints/rest/parsing.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from flask import Request
 from app.models.pagination_parameters import PaginationParameters
 
 
@@ -41,12 +43,12 @@ def parse_fields_parameters(request):
     return fields
 
 
-def parse_pagination_parameters(request) -> PaginationParameters:
+def parse_pagination_parameters(request: Request, default_order_by=None, default_direction='asc') -> PaginationParameters:
     arguments = request.args
     page = arguments.get('page', 1, type=int)
     per_page = arguments.get('per_page', 10, type=int)
-    order_by = arguments.get('order_by', type=str)
-    sort_dir = arguments.get('sort_dir', 'asc', type=str)
+    order_by = arguments.get('order_by', default_order_by, type=str)
+    direction = arguments.get('sort_dir', default_direction, type=str)
 
-    return PaginationParameters(page, per_page, order_by, sort_dir)
+    return PaginationParameters(page, per_page, order_by, direction)
 

--- a/source/app/blueprints/rest/v2/cases/assets.py
+++ b/source/app/blueprints/rest/v2/cases/assets.py
@@ -27,7 +27,8 @@ from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_paginated
 from app.blueprints.rest.endpoints import response_api_not_found
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.blueprints.rest.parsing import parse_pagination_parameters, parse_fields_parameters
+from app.blueprints.rest.parsing import parse_pagination_parameters
+from app.blueprints.rest.parsing import parse_fields_parameters
 from app.business.cases import cases_exists
 from app.business.assets import assets_create
 from app.business.assets import assets_filter

--- a/source/app/blueprints/rest/v2/cases/assets.py
+++ b/source/app/blueprints/rest/v2/cases/assets.py
@@ -50,7 +50,7 @@ case_assets_blueprint = Blueprint('case_assets',
 def case_list_assets(case_identifier):
 
     try:
-
+        # TODO shouldn't CaseAccessLevel.read_only be allowed here too?
         if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
             return ac_api_return_access_denied(caseid=case_identifier)
 

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -36,7 +36,6 @@ from app.schema.marshables import CaseEvidenceSchema
 from app.business.evidences import evidences_create
 from app.business.evidences import evidences_get
 from app.business.evidences import evidences_filter
-from app.models.models import CaseReceivedFile
 
 
 case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_prefix='/<int:case_identifier>/evidences')

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -24,8 +24,10 @@ from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_
 from app.models.authorization import CaseAccessLevel
 from app.business.errors import BusinessProcessingError
 from app.business.errors import ObjectNotFoundError
+from app.blueprints.rest.parsing import parse_pagination_parameters
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.blueprints.rest.endpoints import response_api_created, response_api_paginated
+from app.blueprints.rest.endpoints import response_api_created
+from app.blueprints.rest.endpoints import response_api_paginated
 from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_not_found
@@ -45,7 +47,8 @@ def get_evidences(case_identifier):
     if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=case_identifier)
 
-    evidences = evidences_filter(case_identifier)
+    pagination_parameters = parse_pagination_parameters(request, default_order_by='date_added', default_direction='desc')
+    evidences = evidences_filter(case_identifier, pagination_parameters)
 
     evidence_schema = CaseEvidenceSchema()
     return response_api_paginated(evidence_schema, evidences)

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -45,6 +45,9 @@ case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_pre
 @case_evidences_blueprint.get('')
 @ac_api_requires()
 def get_evidences(case_identifier):
+    if not cases_exists(case_identifier):
+        return response_api_not_found()
+
     if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=case_identifier)
 

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -33,9 +33,21 @@ from app.business.cases import cases_exists
 from app.schema.marshables import CaseEvidenceSchema
 from app.business.evidences import evidences_create
 from app.business.evidences import evidences_get
+from app.datamgmt.case.case_rfiles_db import get_rfiles
 
 
 case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_prefix='/<int:case_identifier>/evidences')
+
+
+@case_evidences_blueprint.get('')
+@ac_api_requires()
+def get_evidences(case_identifier):
+    evidences = get_rfiles(case_identifier)
+
+    evidence_schema = CaseEvidenceSchema()
+    evidence_schema.dump(evidences, many=True)
+
+    return response_api_success(evidence_schema.dump(evidences, many=True))
 
 
 @case_evidences_blueprint.post('')

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -36,6 +36,7 @@ from app.schema.marshables import CaseEvidenceSchema
 from app.business.evidences import evidences_create
 from app.business.evidences import evidences_get
 from app.business.evidences import evidences_filter
+from app.models.models import CaseReceivedFile
 
 
 case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_prefix='/<int:case_identifier>/evidences')
@@ -48,10 +49,13 @@ def get_evidences(case_identifier):
         return ac_api_return_access_denied(caseid=case_identifier)
 
     pagination_parameters = parse_pagination_parameters(request, default_order_by='date_added', default_direction='desc')
-    evidences = evidences_filter(case_identifier, pagination_parameters)
+    try:
+        evidences = evidences_filter(case_identifier, pagination_parameters)
 
-    evidence_schema = CaseEvidenceSchema()
-    return response_api_paginated(evidence_schema, evidences)
+        evidence_schema = CaseEvidenceSchema()
+        return response_api_paginated(evidence_schema, evidences)
+    except BusinessProcessingError as e:
+        return response_api_error(e.get_message(), data=e.get_data())
 
 
 @case_evidences_blueprint.post('')

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -25,7 +25,7 @@ from app.models.authorization import CaseAccessLevel
 from app.business.errors import BusinessProcessingError
 from app.business.errors import ObjectNotFoundError
 from app.blueprints.access_controls import ac_api_return_access_denied
-from app.blueprints.rest.endpoints import response_api_created
+from app.blueprints.rest.endpoints import response_api_created, response_api_paginated
 from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_not_found
@@ -33,7 +33,7 @@ from app.business.cases import cases_exists
 from app.schema.marshables import CaseEvidenceSchema
 from app.business.evidences import evidences_create
 from app.business.evidences import evidences_get
-from app.datamgmt.case.case_rfiles_db import get_rfiles
+from app.business.evidences import evidences_filter
 
 
 case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_prefix='/<int:case_identifier>/evidences')
@@ -45,12 +45,10 @@ def get_evidences(case_identifier):
     if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=case_identifier)
 
-    evidences = get_rfiles(case_identifier)
+    evidences = evidences_filter(case_identifier)
 
     evidence_schema = CaseEvidenceSchema()
-    evidence_schema.dump(evidences, many=True)
-
-    return response_api_success(evidence_schema.dump(evidences, many=True))
+    return response_api_paginated(evidence_schema, evidences)
 
 
 @case_evidences_blueprint.post('')

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -42,6 +42,9 @@ case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_pre
 @case_evidences_blueprint.get('')
 @ac_api_requires()
 def get_evidences(case_identifier):
+    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=case_identifier)
+
     evidences = get_rfiles(case_identifier)
 
     evidence_schema = CaseEvidenceSchema()

--- a/source/app/business/evidences.py
+++ b/source/app/business/evidences.py
@@ -26,10 +26,10 @@ from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.schema.marshables import CaseEvidenceSchema
 from app.models.models import CaseReceivedFile
+from app.models.pagination_parameters import PaginationParameters
 from app.datamgmt.case.case_rfiles_db import add_rfile
 from app.datamgmt.case.case_rfiles_db import get_rfile
 from app.datamgmt.case.case_rfiles_db import get_paginated_evidences
-
 
 
 def _load(request_data):
@@ -62,5 +62,5 @@ def evidences_get(identifier) -> CaseReceivedFile:
     return evidence
 
 
-def evidences_filter(case_identifier) -> Pagination:
-    return get_paginated_evidences(case_identifier)
+def evidences_filter(case_identifier, pagination_parameters: PaginationParameters) -> Pagination:
+    return get_paginated_evidences(case_identifier, pagination_parameters)

--- a/source/app/business/evidences.py
+++ b/source/app/business/evidences.py
@@ -18,6 +18,7 @@
 
 from flask_login import current_user
 from marshmallow.exceptions import ValidationError
+from flask_sqlalchemy.pagination import Pagination
 
 from app.business.errors import BusinessProcessingError
 from app.business.errors import ObjectNotFoundError
@@ -27,6 +28,8 @@ from app.schema.marshables import CaseEvidenceSchema
 from app.models.models import CaseReceivedFile
 from app.datamgmt.case.case_rfiles_db import add_rfile
 from app.datamgmt.case.case_rfiles_db import get_rfile
+from app.datamgmt.case.case_rfiles_db import get_paginated_evidences
+
 
 
 def _load(request_data):
@@ -57,3 +60,7 @@ def evidences_get(identifier) -> CaseReceivedFile:
     if not evidence:
         raise ObjectNotFoundError()
     return evidence
+
+
+def evidences_filter(case_identifier) -> Pagination:
+    return get_paginated_evidences(case_identifier)

--- a/source/app/business/evidences.py
+++ b/source/app/business/evidences.py
@@ -63,4 +63,7 @@ def evidences_get(identifier) -> CaseReceivedFile:
 
 
 def evidences_filter(case_identifier, pagination_parameters: PaginationParameters) -> Pagination:
+    order_by = pagination_parameters.get_order_by()
+    if not hasattr(CaseReceivedFile, order_by):
+        raise BusinessProcessingError(f'Unexpected order_by field {order_by}')
     return get_paginated_evidences(case_identifier, pagination_parameters)

--- a/source/app/datamgmt/case/case_rfiles_db.py
+++ b/source/app/datamgmt/case/case_rfiles_db.py
@@ -50,9 +50,7 @@ def get_paginated_evidences(case_identifier, pagination_parameters: PaginationPa
     order_func = convert_sort_direction(pagination_parameters.get_direction())
 
     order_by = pagination_parameters.get_order_by()
-    column = CaseReceivedFile.date_added
-    if hasattr(CaseReceivedFile, order_by):
-        column = getattr(CaseReceivedFile, order_by)
+    column = getattr(CaseReceivedFile, order_by)
 
     query = query.order_by(order_func(column))
 

--- a/source/app/datamgmt/case/case_rfiles_db.py
+++ b/source/app/datamgmt/case/case_rfiles_db.py
@@ -20,6 +20,7 @@ import datetime
 from flask_login import current_user
 from sqlalchemy import and_
 from sqlalchemy import desc
+from flask_sqlalchemy.pagination import Pagination
 
 from app import db
 from app.datamgmt.manage.manage_attribute_db import get_default_custom_attributes
@@ -42,8 +43,7 @@ def get_rfiles(caseid):
     return crf
 
 
-def get_paginated_evidences(case_identifier):
-    pagination_parameters = PaginationParameters(0, 100, 'date_added', 'desc')
+def get_paginated_evidences(case_identifier, pagination_parameters: PaginationParameters) -> Pagination:
     query = CaseReceivedFile.query.filter(
         CaseReceivedFile.case_id == case_identifier
     )

--- a/source/app/datamgmt/case/case_rfiles_db.py
+++ b/source/app/datamgmt/case/case_rfiles_db.py
@@ -29,6 +29,7 @@ from app.models.models import Comments
 from app.models.models import EvidencesComments
 from app.models.authorization import User
 from app.models.pagination_parameters import PaginationParameters
+from app.datamgmt.conversions import convert_sort_direction
 
 
 def get_rfiles(caseid):
@@ -42,12 +43,18 @@ def get_rfiles(caseid):
 
 
 def get_paginated_evidences(case_identifier):
-    pagination_parameters = PaginationParameters(0, 100, '', '')
+    pagination_parameters = PaginationParameters(0, 100, 'date_added', 'desc')
     query = CaseReceivedFile.query.filter(
         CaseReceivedFile.case_id == case_identifier
-    ).order_by(
-        desc(CaseReceivedFile.date_added)
     )
+    order_func = convert_sort_direction(pagination_parameters.get_direction())
+
+    order_by = pagination_parameters.get_order_by()
+    column = CaseReceivedFile.date_added
+    if hasattr(CaseReceivedFile, order_by):
+        column = getattr(CaseReceivedFile, order_by)
+
+    query = query.order_by(order_func(column))
 
     return query.paginate(
         page=pagination_parameters.get_page(),

--- a/source/app/datamgmt/case/case_rfiles_db.py
+++ b/source/app/datamgmt/case/case_rfiles_db.py
@@ -28,6 +28,7 @@ from app.models.models import CaseReceivedFile
 from app.models.models import Comments
 from app.models.models import EvidencesComments
 from app.models.authorization import User
+from app.models.pagination_parameters import PaginationParameters
 
 
 def get_rfiles(caseid):
@@ -38,6 +39,21 @@ def get_rfiles(caseid):
     ).all()
 
     return crf
+
+
+def get_paginated_evidences(case_identifier):
+    pagination_parameters = PaginationParameters(0, 100, '', '')
+    query = CaseReceivedFile.query.filter(
+        CaseReceivedFile.case_id == case_identifier
+    ).order_by(
+        desc(CaseReceivedFile.date_added)
+    )
+
+    return query.paginate(
+        page=pagination_parameters.get_page(),
+        per_page=pagination_parameters.get_per_page(),
+        error_out=False
+    )
 
 
 def add_rfile(evidence, caseid, user_id):

--- a/tests/tests_rest_assets.py
+++ b/tests/tests_rest_assets.py
@@ -243,7 +243,7 @@ class TestsRestAssets(TestCase):
         self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
         body = {'asset_type_id': 1, 'asset_name': 'asset2'}
         self._subject.create(f'/api/v2/cases/{case_identifier}/assets', body).json()
-        response = self._subject.get(f'/api/v2/cases/{case_identifier}/assets', { 'per_page': 1 }).json()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/assets', {'per_page': 1}).json()
         self.assertEqual(1, len(response['data']))
 
     def test_get_assets_should_accept_order_by_query_parameter(self):

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -133,3 +133,13 @@ class TestsRestEvidences(TestCase):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences').json()
         self.assertEqual(0, response['total'])
+
+    def test_get_evidences_should_order_by_descending_date(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename1'}
+        self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        body = {'filename': 'filename2'}
+        self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences').json()
+        self.assertEqual('filename2', response['data'][0]['filename'])

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -143,3 +143,13 @@ class TestsRestEvidences(TestCase):
 
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences').json()
         self.assertEqual('filename2', response['data'][0]['filename'])
+
+    def test_get_evidences_should_order_by_ascending_date_when_sort_dir_is_set_to_asc(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename1'}
+        self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        body = {'filename': 'filename2'}
+        self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences', { 'sort_dir': 'asc' }).json()
+        self.assertEqual('filename1', response['data'][0]['filename'])

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -121,3 +121,10 @@ class TestsRestEvidences(TestCase):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences')
         self.assertEqual(200, response.status_code)
+
+    def test_get_evidences_should_return_403_when_user_has_no_access_to_case(self):
+        case_identifier = self._subject.create_dummy_case()
+
+        user = self._subject.create_dummy_user()
+        response = user.get(f'/api/v2/cases/{case_identifier}/evidences')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -153,3 +153,8 @@ class TestsRestEvidences(TestCase):
 
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences', {'sort_dir': 'asc'}).json()
         self.assertEqual('filename1', response['data'][0]['filename'])
+
+    def test_get_evidences_should_return_400_when_order_by_is_an_invalid_field(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences', {'order_by': 'an_invalid_field'})
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -116,3 +116,8 @@ class TestsRestEvidences(TestCase):
         user = self._subject.create_dummy_user()
         response = user.get(f'/api/v2/cases/{case_identifier}/evidences/{identifier}')
         self.assertEqual(403, response.status_code)
+
+    def test_get_evidences_should_not_fail(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences')
+        self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -151,5 +151,5 @@ class TestsRestEvidences(TestCase):
         body = {'filename': 'filename2'}
         self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
 
-        response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences', { 'sort_dir': 'asc' }).json()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences', {'sort_dir': 'asc'}).json()
         self.assertEqual('filename1', response['data'][0]['filename'])

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -158,3 +158,7 @@ class TestsRestEvidences(TestCase):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences', {'order_by': 'an_invalid_field'})
         self.assertEqual(400, response.status_code)
+
+    def test_get_evidences_should_return_404_when_the_case_does_not_exist(self):
+        response = self._subject.get(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/evidences')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -117,7 +117,7 @@ class TestsRestEvidences(TestCase):
         response = user.get(f'/api/v2/cases/{case_identifier}/evidences/{identifier}')
         self.assertEqual(403, response.status_code)
 
-    def test_get_evidences_should_not_fail(self):
+    def test_get_evidences_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences')
         self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -128,3 +128,8 @@ class TestsRestEvidences(TestCase):
         user = self._subject.create_dummy_user()
         response = user.get(f'/api/v2/cases/{case_identifier}/evidences')
         self.assertEqual(403, response.status_code)
+
+    def test_get_evidences_should_return_total(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences').json()
+        self.assertEqual(0, response['total'])

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -162,3 +162,13 @@ class TestsRestEvidences(TestCase):
     def test_get_evidences_should_return_404_when_the_case_does_not_exist(self):
         response = self._subject.get(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/evidences')
         self.assertEqual(404, response.status_code)
+
+    def test_get_evidences_should_accept_per_page_query_parameter(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename1'}
+        self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        body = {'filename': 'filename2'}
+        self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences', {'per_page': 1}).json()
+        self.assertEqual(1, len(response['data']))


### PR DESCRIPTION
Implement endpoint `GET /api/v2/cases/{case_identifier}/evidences` to get a paginated list of evidences. Added tests. Deprecated `GET /case/evidences/list`.

Note: this PR goes hand in hand, with its documentation [iris-doc-src PR#48](https://github.com/dfir-iris/iris-doc-src/pull/48)