### PR TITLE
Api v2 update evidences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff.lint]
 preview = true
-select = ["E231", "E241", "E3", "E4", "E7", "E9", "F", "W292"]
+select = ["E231", "E241", "E3", "E4", "E7", "E9", "F", "W292", "W293"]
 ignore = ["E402", "E711", "E712", "E721", "E722"]
 

--- a/source/app/alembic/versions/ff917e2ab02e_asset_type_custom_icons.py
+++ b/source/app/alembic/versions/ff917e2ab02e_asset_type_custom_icons.py
@@ -37,7 +37,7 @@ def upgrade():
         sa.Column('asset_icon_not_compromised', sa.String(255)),
         sa.Column('asset_icon_compromised', sa.String(255))
     )
-    
+
     # Migrate existing Asset_types
     conn = op.get_bind()
     res = conn.execute(text("SELECT asset_id, asset_name FROM public.assets_type;"))

--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -243,7 +243,7 @@ def alerts_add_route() -> Response:
                             creation_date=new_alert.alert_source_event_time)
 
         #register_related_alerts(new_alert, assets_list=assets, iocs_list=iocs)
-        
+
         new_alert = call_modules_hook('on_postload_alert_create', data=new_alert)
 
         track_activity(f"created alert #{new_alert.alert_id} - {new_alert.alert_title}", ctx_less=True)

--- a/source/app/blueprints/rest/case/case_evidences_routes.py
+++ b/source/app/blueprints/rest/case/case_evidences_routes.py
@@ -104,6 +104,7 @@ def case_get_evidence(cur_id, caseid):
 
 
 @case_evidences_rest_blueprint.route('/case/evidences/update/<int:cur_id>', methods=['POST'])
+@endpoint_deprecated('PUT', '/api/v2/cases/{case_identifier}/evidences/{identifier}')
 @ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_edit_rfile(cur_id, caseid):

--- a/source/app/blueprints/rest/case/case_evidences_routes.py
+++ b/source/app/blueprints/rest/case/case_evidences_routes.py
@@ -127,11 +127,11 @@ def case_edit_rfile(cur_id, caseid):
 
         evd = call_modules_hook('on_postload_evidence_update', data=evd, caseid=caseid)
 
-        if evd:
-            track_activity(f"updated evidence \"{evd.filename}\"", caseid=caseid)
-            return response_success("Evidence {} updated".format(evd.filename), data=evidence_schema.dump(evd))
+        if not evd:
+            return response_error('Unable to update task for internal reasons')
 
-        return response_error("Unable to update task for internal reasons")
+        track_activity(f"updated evidence \"{evd.filename}\"", caseid=caseid)
+        return response_success("Evidence {} updated".format(evd.filename), data=evidence_schema.dump(evd))
 
     except marshmallow.exceptions.ValidationError as e:
         return response_error(msg="Data error", data=e.messages)

--- a/source/app/blueprints/rest/reports_route.py
+++ b/source/app/blueprints/rest/reports_route.py
@@ -121,12 +121,12 @@ def generate_report(report_id, caseid):
             if fpath is None:
                 track_activity("failed to generate the report")
                 return response_error(msg="Failed to generate the report", data=logs)
-            
+
             with open(fpath, 'rb') as rfile:
                 encoded_file = base64.b64encode(rfile.read()).decode('utf-8')
 
             res = get_case(caseid)
