### PR TITLE
Api v2 get event

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff.lint]
 preview = true
-select = ["E225", "E23", "E24", "E3", "E4", "E7", "E9", "F", "W29"]
+select = ["E225", "E23", "E24", "E3", "E4", "E7", "E9", "F", "UP032", "W29"]
 ignore = ["E402", "E711", "E712", "E721", "E722"]
 

--- a/source/app/blueprints/access_controls.py
+++ b/source/app/blueprints/access_controls.py
@@ -143,8 +143,8 @@ def _handle_no_cid_required(no_cid_required):
 
 def _update_denied_case(caseid):
     session['current_case'] = {
-        'case_name': "{} to #{}".format("Access denied", caseid),
-        'case_info': "",
+        'case_name': f'Access denied to #{caseid}',
+        'case_info': '',
         'case_id': caseid,
         'access': '<i class="ml-2 text-danger mt-1 fa-solid fa-ban"></i>'
     }
@@ -155,8 +155,8 @@ def _update_current_case(caseid, restricted_access):
         case = get_case(caseid)
         if case:
             session['current_case'] = {
-                'case_name': "{}".format(case.name),
-                'case_info': "(#{} - {})".format(caseid, case.client.name),
+                'case_name': case.name,
+                'case_info': f'(#{caseid} - {case.client.name})',
                 'case_id': caseid,
                 'access': restricted_access
             }

--- a/source/app/blueprints/pages/case/case_timeline_routes.py
+++ b/source/app/blueprints/pages/case/case_timeline_routes.py
@@ -73,7 +73,7 @@ def case_comment_modal(cur_id, caseid, url_redir):
     if url_redir:
         return redirect(url_for('case_timeline.case_timeline', cid=caseid, redirect=True))
 
-    event = get_case_event(cur_id, caseid=caseid)
+    event = get_case_event(cur_id)
     if not event:
         return response_error('Invalid event ID')
 
@@ -87,7 +87,7 @@ def event_view_modal(cur_id, caseid, url_redir):
     if url_redir:
         return redirect(url_for('case_timeline.case_timeline', cid=caseid, redirect=True))
 
-    event = get_case_event(cur_id, caseid)
+    event = get_case_event(cur_id)
     if not event:
         return response_error("Invalid event ID for this case")
 

--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -650,7 +650,7 @@ def alerts_escalate_route(alert_id) -> Response:
         case = call_modules_hook('on_postload_case_create', data=case)
 
         add_obj_history_entry(case, 'created')