-            
+
             _data = {
                 'report_id': report_id,
                 'file_path': fpath,

--- a/source/app/blueprints/rest/v2/cases/assets.py
+++ b/source/app/blueprints/rest/v2/cases/assets.py
@@ -51,8 +51,7 @@ case_assets_blueprint = Blueprint('case_assets',
 def case_list_assets(case_identifier):
 
     try:
-        # TODO shouldn't CaseAccessLevel.read_only be allowed here too?
-        if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
+        if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
             return ac_api_return_access_denied(caseid=case_identifier)
 
         pagination_parameters = parse_pagination_parameters(request)

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -99,6 +99,9 @@ def get_evidence(case_identifier, identifier):
 @case_evidences_blueprint.put('/<int:identifier>')
 @ac_api_requires()
 def update_evidence(case_identifier, identifier):
+    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
+        return ac_api_return_access_denied(caseid=case_identifier)
+
     evidence = evidences_get(identifier)
 
     evidence = evidences_update(evidence, request.get_json())

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -102,6 +102,7 @@ def update_evidence(case_identifier, identifier):
 
     return response_api_success(evidence)
 
+
 def _check_evidence_and_case_identifier_match(evidence, case_identifier):
     if evidence.case_id != case_identifier:
         raise ObjectNotFoundError

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -35,6 +35,7 @@ from app.business.cases import cases_exists
 from app.schema.marshables import CaseEvidenceSchema
 from app.business.evidences import evidences_create
 from app.business.evidences import evidences_get
+from app.business.evidences import evidences_update
 from app.business.evidences import evidences_filter
 
 
@@ -100,6 +101,7 @@ def get_evidence(case_identifier, identifier):
 def update_evidence(case_identifier, identifier):
     evidence = evidences_get(identifier)
 
+    evidence = evidences_update(evidence, request.get_json())
     return response_api_success(evidence)
 
 

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -102,7 +102,10 @@ def update_evidence(case_identifier, identifier):
     evidence = evidences_get(identifier)
 
     evidence = evidences_update(evidence, request.get_json())
-    return response_api_success(evidence)
+
+    schema = CaseEvidenceSchema()
+    result = schema.dump(evidence)
+    return response_api_success(result)
 
 
 def _check_evidence_and_case_identifier_match(evidence, case_identifier):

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -95,6 +95,13 @@ def get_evidence(case_identifier, identifier):
         return response_api_not_found()
 
 
+@case_evidences_blueprint.put('/<int:identifier>')
+@ac_api_requires()
+def update_evidence(case_identifier, identifier):
+    evidence = evidences_get(identifier)
+
+    return response_api_success(evidence)
+
 def _check_evidence_and_case_identifier_match(evidence, case_identifier):
     if evidence.case_id != case_identifier:
         raise ObjectNotFoundError

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -104,11 +104,11 @@ def get_evidence(case_identifier, identifier):
 def update_evidence(case_identifier, identifier):
     if not cases_exists(case_identifier):
         return response_api_not_found()
-    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
-        return ac_api_return_access_denied(caseid=case_identifier)
 
-    evidence = evidences_get(identifier)
     try:
+        evidence = evidences_get(identifier)
+        if not ac_fast_check_current_user_has_case_access(evidence.case_id, [CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=evidence.case_id)
         _check_evidence_and_case_identifier_match(evidence, case_identifier)
 
         evidence = evidences_update(evidence, request.get_json())

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -37,6 +37,7 @@ from app.business.evidences import evidences_create
 from app.business.evidences import evidences_get
 from app.business.evidences import evidences_update
 from app.business.evidences import evidences_filter
+from app.models.models import CaseReceivedFile
 
 
 case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_prefix='/<int:case_identifier>/evidences')
@@ -82,6 +83,8 @@ def create_evidence(case_identifier):
 @case_evidences_blueprint.get('/<int:identifier>')
 @ac_api_requires()
 def get_evidence(case_identifier, identifier):
+    if not cases_exists(case_identifier):
+        return response_api_not_found()
 
     try:
         evidence = evidences_get(identifier)
@@ -99,6 +102,8 @@ def get_evidence(case_identifier, identifier):
 @case_evidences_blueprint.put('/<int:identifier>')
 @ac_api_requires()
 def update_evidence(case_identifier, identifier):
+    if not cases_exists(case_identifier):
+        return response_api_not_found()
     if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
         return ac_api_return_access_denied(caseid=case_identifier)
 
@@ -113,8 +118,10 @@ def update_evidence(case_identifier, identifier):
         return response_api_success(result)
     except ObjectNotFoundError:
         return response_api_not_found()
+    except BusinessProcessingError as e:
+        return response_api_error(e.get_message(), data=e.get_data())
 
 
-def _check_evidence_and_case_identifier_match(evidence, case_identifier):
+def _check_evidence_and_case_identifier_match(evidence: CaseReceivedFile, case_identifier):
     if evidence.case_id != case_identifier:
-        raise ObjectNotFoundError
+        raise BusinessProcessingError(f'Evidence {evidence.id} does not belong to case {case_identifier}')

--- a/source/app/blueprints/rest/v2/cases/evidences.py
+++ b/source/app/blueprints/rest/v2/cases/evidences.py
@@ -103,12 +103,16 @@ def update_evidence(case_identifier, identifier):
         return ac_api_return_access_denied(caseid=case_identifier)
 
     evidence = evidences_get(identifier)
+    try:
+        _check_evidence_and_case_identifier_match(evidence, case_identifier)
 
-    evidence = evidences_update(evidence, request.get_json())
+        evidence = evidences_update(evidence, request.get_json())
 
-    schema = CaseEvidenceSchema()
-    result = schema.dump(evidence)
-    return response_api_success(result)
+        schema = CaseEvidenceSchema()
+        result = schema.dump(evidence)
+        return response_api_success(result)
+    except ObjectNotFoundError:
+        return response_api_not_found()
 
 
 def _check_evidence_and_case_identifier_match(evidence, case_identifier):

--- a/source/app/business/evidences.py
+++ b/source/app/business/evidences.py
@@ -66,7 +66,6 @@ def evidences_get(identifier) -> CaseReceivedFile:
 def evidences_update(evidence: CaseReceivedFile, request_json: dict) -> CaseReceivedFile:
     request_data = call_modules_hook('on_preload_evidence_update', data=request_json, caseid=evidence.case_id)
     request_data['id'] = evidence.id
-    evidence_schema = CaseEvidenceSchema()
     evidence = _load(request_data, instance=evidence, partial=True)
     evidence = update_rfile(evidence=evidence, user_id=current_user.id, caseid=evidence.case_id)
     evidence = call_modules_hook('on_postload_evidence_update', data=evidence, caseid=evidence.case_id)

--- a/source/app/business/evidences.py
+++ b/source/app/business/evidences.py
@@ -33,10 +33,10 @@ from app.datamgmt.case.case_rfiles_db import get_paginated_evidences
 from app.datamgmt.case.case_rfiles_db import update_rfile
 
 
-def _load(request_data):
+def _load(request_data, **kwargs):
     try:
         evidence_schema = CaseEvidenceSchema()
-        return evidence_schema.load(request_data)
+        return evidence_schema.load(request_data, **kwargs)
     except ValidationError as e:
         raise BusinessProcessingError('Data error', data=e.messages)
 
@@ -67,7 +67,7 @@ def evidences_update(evidence: CaseReceivedFile, request_json: dict) -> CaseRece
     request_data = call_modules_hook('on_preload_evidence_update', data=request_json, caseid=evidence.case_id)
     request_data['id'] = evidence.id
     evidence_schema = CaseEvidenceSchema()
-    evidence = evidence_schema.load(request_data, instance=evidence)
+    evidence = _load(request_data, instance=evidence, partial=True)
     evidence = update_rfile(evidence=evidence, user_id=current_user.id, caseid=evidence.case_id)
     evidence = call_modules_hook('on_postload_evidence_update', data=evidence, caseid=evidence.case_id)
     if not evidence:

--- a/source/app/datamgmt/states.py
+++ b/source/app/datamgmt/states.py
@@ -27,12 +27,12 @@ from app.models.models import ObjectState
 def _update_object_state(object_name, caseid, userid=None) -> ObjectState:
     """
     Expects a db commit soon after
-    
+
     Args:
         object_name: name of the object to update
         caseid: case id
         userid: user id
-        
+
     Returns:
         ObjectState object
     """

--- a/source/app/iris_engine/access_control/utils.py
+++ b/source/app/iris_engine/access_control/utils.py
@@ -411,7 +411,7 @@ def ac_set_new_case_access(org_members, case_id, customer_id = None):
     """
 
     users = ac_apply_autofollow_groups_access(case_id)
-    if current_user.id in users.keys():
+    if current_user.id in users:
         del users[current_user.id]
 
     users_full = User.query.with_entities(User.id).all()
@@ -506,7 +506,7 @@ def ac_auto_update_user_effective_access(user_id):
                 ucea_to_add.update({case_id: target_ucas[case_id]})
 
     for prev_case_id in grouped_uca:
-        if prev_case_id not in target_ucas.keys():
+        if prev_case_id not in target_ucas:
             cid_to_remove.append(prev_case_id)
 
     UserCaseEffectiveAccess.query.where(and_(

--- a/source/app/util.py
+++ b/source/app/util.py
@@ -160,7 +160,7 @@ def assert_type_mml(input_var: any, field_name: str, type: type, allow_none: boo
                                               field_name=field_name if field_name else 'type')
         else:
             return True
-    
+
     if isinstance(input_var, type):
         if max_len:
             if len(input_var) > max_len:
@@ -178,7 +178,7 @@ def assert_type_mml(input_var: any, field_name: str, type: type, allow_none: boo
                                                   field_name=field_name if field_name else 'type')
 
         return True
-    
+
     try:
 
         if isinstance(type(input_var), type):
@@ -187,6 +187,6 @@ def assert_type_mml(input_var: any, field_name: str, type: type, allow_none: boo
     except Exception as e:
         log.error(e)
         print(e)
-        
+
     raise marshmallow.ValidationError('Invalid data type',
                                       field_name=field_name if field_name else 'type')

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -191,6 +191,15 @@ class TestsRestEvidences(TestCase):
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
         self.assertEqual('filename2', response['filename'])
 
+    def test_update_evidence_should_change_file_size(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        identifier = response['id']
+        body = {'file_size': 30}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
+        self.assertEqual(30, response['file_size'])
+
     def test_update_evidence_should_keep_file_uuid(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'filename': 'filename'}

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -172,3 +172,12 @@ class TestsRestEvidences(TestCase):
 
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences', {'per_page': 1}).json()
         self.assertEqual(1, len(response['data']))
+
+    def test_update_evidence_should_return_200(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        identifier = response['id']
+        body = {'filename': 'filename2'}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body)
+        self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -220,3 +220,13 @@ class TestsRestEvidences(TestCase):
         body = {'filename': 'filename2'}
         response = self._subject.update(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/evidences/{identifier}', body)
         self.assertEqual(404, response.status_code)
+
+    def test_update_evidence_should_return_400_when_case_identifier_does_not_match_evidence_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        identifier = response['id']
+        body = {'filename': 'filename2'}
+        case_identifier2 = self._subject.create_dummy_case()
+        response = self._subject.update(f'/api/v2/cases/{case_identifier2}/evidences/{identifier}', body)
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -200,6 +200,24 @@ class TestsRestEvidences(TestCase):
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
         self.assertEqual(30, response['file_size'])
 
+    def test_update_evidence_should_change_type_id(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        identifier = response['id']
+        body = {'type_id': 3}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
+        self.assertEqual(3, response['type_id'])
+
+    def test_update_evidence_should_change_start_date(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        identifier = response['id']
+        body = {'start_date': '2024-04-13T03:02:00'}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
+        self.assertEqual('2024-04-13T03:02:00', response['start_date'])
+
     def test_update_evidence_should_keep_file_uuid(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'filename': 'filename'}

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -41,7 +41,7 @@ class TestsRestEvidences(TestCase):
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', {})
         self.assertEqual(400, response.status_code)
 
-    def test_create_evidence_should_return_403_when_user_has_no_access_to_case(self):
+    def test_create_evidence_should_return_403_when_user_has_no_permission_to_access_to_case(self):
         case_identifier = self._subject.create_dummy_case()
 
         user = self._subject.create_dummy_user()
@@ -201,7 +201,7 @@ class TestsRestEvidences(TestCase):
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
         self.assertEqual(uuid, response['file_uuid'])
 
-    def test_update_evidence_should_return_403_when_user_has_no_access_to_case(self):
+    def test_update_evidence_should_return_403_when_user_has_no_permission_to_access_to_case(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'filename': 'filename'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -200,3 +200,14 @@ class TestsRestEvidences(TestCase):
         body = {'filename': 'filename2'}
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
         self.assertEqual(uuid, response['file_uuid'])
+
+    def test_update_evidence_should_return_403_when_user_has_no_access_to_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        identifier = response['id']
+
+        user = self._subject.create_dummy_user()
+        body = {'filename': 'filename2'}
+        response = user.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body)
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -211,3 +211,12 @@ class TestsRestEvidences(TestCase):
         body = {'filename': 'filename2'}
         response = user.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body)
         self.assertEqual(403, response.status_code)
+
+    def test_update_evidence_should_return_404_when_case_does_not_exist(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        identifier = response['id']
+        body = {'filename': 'filename2'}
+        response = self._subject.update(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/evidences/{identifier}', body)
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -230,3 +230,9 @@ class TestsRestEvidences(TestCase):
         case_identifier2 = self._subject.create_dummy_case()
         response = self._subject.update(f'/api/v2/cases/{case_identifier2}/evidences/{identifier}', body)
         self.assertEqual(400, response.status_code)
+
+    def test_update_evidence_should_return_404_when_evidence_does_not_exist(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename2'}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', body)
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -190,3 +190,13 @@ class TestsRestEvidences(TestCase):
         body = {'filename': 'filename2'}
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
         self.assertEqual('filename2', response['filename'])
+
+    def test_update_evidence_should_keep_file_uuid(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        uuid = response['file_uuid']
+        identifier = response['id']
+        body = {'filename': 'filename2'}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
+        self.assertEqual(uuid, response['file_uuid'])

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -181,3 +181,12 @@ class TestsRestEvidences(TestCase):
         body = {'filename': 'filename2'}
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body)
         self.assertEqual(200, response.status_code)
+
+    def test_update_evidence_should_change_filename(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        identifier = response['id']
+        body = {'filename': 'filename2'}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/evidences/{identifier}', body).json()
+        self.assertEqual('filename2', response['filename'])

--- a/tests/tests_rest_permissions.py
+++ b/tests/tests_rest_permissions.py
@@ -18,6 +18,7 @@
 
 from unittest import TestCase
 from iris import Iris
+
 _INITIAL_DEMO_CASE_IDENTIFIER = 1
 _CASE_ACCESS_LEVEL_FULL_ACCESS = 4
 


### PR DESCRIPTION
Implement endpoint `PUT /api/v2/cases/{case_identifier}/evidences/{identifier}` to update an evidence.

* implementation and tests
* Deprecated `POST /case/evidences/update/{evidence_id}`
* Fixed `GET /api/v2/cases/{case_identifier}/assets` returns 200 when user has only read_only access to case
* quality: fixed all occurences and acticated Ruff rule [W293](https://docs.astral.sh/ruff/rules/blank-line-with-whitespace/)
* quality: fixed 2 occurences of DeepSource PYL-C0201

Note: this PR goes with the accompanying documentation [PR#49](https://github.com/dfir-iris/iris-doc-src/pull/49) in iris-doc-src.