-        track_activity("new case {case_name} created from alert".format(case_name=case.name),
+        track_activity(f"new case {case.name} created from alert",
                        ctx_less=True)
 
         add_obj_history_entry(alert, f"Alert escalated to case #{case.case_id}")
@@ -931,7 +931,7 @@ def alerts_batch_escalate_route() -> Response:
         case = call_modules_hook('on_postload_case_create', data=case)
 
         add_obj_history_entry(case, 'created')
-        track_activity("new case {case_name} created from alerts".format(case_name=case.name),
+        track_activity(f"new case {case.name} created from alerts",
                        caseid=case.case_id)
 
         for alert in alerts_list:

--- a/source/app/blueprints/rest/case/case_graphs_routes.py
+++ b/source/app/blueprints/rest/case/case_graphs_routes.py
@@ -55,9 +55,9 @@ def case_graph_get_data(caseid):
                 img = event.asset_icon_not_compromised
 
             if event.asset_ip:
-                title = "{} -{}".format(event.asset_ip, event.asset_description)
+                title = f"{event.asset_ip} -{event.asset_description}"
             else:
-                title = "{}".format(event.asset_description)
+                title = f"{event.asset_description}"
             label = event.asset_name
             idx = f'a{event.asset_id}'
             node_type = 'asset'
@@ -70,7 +70,7 @@ def case_graph_get_data(caseid):
             node_type = 'ioc'
 
         try:
-            date = "{}-{}-{}".format(event.event_date.day, event.event_date.month, event.event_date.year)
+            date = f"{event.event_date.day}-{event.event_date.month}-{event.event_date.year}"
         except:
             date = '15-05-2021'
 
@@ -95,7 +95,7 @@ def case_graph_get_data(caseid):
 
         ak = {
             'node_id': idx,
-            'node_title': "{} - {}".format(event.event_date, event.event_title),
+            'node_title': f"{event.event_date} - {event.event_title}",
             'node_name': label,
             'node_type': node_type
         }

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -414,7 +414,7 @@ def case_comment_note_add(cur_id, caseid):
         }
         call_modules_hook('on_postload_note_commented', data=hook_data, caseid=caseid)
 
-        track_activity("note \"{}\" commented".format(note.note_title), caseid=caseid)
+        track_activity(f"note \"{note.note_title}\" commented", caseid=caseid)
         return response_success("Note commented", data=comment_schema.dump(comment))
 
     except marshmallow.exceptions.ValidationError as e:

--- a/source/app/blueprints/rest/case/case_routes.py
+++ b/source/app/blueprints/rest/case/case_routes.py
@@ -204,7 +204,7 @@ def group_cac_set_case(caseid):
             success, logs = ac_set_case_access_for_users(group.group_members, caseid, access_level)
 
     except Exception as e:
-        log.error('Error while setting case access for group: {}'.format(e))
+        log.error(f'Error while setting case access for group: {e}')
         log.error(traceback.format_exc())
         return response_error(msg=str(e))
 
@@ -250,7 +250,7 @@ def user_cac_set_case(caseid):
         db.session.commit()
 
     except Exception as e:
-        log.error('Error while setting case access for user: {}'.format(e))
+        log.error(f'Error while setting case access for user: {e}')
         log.error(traceback.format_exc())
         return response_error(msg=str(e))
 

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -565,7 +565,7 @@ def case_filter_timeline(caseid):
             if asset.event_id == ras['event_id']:
                 alki.append(
                     {
-                        "name": "{} ({})".format(asset.asset_name, asset.type),
+                        "name": f"{asset.asset_name} ({asset.type})",
                         "ip": asset.asset_ip,
                         "description": asset.asset_description,
                         "compromised": asset.asset_compromise_status_id == CompromiseStatus.compromised.value
@@ -581,7 +581,7 @@ def case_filter_timeline(caseid):
 
                 alki.append(
                     {
-                        "name": "{}".format(ioc.ioc_value),
+                        "name": f"{ioc.ioc_value}",
                         "description": ioc.ioc_description
                     }
                 )
@@ -641,7 +641,7 @@ def case_delete_event(cur_id, caseid):
 
     track_activity(f"deleted event \"{event.event_title}\" in timeline", caseid)
 
-    return response_success('Event ID {} deleted'.format(cur_id))
+    return response_success(f'Event ID {cur_id} deleted')
 
 
 @case_timeline_rest_blueprint.route('/case/timeline/events/flag/<int:cur_id>', methods=['GET'])
@@ -1002,7 +1002,7 @@ def case_events_upload_csv(caseid):
 
             event = call_modules_hook('on_postload_event_create', data=event, caseid=caseid)
 
-            track_activity("added event {}".format(event.event_id), caseid=caseid)
+            track_activity(f"added event {event.event_id}", caseid=caseid)
 
     except marshmallow.exceptions.ValidationError as e:
         return response_error(msg="Data error", data=e.normalized_messages())

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -661,6 +661,7 @@ def event_flag(cur_id, caseid):
 
 
 @case_timeline_rest_blueprint.route('/case/timeline/events/<int:cur_id>', methods=['GET'])
+@endpoint_deprecated('GET', '/api/v2/cases/{case_identifier}/events/{identifier}')
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def event_view(cur_id, caseid):

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -126,7 +126,7 @@ def case_comment_edit(cur_id, com_id, caseid):
 @ac_api_requires()
 def case_comment_add(cur_id, caseid):
     try:
-        event = get_case_event(event_id=cur_id, caseid=caseid)
+        event = get_case_event(cur_id)
         if not event:
             return response_error('Invalid event ID')
 
@@ -629,7 +629,7 @@ def case_filter_timeline(caseid):
 def case_delete_event(cur_id, caseid):
     call_modules_hook('on_preload_event_delete', data=cur_id, caseid=caseid)
 
-    event = get_case_event(event_id=cur_id, caseid=caseid)
+    event = get_case_event(cur_id)
     if not event:
         return response_error('Not a valid event ID for this case')
 
@@ -648,7 +648,7 @@ def case_delete_event(cur_id, caseid):
 @ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
 def event_flag(cur_id, caseid):
-    event = get_case_event(cur_id, caseid)
+    event = get_case_event(cur_id)
     if not event:
         return response_error("Invalid event ID for this case")
 
@@ -664,9 +664,9 @@ def event_flag(cur_id, caseid):
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def event_view(cur_id, caseid):
-    event = get_case_event(cur_id, caseid)
+    event = get_case_event(cur_id)
     if not event:
-        return response_error("Invalid event ID for this case")
+        return response_error('Invalid event ID for this case')
 
     event_schema = EventSchema()
 
@@ -687,7 +687,7 @@ def event_view(cur_id, caseid):
 @ac_api_requires()
 def case_edit_event(cur_id, caseid):
     try:
-        event = get_case_event(cur_id, caseid)
+        event = get_case_event(cur_id)
         if not event:
             return response_error("Invalid event ID for this case")
 
@@ -770,7 +770,7 @@ def case_duplicate_event(cur_id, caseid):
 
     try:
         event_schema = EventSchema()
-        old_event = get_case_event(event_id=cur_id, caseid=caseid)
+        old_event = get_case_event(cur_id)
         if not old_event:
             return response_error("Invalid event ID for this case")
 

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -107,7 +107,7 @@ def case_comment_delete(cur_id, com_id, caseid):
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_comment_get(cur_id, com_id, caseid):
-    comment = get_case_event_comment(cur_id, com_id, caseid=caseid)
+    comment = get_case_event_comment(cur_id, com_id)
     if not comment:
         return response_error("Invalid comment ID")
 

--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -86,8 +86,7 @@ def logout():
                     state=session["oidc_state"])
                 logout_url = logout_request.request(
                     oidc_client.provider_info["end_session_endpoint"])
-                track_activity("user '{}' is been logged-out".format(
-                    current_user.user), ctx_less=True, display_in_ui=False)
+                track_activity(f"user '{current_user.user}' is been logged-out", ctx_less=True, display_in_ui=False)
                 logout_user()
                 session.clear()
                 return redirect(logout_url)
@@ -98,7 +97,7 @@ def logout():
                     display_in_ui=False
                 )
 
-    track_activity("user '{}' is been logged-out".format(current_user.user),
+    track_activity(f"user '{current_user.user}' is been logged-out",
                    ctx_less=True, display_in_ui=False)
     logout_user()
     session.clear()
@@ -123,8 +122,7 @@ def get_cases_charts():
     retr = [[], []]
     rk = {}
     for case in res:
-        month = "{}/{}/{}".format(case.open_date.day,
-                                  case.open_date.month, case.open_date.year)
+        month = f"{case.open_date.day}/{case.open_date.month}/{case.open_date.year}"
 
         if month in rk:
             rk[month] += 1
@@ -231,8 +229,7 @@ def add_gtask(caseid):
 
     gtask = call_modules_hook(
         'on_postload_global_task_create', data=gtask, caseid=caseid)
-    track_activity("created new global task \'{}\'".format(
-        gtask.task_title), caseid=caseid)
+    track_activity(f"created new global task \'{gtask.task_title}\'", caseid=caseid)
 
     return response_success('Task added', data=gtask_schema.dump(gtask))
 
@@ -269,8 +266,7 @@ def edit_gtask(cur_id, caseid):
     except marshmallow.exceptions.ValidationError as e:
         return response_error(msg="Data error", data=e.messages)
 
-    track_activity("updated global task {} (status {})".format(
-        task.task_title, task.task_status_id), caseid=caseid)
+    track_activity(f"updated global task {task.task_title} (status {task.task_status_id})", caseid=caseid)
 
     return response_success('Task updated', data=gtask_schema.dump(gtask))
 
@@ -294,7 +290,7 @@ def gtask_delete(cur_id, caseid):
 
     call_modules_hook('on_postload_global_task_delete',
                       data=request.get_json(), caseid=caseid)
-    track_activity("deleted global task ID {}".format(cur_id), caseid=caseid)
+    track_activity(f"deleted global task ID {cur_id}", caseid=caseid)
 
     return response_success("Task deleted")
 

--- a/source/app/blueprints/rest/datastore_routes.py
+++ b/source/app/blueprints/rest/datastore_routes.py
@@ -22,10 +22,10 @@ import json
 import marshmallow.exceptions
 import urllib.parse
 from flask import Blueprint
+from flask import current_app
 from flask import request
 from flask import send_file
 from flask_login import current_user
-from flask import current_app
 from pathlib import Path
 
 from app import db

--- a/source/app/blueprints/rest/datastore_routes.py
+++ b/source/app/blueprints/rest/datastore_routes.py
@@ -75,13 +75,13 @@ def datastore_list_filter(caseid):
         filter_d = dict(json.loads(urllib.parse.unquote_plus(query_filter)))
 
     except Exception as e:
-        current_app.logger.error('Error parsing filter: {}'.format(query_filter))
+        current_app.logger.error(f'Error parsing filter: {query_filter}')
         current_app.logger.error(e)
         return response_error('Invalid query')
 
     data, log = datastore_filter_tree(filter_d, caseid)
     if data is None:
-        current_app.logger.error('Error parsing filter: {}'.format(query_filter))
+        current_app.logger.error(f'Error parsing filter: {query_filter}')
         current_app.logger.error(log)
         return response_error('Invalid query')
 

--- a/source/app/blueprints/rest/manage/manage_assets_type_routes.py
+++ b/source/app/blueprints/rest/manage/manage_assets_type_routes.py
@@ -102,7 +102,7 @@ def view_assets(cur_id):
             asset_sc.asset_icon_compromised = fpath_c
 
         if asset_sc:
-            track_activity("updated asset type {}".format(asset_sc.asset_name))
+            track_activity(f"updated asset type {asset_sc.asset_name}")
             return response_success("Asset type updated", asset_sc)
 
     except marshmallow.exceptions.ValidationError as e:
@@ -132,7 +132,7 @@ def add_assets():
             db.session.add(asset_sc)
             db.session.commit()
 
-            track_activity("updated asset type {}".format(asset_sc.asset_name))
+            track_activity(f"updated asset type {asset_sc.asset_name}")
             return response_success("Asset type updated", asset_sc)
 
     except marshmallow.exceptions.ValidationError as e:
@@ -167,9 +167,9 @@ def delete_assets(cur_id):
 
     db.session.delete(asset)
 
-    track_activity("Deleted asset type ID {asset_id}".format(asset_id=cur_id), ctx_less=True)
+    track_activity(f"Deleted asset type ID {cur_id}", ctx_less=True)
 
-    return response_success("Deleted asset type ID {cur_id} successfully".format(cur_id=cur_id))
+    return response_success(f"Deleted asset type ID {cur_id} successfully")
 
 
 @manage_assets_type_rest_blueprint.route('/manage/asset-types/search', methods=['POST'])

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -187,7 +187,7 @@ def api_reopen_case(identifier):
     case = call_modules_hook('on_postload_case_update', data=case, caseid=identifier)
 
     add_obj_history_entry(case, 'case reopen')
-    track_activity("reopen case ID {}".format(identifier), caseid=identifier)
+    track_activity(f"reopen case ID {identifier}", caseid=identifier)
     case_schema = CaseSchema()
 
     return response_success("Case reopen successfully", data=case_schema.dump(res))
@@ -365,8 +365,7 @@ def manage_cases_uploadfiles(caseid):
     mod, _ = instantiate_module_from_name(pipeline_mod)
     status = configure_module_on_init(mod)
     if status.is_failure():
-        return response_error("Path for upload {} is not built ! Unreachable pipeline".format(
-            os.path.join(f.filename)))
+        return response_error(f"Path for upload {os.path.join(f.filename)} is not built ! Unreachable pipeline")
 
     case_customer = None
     case_name = None

--- a/source/app/blueprints/rest/manage/manage_groups.py
+++ b/source/app/blueprints/rest/manage/manage_groups.py
@@ -285,7 +285,7 @@ def manage_groups_cac_delete_case(cur_id):
         db.session.commit()
 
     except Exception as e:
-        log.error("Error while removing cases access from group: {}".format(e))
+        log.error(f"Error while removing cases access from group: {e}")
         log.error(traceback.format_exc())
         return response_error(msg=str(e))
 

--- a/source/app/blueprints/rest/manage/manage_ioc_types_routes.py
+++ b/source/app/blueprints/rest/manage/manage_ioc_types_routes.py
@@ -49,7 +49,7 @@ def get_ioc_type(cur_id):
 
     ioc_type = IocType.query.filter(IocType.type_id == cur_id).first()
     if not ioc_type:
-        return response_error("Invalid ioc type ID {type_id}".format(type_id=cur_id))
+        return response_error(f"Invalid ioc type ID {cur_id}")
 
     return response_success("", data=ioc_type)
 
@@ -71,7 +71,7 @@ def add_ioc_type_api():
     except marshmallow.exceptions.ValidationError as e:
         return response_error(msg="Data error", data=e.messages)
 
-    track_activity("Added ioc type {ioc_type_name}".format(ioc_type_name=ioct_sc.type_name), ctx_less=True)
+    track_activity(f"Added ioc type {ioct_sc.type_name}", ctx_less=True)
     # Return the assets
     return response_success("Added successfully", data=ioct_sc)
 
@@ -89,12 +89,12 @@ def remove_ioc_type(cur_id):
 
     if type_id:
         db.session.delete(type_id)
-        track_activity("Deleted ioc type ID {type_id}".format(type_id=cur_id), ctx_less=True)
-        return response_success("Deleted ioc type ID {type_id}".format(type_id=cur_id))
+        track_activity(f"Deleted ioc type ID {cur_id}", ctx_less=True)
+        return response_success(f"Deleted ioc type ID {cur_id}")
 
     track_activity(f'Attempted to delete ioc type ID {cur_id}, but was not found', ctx_less=True)
 
-    return response_error("Attempted to delete ioc type ID {type_id}, but was not found".format(type_id=cur_id))
+    return response_error(f"Attempted to delete ioc type ID {cur_id}, but was not found")
 
 
 @manage_ioc_type_rest_blueprint.route('/manage/ioc-types/update/<int:cur_id>', methods=['POST'])
@@ -105,7 +105,7 @@ def update_ioc(cur_id):
 
     ioc_type = IocType.query.filter(IocType.type_id == cur_id).first()
     if not ioc_type:
-        return response_error("Invalid ioc type ID {type_id}".format(type_id=cur_id))
+        return response_error(f"Invalid ioc type ID {cur_id}")
 
     ioct_schema = IocTypeSchema()
 
@@ -114,7 +114,7 @@ def update_ioc(cur_id):
         ioct_sc = ioct_schema.load(request.get_json(), instance=ioc_type)
 
         if ioct_sc:
-            track_activity("updated ioc type type {}".format(ioct_sc.type_name))
+            track_activity(f"updated ioc type type {ioct_sc.type_name}")
             return response_success("IOC type updated", ioct_sc)
 
     except marshmallow.exceptions.ValidationError as e:

--- a/source/app/blueprints/rest/manage/manage_tlps_routes.py
+++ b/source/app/blueprints/rest/manage/manage_tlps_routes.py
@@ -40,6 +40,6 @@ def get_tlp_type(cur_id):
 
     tlp_type = Tlp.query.filter(Tlp.tlp_id == cur_id).first()
     if not tlp_type:
-        return response_error("Invalid TLP ID {type_id}".format(type_id=cur_id))
+        return response_error(f"Invalid TLP ID {cur_id}")
 
     return response_success("", data=tlp_type)

--- a/source/app/blueprints/rest/manage/manage_users.py
+++ b/source/app/blueprints/rest/manage/manage_users.py
@@ -129,7 +129,7 @@ def add_user():
         del udata['user_password']
 
         if cuser:
-            track_activity("created user {}".format(user.user), ctx_less=True)
+            track_activity(f"created user {user.user}", ctx_less=True)
             return response_success("user created", data=udata)
 
         return response_error("Unable to create user for internal reasons")
@@ -259,7 +259,7 @@ def manage_user_cac_delete_cases(cur_id):
         db.session.commit()
 
     except Exception as e:
-        log.error("Error while removing cases access from user: {}".format(e))
+        log.error(f"Error while removing cases access from user: {e}")
         log.error(traceback.format_exc())
         return response_error(msg=str(e))
 
@@ -296,7 +296,7 @@ def update_user_api(cur_id):
         db.session.commit()
 
         if cuser:
-            track_activity("updated user {}".format(user.user), ctx_less=True)
+            track_activity(f"updated user {user.user}", ctx_less=True)
             return response_success("User updated", data=user_schema.dump(user))
 
         return response_error("Unable to update user for internal reasons")
@@ -380,18 +380,18 @@ def view_delete_user(cur_id):
             return ac_api_return_access_denied()
 
         if user.active is True:
-            track_activity(message="tried to delete active user ID {}".format(cur_id), ctx_less=True)
+            track_activity(message=f"tried to delete active user ID {cur_id}", ctx_less=True)
             return response_error("Cannot delete active user")
 
         delete_user(user.id)
 
-        track_activity(message="deleted user ID {}".format(cur_id), ctx_less=True)
-        return response_success("Deleted user ID {}".format(cur_id))
+        track_activity(message=f"deleted user ID {cur_id}", ctx_less=True)
+        return response_success(f"Deleted user ID {cur_id}")
 
     except Exception as e:
         print(e)
         db.session.rollback()
-        track_activity(message="tried to delete active user ID {}".format(cur_id), ctx_less=True)
+        track_activity(message=f"tried to delete active user ID {cur_id}", ctx_less=True)
         return response_error("Cannot delete active user")
 
 

--- a/source/app/blueprints/rest/profile_routes.py
+++ b/source/app/blueprints/rest/profile_routes.py
@@ -99,7 +99,7 @@ def update_user_view():
         db.session.commit()
 
         if cuser:
-            track_activity("user {} updated itself".format(user.user))
+            track_activity(f"user {user.user} updated itself")
             return response_success("User updated", data=user_schema.dump(user))
 
         return response_error("Unable to update user for internal reasons")

--- a/source/app/blueprints/rest/search_routes.py
+++ b/source/app/blueprints/rest/search_routes.py
@@ -45,7 +45,7 @@ def search_file_post():
     files = []
     search_condition = and_()
 
-    track_activity("started a global search for {} on {}".format(search_value, search_type))
+    track_activity(f'started a global search for {search_value} on {search_type}')
 
     if search_type == "ioc":
         res = Ioc.query.with_entities(
@@ -74,7 +74,7 @@ def search_file_post():
 
         ns = []
         if search_value:
-            search_value = "%{}%".format(search_value)
+            search_value = f'%{search_value}%'
             ns = Notes.query.filter(
                 Notes.note_content.like(search_value),
                 Cases.client_id == Client.client_id,
@@ -96,7 +96,7 @@ def search_file_post():
         files = ns
 
     if search_type == "comments":
-        search_value = "%{}%".format(search_value)
+        search_value = f'%{search_value}%'
         comments = Comments.query.filter(
             Comments.comment_text.like(search_value),
             Cases.client_id == Client.client_id,

--- a/source/app/blueprints/rest/v2/auth.py
+++ b/source/app/blueprints/rest/v2/auth.py
@@ -87,25 +87,25 @@ def logout():
         db.session.commit()
 
     if is_authentication_oidc():
-        if oidc_client.provider_info.get("end_session_endpoint"):
+        if oidc_client.provider_info.get('end_session_endpoint'):
             try:
                 logout_request = oidc_client.construct_EndSessionRequest(
-                    state=session["oidc_state"])
+                    state=session['oidc_state'])
                 logout_url = logout_request.request(
                     oidc_client.provider_info["end_session_endpoint"])
-                track_activity("user '{}' has been logged-out".format(
-                    current_user.user), ctx_less=True, display_in_ui=False)
+                track_activity(f'user \'{current_user.user}\' has been logged-out',
+                               ctx_less=True, display_in_ui=False)
                 logout_user()
                 session.clear()
                 return redirect(logout_url)
             except GrantError:
                 track_activity(
-                    f"no oidc session found for user '{current_user.user}', skipping oidc provider logout and continuing to logout local user",
+                    f'no oidc session found for user \'{current_user.user}\', skipping oidc provider logout and continuing to logout local user',
                     ctx_less=True,
                     display_in_ui=False
                 )
 
-    track_activity("user '{}' has been logged-out".format(current_user.user),
+    track_activity(f'user \'{current_user.user}\' has been logged-out',
                    ctx_less=True, display_in_ui=False)
     logout_user()
     session.clear()

--- a/source/app/blueprints/rest/v2/case_objects/events.py
+++ b/source/app/blueprints/rest/v2/case_objects/events.py
@@ -29,6 +29,7 @@ from app.business.events import events_create
 from app.business.events import events_get
 from app.schema.marshables import EventSchema
 from app.business.errors import BusinessProcessingError
+from app.business.errors import ObjectNotFoundError
 from app.business.cases import cases_exists
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.models.authorization import CaseAccessLevel
@@ -56,8 +57,11 @@ def create_evidence(case_identifier):
 @case_events_blueprint.get('/<int:identifier>')
 @ac_api_requires()
 def get_event(case_identifier, identifier):
-    event = events_get(identifier)
-    schema = EventSchema()
-    result = schema.dump(event)
-    result['event_category_id'] = event.category[0].id if event.category else None
-    return response_api_success(result)
+    try:
+        event = events_get(identifier)
+        schema = EventSchema()
+        result = schema.dump(event)
+        result['event_category_id'] = event.category[0].id if event.category else None
+        return response_api_success(result)
+    except ObjectNotFoundError:
+        return response_api_not_found()

--- a/source/app/blueprints/rest/v2/case_objects/events.py
+++ b/source/app/blueprints/rest/v2/case_objects/events.py
@@ -76,6 +76,7 @@ def get_event(case_identifier, identifier):
     except BusinessProcessingError as e:
         return response_api_error(e.get_message(), data=e.get_data())
 
+
 def _check_event_and_case_identifier_match(event: CasesEvent, case_identifier):
     if event.case_id != case_identifier:
         raise BusinessProcessingError(f'Event {event.event_id} does not belong to case {case_identifier}')

--- a/source/app/blueprints/rest/v2/case_objects/events.py
+++ b/source/app/blueprints/rest/v2/case_objects/events.py
@@ -26,6 +26,7 @@ from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_not_found
 from app.blueprints.access_controls import ac_api_return_access_denied
 from app.business.events import events_create
+from app.business.events import events_get
 from app.schema.marshables import EventSchema
 from app.business.errors import BusinessProcessingError
 from app.business.cases import cases_exists
@@ -51,7 +52,10 @@ def create_evidence(case_identifier):
     except BusinessProcessingError as e:
         return response_api_error(e.get_message(), data=e.get_data())
 
+
 @case_events_blueprint.get('/<int:identifier>')
 @ac_api_requires()
 def get_event(case_identifier, identifier):
-    return response_api_success(None)
+    event = events_get(identifier)
+    schema = EventSchema()
+    return response_api_success(schema.dump(event))

--- a/source/app/blueprints/rest/v2/case_objects/events.py
+++ b/source/app/blueprints/rest/v2/case_objects/events.py
@@ -62,6 +62,9 @@ def get_event(case_identifier, identifier):
 
     try:
         event = events_get(identifier)
+        if not ac_fast_check_current_user_has_case_access(event.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=event.case_id)
+
         schema = EventSchema()
         result = schema.dump(event)
         result['event_category_id'] = event.category[0].id if event.category else None

--- a/source/app/blueprints/rest/v2/case_objects/events.py
+++ b/source/app/blueprints/rest/v2/case_objects/events.py
@@ -21,6 +21,7 @@ from flask import request
 
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import response_api_created
+from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_not_found
 from app.blueprints.access_controls import ac_api_return_access_denied
@@ -49,3 +50,8 @@ def create_evidence(case_identifier):
         return response_api_created(schema.dump(event))
     except BusinessProcessingError as e:
         return response_api_error(e.get_message(), data=e.get_data())
+
+@case_events_blueprint.get('/<int:identifier>')
+@ac_api_requires()
+def get_event(case_identifier, identifier):
+    return response_api_success(None)

--- a/source/app/blueprints/rest/v2/case_objects/events.py
+++ b/source/app/blueprints/rest/v2/case_objects/events.py
@@ -58,4 +58,6 @@ def create_evidence(case_identifier):
 def get_event(case_identifier, identifier):
     event = events_get(identifier)
     schema = EventSchema()
-    return response_api_success(schema.dump(event))
+    result = schema.dump(event)
+    result['event_category_id'] = event.category[0].id if event.category else None
+    return response_api_success(result)

--- a/source/app/blueprints/rest/v2/case_objects/events.py
+++ b/source/app/blueprints/rest/v2/case_objects/events.py
@@ -57,6 +57,9 @@ def create_evidence(case_identifier):
 @case_events_blueprint.get('/<int:identifier>')
 @ac_api_requires()
 def get_event(case_identifier, identifier):
+    if not cases_exists(case_identifier):
+        return response_api_not_found()
+
     try:
         event = events_get(identifier)
         schema = EventSchema()

--- a/source/app/blueprints/rest/v2/case_objects/evidences.py
+++ b/source/app/blueprints/rest/v2/case_objects/evidences.py
@@ -99,6 +99,8 @@ def get_evidence(case_identifier, identifier):
         return response_api_success(evidence_schema.dump(evidence))
     except ObjectNotFoundError:
         return response_api_not_found()
+    except BusinessProcessingError as e:
+        return response_api_error(e.get_message(), data=e.get_data())
 
 
 @case_evidences_blueprint.put('/<int:identifier>')

--- a/source/app/business/events.py
+++ b/source/app/business/events.py
@@ -32,6 +32,7 @@ from app.datamgmt.case.case_events_db import update_event_assets
 from app.business.errors import BusinessProcessingError
 from app.datamgmt.case.case_events_db import update_event_iocs
 from app.iris_engine.utils.tracker import track_activity
+from app.datamgmt.case.case_events_db import get_case_event
 
 
 def _load(request_data, **kwargs):
@@ -83,3 +84,6 @@ def events_create(case_identifier, request_json) -> CasesEvent:
 
     track_activity(f'added event "{event.event_title}"', caseid=case_identifier)
     return event
+
+def events_get(identifier) -> CasesEvent:
+    return get_case_event(identifier)

--- a/source/app/business/events.py
+++ b/source/app/business/events.py
@@ -23,6 +23,7 @@ from marshmallow.exceptions import ValidationError
 
 from app import db
 from app.models.cases import CasesEvent
+from app.business.errors import ObjectNotFoundError
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.schema.marshables import EventSchema
 from app.util import add_obj_history_entry
@@ -85,5 +86,9 @@ def events_create(case_identifier, request_json) -> CasesEvent:
     track_activity(f'added event "{event.event_title}"', caseid=case_identifier)
     return event
 
+
 def events_get(identifier) -> CasesEvent:
-    return get_case_event(identifier)
+    event = get_case_event(identifier)
+    if not event:
+        raise ObjectNotFoundError()
+    return event

--- a/source/app/datamgmt/case/case_events_db.py
+++ b/source/app/datamgmt/case/case_events_db.py
@@ -136,7 +136,7 @@ def get_case_events_comments_count(events_list):
     ).all()
 
 
-def get_case_event_comment(event_id, comment_id, caseid):
+def get_case_event_comment(event_id, comment_id):
     return EventComments.query.filter(
         EventComments.comment_event_id == event_id,
         EventComments.comment_id == comment_id

--- a/source/app/datamgmt/case/case_events_db.py
+++ b/source/app/datamgmt/case/case_events_db.py
@@ -107,10 +107,9 @@ def get_default_cat():
     return [cat._asdict()]
 
 
-def get_case_event(event_id, caseid):
+def get_case_event(event_id):
     return CasesEvent.query.filter(
-        CasesEvent.event_id == event_id,
-        CasesEvent.case_id == caseid
+        CasesEvent.event_id == event_id
     ).first()
 
 

--- a/source/app/datamgmt/case/case_events_db.py
+++ b/source/app/datamgmt/case/case_events_db.py
@@ -323,7 +323,7 @@ def get_case_assets_for_tm(caseid):
 
     for asset in assets_list:
         assets.append({
-            'asset_name': "{} ({})".format(asset.asset_name, asset.type),
+            'asset_name': f'{asset.asset_name} ({asset.type})',
             'asset_id': asset.asset_id
         })
 
@@ -344,7 +344,7 @@ def get_case_iocs_for_tm(caseid):
 
     for ioc in iocs_list:
         iocs.append({
-            'ioc_value': "{}".format(ioc.ioc_value),
+            'ioc_value': f'{ioc.ioc_value}',
             'ioc_id': ioc.ioc_id
         })
 

--- a/source/app/datamgmt/context/context_db.py
+++ b/source/app/datamgmt/context/context_db.py
@@ -81,8 +81,8 @@ def ctx_search_user_cases(search, user_id, max_results: int = 100):
         conditions.append(and_(
             UserCaseEffectiveAccess.user_id == user_id,
             or_(
-                Cases.name.ilike('%{}%'.format(search)),
-                Client.name.ilike('%{}%'.format(search))
+                Cases.name.ilike(f'%{search}%'),
+                Client.name.ilike(f'%{search}%')
         )))
 
     uceas = UserCaseEffectiveAccess.query.with_entities(

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -22,7 +22,7 @@ from functools import reduce
 from flask_login import current_user
 from sqlalchemy import and_
 
-import app
+from app.logger import logger
 from app import bc
 from app import db
 from app.datamgmt.case.case_db import get_case
@@ -771,7 +771,7 @@ def get_filtered_users(user_ids: str = None,
         )
 
     except Exception as e:
-        app.logger.exception(f'Error getting users: {str(e)}')
+        logger.exception(f'Error getting users: {str(e)}')
         return None
 
     return filtered_users

--- a/source/app/datamgmt/manage/manage_users_db.py
+++ b/source/app/datamgmt/manage/manage_users_db.py
@@ -481,7 +481,7 @@ def set_user_case_access(user_id, case_id, access_level):
 
     ac_set_case_access_for_user(user_id, case_id, access_level)
 
-    return True, 'Case access set to {} for user {}'.format(access_level, user_id)
+    return True, f'Case access set to {access_level} for user {user_id}'
 
 
 def get_user_details(user_id, include_api_key=False):

--- a/source/app/datamgmt/reporter/report_db.py
+++ b/source/app/datamgmt/reporter/report_db.py
@@ -255,7 +255,7 @@ def export_case_tm_json(case_id):
 
         alki = []
         for asset in as_list:
-            alki.append("{} ({})".format(asset.asset_name, asset.type))
+            alki.append(f'{asset.asset_name} ({asset.type})')
 
         ras['assets'] = alki
 

--- a/source/app/iris_engine/demo_builder.py
+++ b/source/app/iris_engine/demo_builder.py
@@ -165,7 +165,7 @@ def create_demo_cases(users_data: dict = None, cases_count: int = 0, clients_cou
 
         db.session.commit()
         cases_list.append(case.case_id)
-        log.info('Added unrestricted case {}'.format(case.name))
+        log.info(f'Added unrestricted case {case.name}')
 
     log.info('Setting permissions for unrestricted cases')
     add_case_access_to_group(group=users_data['ganalystes'],
@@ -202,7 +202,7 @@ def create_demo_cases(users_data: dict = None, cases_count: int = 0, clients_cou
 
         db.session.commit()
         cases_list.append(case.case_id)
-        log.info('Added restricted case {}'.format(case.name))
+        log.info(f'Added restricted case {case.name}')
 
     add_case_access_to_group(group=users_data['ganalystes'],
                              cases_list=cases_list,

--- a/source/app/iris_engine/module_handler/module_handler.py
+++ b/source/app/iris_engine/module_handler/module_handler.py
@@ -100,8 +100,8 @@ def check_module_health(module_instance):
         return False, ['Error - cannot instantiate the module. Check server logs']
 
     try:
-        dup_logs("Testing module")
-        dup_logs("Module name : {}".format(module_instance.get_module_name()))
+        dup_logs('Testing module')
+        dup_logs(f'Module name: {module_instance.get_module_name()}')
 
         if type(module_instance.get_interface_version()) != str:
             mod_interface_version = str(module_instance.get_interface_version())
@@ -111,7 +111,7 @@ def check_module_health(module_instance):
         if not (version.parse(app.config.get('MODULES_INTERFACE_MIN_VERSION'))
                 <= version.parse(mod_interface_version)
                 <= version.parse(app.config.get('MODULES_INTERFACE_MAX_VERSION'))):
-            log.critical("Module interface no compatible with server. Expected "
+            log.critical('Module interface no compatible with server. Expected '
                          f"{app.config.get('MODULES_INTERFACE_MIN_VERSION')} <= module "
                          f"<= {app.config.get('MODULES_INTERFACE_MAX_VERSION')}")
             logs.append("Module interface no compatible with server. Expected "
@@ -120,7 +120,7 @@ def check_module_health(module_instance):
 
             return False, logs
 
-        dup_logs("Module interface version : {}".format(module_instance.get_interface_version()))
+        dup_logs(f'Module interface version: {module_instance.get_interface_version()}')
 
         module_type = module_instance.get_module_type()
         if module_type not in ["module_pipeline", "module_processor"]:
@@ -128,7 +128,7 @@ def check_module_health(module_instance):
             logs.append(f"Unrecognised module type. Expected module_pipeline or module_processor, got {module_type}")
             return False, logs
 
-        dup_logs("Module type : {}".format(module_instance.get_module_type()))
+        dup_logs(f'Module type: {module_instance.get_module_type()}')
 
         if not module_instance.is_providing_pipeline() and module_type == 'pipeline':
             log.critical("Module of type pipeline has no pipelines")
@@ -136,7 +136,7 @@ def check_module_health(module_instance):
             return False, logs
 
         if module_instance.is_providing_pipeline():
-            dup_logs("Module has pipeline : {}".format(module_instance.is_providing_pipeline()))
+            dup_logs(f'Module has pipeline: {module_instance.is_providing_pipeline()}')
             # Check the pipelines config health
             has_error, llogs = check_pipeline_args(module_instance.pipeline_get_info())
 
@@ -173,10 +173,9 @@ def instantiate_module_from_name(module_name):
     # The whole concept is based on the fact that the root module provides an __iris_module_interface
     # variable pointing to the interface class with which Iris can talk to
     try:
-        mod_interface = importlib.import_module("{}.{}".format(module_name,
-                                                           mod_root_interface.__iris_module_interface))
+        mod_interface = importlib.import_module(f'{module_name}.{mod_root_interface.__iris_module_interface}')
     except Exception as e:
-        msg = f"Could not import module {module_name}: {e}"
+        msg = f'Could not import module {module_name}: {e}'
         log.error(msg)
         return None, msg
 
@@ -198,7 +197,7 @@ def instantiate_module_from_name(module_name):
     try:
         mod_inst = cl_interface()
     except Exception as e:
-        msg = f"Could not instantiate the class for module {module_name}: {e}"
+        msg = f'Could not instantiate the class for module {module_name}: {e}'
         log.error(msg)
         return None, msg
 
@@ -291,7 +290,7 @@ def register_module(module_name):
             mod_inst.register_hooks(module_id=module.id)
 
     except Exception as e:
-        return None, "Fatal - {}".format(e.__str__())
+        return None, f'Fatal - {e.__str__()}'
 
     return module, "Module registered"
 
@@ -317,7 +316,7 @@ def iris_update_hooks(module_name, module_id):
             mod_inst.register_hooks(module_id=module_id)
 
     except Exception as e:
-        return False, ["Fatal - {}".format(e.__str__())]
+        return False, [f'Fatal - {e.__str__()}']
 
     return True, ["Module updated"]
 
@@ -612,4 +611,4 @@ def pipeline_dispatcher(self, module_name, hook_name, pipeline_type, pipeline_da
         return mod.pipeline_handler(pipeline_type=pipeline_type,
                                     pipeline_data=pipeline_data)
 
-    return IStatus.I2InterfaceNotImplemented("Couldn't instantiate module {}".format(module_name))
+    return IStatus.I2InterfaceNotImplemented(f'Couldn\'t instantiate module {module_name}')

--- a/source/app/iris_engine/reporter/reporter.py
+++ b/source/app/iris_engine/reporter/reporter.py
@@ -180,7 +180,7 @@ class IrisReportMaker(object):
 
             alki = []
             for asset in as_list:
-                alki.append('{} ({})'.format(asset.asset_name, asset.type))
+                alki.append(f'{asset.asset_name} ({asset.type})')
 
             setattr(ras, 'asset', "\r\n".join(alki))
 
@@ -296,7 +296,7 @@ class IrisMakeDocReport(IrisReportMaker):
 
         report = CaseTemplateReport.query.filter(CaseTemplateReport.id == self._report_id).first()
 
-        name = '{}.docx'.format(report.naming_format)
+        name = f'{report.naming_format}.docx'
         name = name.replace("%code_name%", case_info['doc_id'])
         name = name.replace('%customer%', case_info['case']['client']['customer_name'])
         name = name.replace('%case_name%', case_info['case'].get('name'))
@@ -423,7 +423,7 @@ class IrisMakeDocReport(IrisReportMaker):
 
             alki = []
             for asset in as_list:
-                alki.append('{} ({})'.format(asset.asset_name, asset.type))
+                alki.append(f'{asset.asset_name} ({asset.type})')
 
             setattr(ras, 'asset', "\r\n".join(alki))
 
@@ -565,7 +565,7 @@ class IrisMakeMdReport(IrisReportMaker):
                 html_file.write(output_text)
 
         except Exception as e:
-            log.exception('Error while generating report: {}'.format(e))
+            log.exception(f'Error while generating report: {e}')
             return None, e.__str__()
 
         return output_file_path, 'Report generated'

--- a/source/app/iris_engine/reporter/reporter.py
+++ b/source/app/iris_engine/reporter/reporter.py
@@ -86,7 +86,7 @@ class IrisReportMaker(object):
         case_info_in = self._get_case_info()
 
         # Format information and generate the activity report #
-        doc_id = '{}'.format(datetime.utcnow().strftime("%y%m%d_%H%M"))
+        doc_id = datetime.utcnow().strftime("%y%m%d_%H%M")
 
         case_info = {
             'auto_activities': auto_activities,

--- a/tests/tests_rest_events.py
+++ b/tests/tests_rest_events.py
@@ -152,3 +152,19 @@ class TestsRestEvents(TestCase):
         case_identifier2 = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier2}/events/{identifier}')
         self.assertEqual(400, response.status_code)
+
+    def test_get_event_should_return_children_when_event_is_parent_of_another_event(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'event_title': 'title', 'event_category_id': 1,
+                'event_date': '2025-03-26T00:00:00.000', 'event_tz': '+00:00',
+                'event_assets': [], 'event_iocs': []}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/events', body).json()
+        identifier = response['event_id']
+        body = {'event_title': 'title2', 'event_category_id': 1,
+                'event_date': '2025-03-26T00:00:00.000', 'event_tz': '+00:00',
+                'event_assets': [], 'event_iocs': [],
+                'parent_event_id': identifier}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/events', body).json()
+        child_identifier = response['event_id']
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/events/{identifier}', body).json()
+        self.assertEqual(child_identifier, response['children'][0]['event_id'])

--- a/tests/tests_rest_events.py
+++ b/tests/tests_rest_events.py
@@ -114,3 +114,8 @@ class TestsRestEvents(TestCase):
         identifier = response['event_id']
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/events/{identifier}').json()
         self.assertEqual(1, response['event_category_id'])
+
+    def test_get_event_should_return_404_when_evidence_does_not_exist(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/events/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_events.py
+++ b/tests/tests_rest_events.py
@@ -141,3 +141,14 @@ class TestsRestEvents(TestCase):
         user = self._subject.create_dummy_user()
         response = user.get(f'/api/v2/cases/{case_identifier}/events/{identifier}')
         self.assertEqual(403, response.status_code)
+
+    def test_get_event_should_return_400_when_case_identifier_does_not_match_event_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'event_title': 'title', 'event_category_id': 1,
+                'event_date': '2025-03-26T00:00:00.000', 'event_tz': '+00:00',
+                'event_assets': [], 'event_iocs': []}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/events', body).json()
+        identifier = response['event_id']
+        case_identifier2 = self._subject.create_dummy_case()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier2}/events/{identifier}')
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_events.py
+++ b/tests/tests_rest_events.py
@@ -94,3 +94,13 @@ class TestsRestEvents(TestCase):
         identifier = response['event_id']
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/events/{identifier}')
         self.assertEqual(200, response.status_code)
+
+    def test_get_event_should_return_event_title(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'event_title': 'title', 'event_category_id': 1,
+                'event_date': '2025-03-26T00:00:00.000', 'event_tz': '+00:00',
+                'event_assets': [], 'event_iocs': []}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/events', body).json()
+        identifier = response['event_id']
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/events/{identifier}').json()
+        self.assertEqual('title', response['event_title'])

--- a/tests/tests_rest_events.py
+++ b/tests/tests_rest_events.py
@@ -119,3 +119,13 @@ class TestsRestEvents(TestCase):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/events/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)
+
+    def test_get_event_should_return_404_when_case_does_not_exist(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'event_title': 'title', 'event_category_id': 1,
+                'event_date': '2025-03-26T00:00:00.000', 'event_tz': '+00:00',
+                'event_assets': [], 'event_iocs': []}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/events', body).json()
+        identifier = response['event_id']
+        response = self._subject.get(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/events/{identifier}')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_events.py
+++ b/tests/tests_rest_events.py
@@ -104,3 +104,13 @@ class TestsRestEvents(TestCase):
         identifier = response['event_id']
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/events/{identifier}').json()
         self.assertEqual('title', response['event_title'])
+
+    def test_get_event_should_return_event_category_id(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'event_title': 'title', 'event_category_id': 1,
+                'event_date': '2025-03-26T00:00:00.000', 'event_tz': '+00:00',
+                'event_assets': [], 'event_iocs': []}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/events', body).json()
+        identifier = response['event_id']
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/events/{identifier}').json()
+        self.assertEqual(1, response['event_category_id'])

--- a/tests/tests_rest_events.py
+++ b/tests/tests_rest_events.py
@@ -129,3 +129,15 @@ class TestsRestEvents(TestCase):
         identifier = response['event_id']
         response = self._subject.get(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/events/{identifier}')
         self.assertEqual(404, response.status_code)
+
+    def test_get_event_should_return_403_when_user_has_no_access_to_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'event_title': 'title', 'event_category_id': 1,
+                'event_date': '2025-03-26T00:00:00.000', 'event_tz': '+00:00',
+                'event_assets': [], 'event_iocs': []}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/events', body).json()
+        identifier = response['event_id']
+
+        user = self._subject.create_dummy_user()
+        response = user.get(f'/api/v2/cases/{case_identifier}/events/{identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest_events.py
+++ b/tests/tests_rest_events.py
@@ -84,3 +84,13 @@ class TestsRestEvents(TestCase):
                 'parent_event_id': identifier}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/events', body).json()
         self.assertEqual(identifier, response['parent_event_id'])
+
+    def test_get_event_should_return_200(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'event_title': 'title', 'event_category_id': 1,
+                'event_date': '2025-03-26T00:00:00.000', 'event_tz': '+00:00',
+                'event_assets': [], 'event_iocs': []}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/events', body).json()
+        identifier = response['event_id']
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/events/{identifier}')
+        self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_evidences.py
+++ b/tests/tests_rest_evidences.py
@@ -117,6 +117,15 @@ class TestsRestEvidences(TestCase):
         response = user.get(f'/api/v2/cases/{case_identifier}/evidences/{identifier}')
         self.assertEqual(403, response.status_code)
 
+    def test_get_evidence_should_return_400_when_evidence_does_not_belong_to_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'filename': 'filename'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/evidences', body).json()
+        identifier = response['id']
+        case_identifier2 = self._subject.create_dummy_case()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier2}/evidences/{identifier}')
+        self.assertEqual(400, response.status_code)
+
     def test_get_evidences_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/evidences')


### PR DESCRIPTION
Implementation of endpoint `GET /api/v2/cases/{case_identifier}/events/{identifier}` to get an evidence.

* Deprecated `GET /case/timeline/events/{event_id}`
* Fixed: `GET /api/v2/cases/{case_identifier}/evidences/{identifier}` returns 400 when evidence does not belong to case
* Fixed all occurences and activated ruff rule [UP032](https://docs.astral.sh/ruff/rules/f-string/)

Note: this PR is accompanied by the documentation [iris-doc-src PR#53](https://github.com/dfir-iris/iris-doc-src/pull/53).