### PR TITLE
Api v2 create alert

### DIFF
--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -1,5 +1,5 @@
 #  IRIS Source Code
-#  Copyright (C) 2025 - DFIR-IRIS
+#  Copyright (C) 2024 - DFIR-IRIS
 #  contact@dfir-iris.org
 #
 #  This program is free software; you can redistribute it and/or

--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -16,7 +16,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import json
 import marshmallow
 from datetime import datetime
 from flask import Blueprint
@@ -36,7 +35,6 @@ from app.datamgmt.alerts.alerts_db import create_case_from_alert
 from app.datamgmt.alerts.alerts_db import delete_related_alerts_cache
 from app.datamgmt.alerts.alerts_db import merge_alert_in_case
 from app.datamgmt.alerts.alerts_db import unmerge_alert_from_case
-from app.datamgmt.alerts.alerts_db import cache_similar_alert
 from app.datamgmt.alerts.alerts_db import get_related_alerts
 from app.datamgmt.alerts.alerts_db import get_related_alerts_details
 from app.datamgmt.alerts.alerts_db import get_alert_comments
@@ -198,6 +196,7 @@ def alerts_add_route():
 
     except BusinessProcessingError as e:
         return response_error(e.get_message(), data=e.get_data())
+
 
 @alerts_rest_blueprint.route('/alerts/<int:alert_id>', methods=['GET'])
 @ac_api_requires(Permissions.alerts_read)

--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -1,5 +1,5 @@
 #  IRIS Source Code
-#  Copyright (C) 2024 - DFIR-IRIS
+#  Copyright (C) 2025 - DFIR-IRIS
 #  contact@dfir-iris.org
 #
 #  This program is free software; you can redistribute it and/or
@@ -27,7 +27,6 @@ from typing import List
 from werkzeug import Response
 
 from app import db
-from app import socket_io
 from app.blueprints.rest.endpoints import endpoint_deprecated
 from app.blueprints.rest.parsing import parse_comma_separated_identifiers
 from app.blueprints.rest.case_comments import case_comment_update
@@ -57,12 +56,12 @@ from app.models.authorization import Permissions
 from app.schema.marshables import AlertSchema
 from app.schema.marshables import CaseSchema
 from app.schema.marshables import CommentSchema
-from app.schema.marshables import CaseAssetsSchema
-from app.schema.marshables import IocSchema
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.responses import response_error
 from app.util import add_obj_history_entry
 from app.blueprints.responses import response_success
+from app.business.errors import BusinessProcessingError
+from app.business.alerts import alerts_create
 
 alerts_rest_blueprint = Blueprint('alerts_rest', __name__)
 
@@ -189,78 +188,16 @@ def alerts_list_route() -> Response:
 
 
 @alerts_rest_blueprint.route('/alerts/add', methods=['POST'])
+@endpoint_deprecated('POST', '/api/v2/alerts')
 @ac_api_requires(Permissions.alerts_write)
-def alerts_add_route() -> Response:
-    """
-    Add a new alert to the database
-
-    args:
-        caseid (str): The case id
-
-    returns:
-        Response: The response
-    """
-
-    if not request.json:
-        return response_error('No JSON data provided')
-
-    alert_schema = AlertSchema()
-    ioc_schema = IocSchema()
-    asset_schema = CaseAssetsSchema()
-
+def alerts_add_route():
     try:
-        # Load the JSON data from the request
-        data = request.get_json()
+        alert = alerts_create(request.get_json())
+        alert_schema = AlertSchema()
+        return response_success('Alert added', data=alert_schema.dump(alert))
 
-        iocs_list = data.pop('alert_iocs', [])
-        assets_list = data.pop('alert_assets', [])
-
-        iocs = ioc_schema.load(iocs_list, many=True, partial=True)
-        assets = asset_schema.load(assets_list, many=True, partial=True)
-
-        # Deserialize the JSON data into an Alert object
-        new_alert = alert_schema.load(data)
-
-        # Verify the user is entitled to create an alert for the client
-        if not user_has_client_access(current_user.id, new_alert.alert_customer_id):
-            return response_error('User not entitled to create alerts for the client')
-
-        new_alert.alert_creation_time = datetime.utcnow()
-
-        new_alert.iocs = iocs
-        new_alert.assets = assets
-
-        # Add the new alert to the session and commit it
-        db.session.add(new_alert)
-        db.session.commit()
-
-        # Add history entry
-        add_obj_history_entry(new_alert, 'Alert created')
-
-        # Cache the alert for similarities check
-        cache_similar_alert(new_alert.alert_customer_id, assets=assets_list,
-                            iocs=iocs_list, alert_id=new_alert.alert_id,
-                            creation_date=new_alert.alert_source_event_time)
-
-        #register_related_alerts(new_alert, assets_list=assets, iocs_list=iocs)
-
-        new_alert = call_modules_hook('on_postload_alert_create', data=new_alert)
-
-        track_activity(f"created alert #{new_alert.alert_id} - {new_alert.alert_title}", ctx_less=True)
-
-        # Emit a socket io event
-        socket_io.emit('new_alert', json.dumps({
-            'alert_id': new_alert.alert_id
-        }), namespace='/alerts')
-
-        # Return the newly created alert as JSON
-        return response_success(data=alert_schema.dump(new_alert))
-
-    except Exception as e:
-        current_app.logger.exception(e)
-        # Handle any errors during deserialization or DB operations
-        return response_error(str(e))
-
+    except BusinessProcessingError as e:
+        return response_error(e.get_message(), data=e.get_data())
 
 @alerts_rest_blueprint.route('/alerts/<int:alert_id>', methods=['GET'])
 @ac_api_requires(Permissions.alerts_read)

--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -188,7 +188,7 @@ def alerts_list_route() -> Response:
 @alerts_rest_blueprint.route('/alerts/add', methods=['POST'])
 @endpoint_deprecated('POST', '/api/v2/alerts')
 @ac_api_requires(Permissions.alerts_write)
-def alerts_add_route():
+def alerts_add_route() -> Response:
     try:
         alert = alerts_create(request.get_json())
         alert_schema = AlertSchema()

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -22,7 +22,7 @@ from flask import Response
 from flask_login import current_user
 
 from app.blueprints.access_controls import ac_api_requires
-from app.blueprints.rest.endpoints import response_api_success 
+from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.parsing import parse_comma_separated_identifiers
@@ -136,6 +136,7 @@ def alerts_list_route() -> Response:
     }
     return response_api_success(data=filtered_data)
 
+
 @alerts_blueprint.post('')
 @ac_api_requires()
 def create_alert():
@@ -144,6 +145,6 @@ def create_alert():
         alert = alerts_create(request.get_json())
         alert_schema = AlertSchema()
         return response_api_created(alert_schema.dump(alert))
-    
+
     except BusinessProcessingError as e:
         return response_api_error(e.get_message(), data=e.get_data())

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -138,7 +138,7 @@ def alerts_list_route() -> Response:
 
 
 @alerts_blueprint.post('')
-@ac_api_requires()
+@ac_api_requires(Permissions.alerts_write)
 def create_alert():
 
     try:

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -1,5 +1,5 @@
 #  IRIS Source Code
-#  Copyright (C) 2025 - DFIR-IRIS
+#  Copyright (C) 2024 - DFIR-IRIS
 #  contact@dfir-iris.org
 #
 #  This program is free software; you can redistribute it and/or

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -45,12 +45,12 @@ def _load(request_data, **kwargs):
 
 
 def alerts_create(request_data) -> Alert:
-    
+
     ioc_schema = IocSchema()
-    asset_schema = CaseAssetsSchema() 
-    
+    asset_schema = CaseAssetsSchema()
+
     try:
-        
+
         iocs_list = request_data.pop('alert_iocs', [])
         assets_list = request_data.pop('alert_assets', [])
 
@@ -61,7 +61,7 @@ def alerts_create(request_data) -> Alert:
 
         if not user_has_client_access(current_user.id, alert.alert_customer_id):
             return response_error('User not entitled to create alerts for the client')
-    
+
         alert.alert_creation_time = datetime.utcnow()
 
         alert.iocs = iocs
@@ -72,7 +72,7 @@ def alerts_create(request_data) -> Alert:
 
         add_obj_history_entry(alert, 'Alert created')
 
-        cache_similar_alert(alert.alert_customer_id, assets=assets_list, iocs=iocs_list, alert_id=alert.alert_id, 
+        cache_similar_alert(alert.alert_customer_id, assets=assets_list, iocs=iocs_list, alert_id=alert.alert_id,
                             creation_date=alert.alert_source_event_time)
 
         alert = call_modules_hook('on_postload_alert_create', data=alert)

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -1,0 +1,87 @@
+#  IRIS Source Code
+#  Copyright (C) 2025 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+from flask_login import current_user
+
+import json
+from datetime import datetime
+from marshmallow.exceptions import ValidationError
+
+from app import db
+from app import socket_io
+from app.models.alerts import Alert
+from app.datamgmt.alerts.alerts_db import cache_similar_alert
+from app.datamgmt.manage.manage_access_control_db import user_has_client_access
+from app.iris_engine.module_handler.module_handler import call_modules_hook
+from app.iris_engine.utils.tracker import track_activity
+from app.blueprints.responses import response_error
+from app.util import add_obj_history_entry
+from app.business.errors import BusinessProcessingError
+from app.schema.marshables import AlertSchema
+from app.schema.marshables import CaseAssetsSchema
+from app.schema.marshables import IocSchema
+
+def _load(request_data, **kwargs):
+    try:
+        alert_schema = AlertSchema()
+        return alert_schema.load(request_data, **kwargs)
+    except ValidationError as e:
+        raise BusinessProcessingError('Data error', data=e.messages)
+    
+def alerts_create(request_data) -> Alert:
+    
+    ioc_schema = IocSchema()
+    asset_schema = CaseAssetsSchema() 
+    
+    try:
+        
+        iocs_list = request_data.pop('alert_iocs', [])
+        assets_list = request_data.pop('alert_assets', [])
+
+        iocs = ioc_schema.load(iocs_list, many=True, partial=True)
+        assets = asset_schema.load(assets_list, many=True, partial=True)
+
+        alert = _load(request_data)
+
+        if not user_has_client_access(current_user.id, alert.alert_customer_id):
+            return response_error('User not entitled to create alerts for the client')
+    
+        alert.alert_creation_time = datetime.utcnow()
+
+        alert.iocs = iocs
+        alert.assets = assets
+
+        db.session.add(alert)
+        db.session.commit()
+
+        add_obj_history_entry(alert, 'Alert created')
+
+        cache_similar_alert(alert.alert_customer_id, assets=assets_list, iocs=iocs_list, alert_id=alert.alert_id, 
+                            creation_date=alert.alert_source_event_time)
+
+        alert = call_modules_hook('on_postload_alert_create', data=alert)
+
+        track_activity(f"created alert #{alert.alert_id} - {alert.alert_title}", ctx_less=True)
+
+        socket_io.emit('new_alert', json.dumps({
+            'alert_id': alert.alert_id
+        }), namespace='/alerts')
+
+        return alert
+
+    except BusinessProcessingError as e:
+        return response_error(e.get_message(), data=e.get_data())

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -35,13 +35,15 @@ from app.schema.marshables import AlertSchema
 from app.schema.marshables import CaseAssetsSchema
 from app.schema.marshables import IocSchema
 
+
 def _load(request_data, **kwargs):
     try:
         alert_schema = AlertSchema()
         return alert_schema.load(request_data, **kwargs)
     except ValidationError as e:
         raise BusinessProcessingError('Data error', data=e.messages)
-    
+
+
 def alerts_create(request_data) -> Alert:
     
     ioc_schema = IocSchema()

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -1,5 +1,5 @@
 #  IRIS Source Code
-#  Copyright (C) 2025 - DFIR-IRIS
+#  Copyright (C) 2024 - DFIR-IRIS
 #  contact@dfir-iris.org
 #
 #  This program is free software; you can redistribute it and/or

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -58,8 +58,7 @@ def alerts_create(request_data) -> Alert:
     alert = _load(request_data)
 
     if not user_has_client_access(current_user.id, alert.alert_customer_id):
-        return response_error('User not entitled to create alerts for the client')
-
+        raise BusinessProcessingError('User not entitled to create alerts for the client')
     alert.alert_creation_time = datetime.utcnow()
 
     alert.iocs = iocs

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -28,7 +28,6 @@ from app.datamgmt.alerts.alerts_db import cache_similar_alert
 from app.datamgmt.manage.manage_access_control_db import user_has_client_access
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
-from app.blueprints.responses import response_error
 from app.util import add_obj_history_entry
 from app.business.errors import BusinessProcessingError
 from app.schema.marshables import AlertSchema

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -42,6 +42,25 @@ class TestsRestAlerts(TestCase):
         }
         response = self._subject.create(f'/api/v2/alerts', body)
         self.assertEqual(201, response.status_code)
+    
+    def test_create_alert_should_field_alert_title(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+        }
+        response = self._subject.create(f'/api/v2/alerts', body).json()
+        self.assertEqual('title', response['alert_title'])
+
+    def test_create_alert_should_return_400_when_alert_customer_id_is_missing(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+        }
+        response = self._subject.create(f'/api/v2/alerts', body)
+        self.assertEqual(400, response.status_code)
 
     def test_alerts_with_filter_alerts_assets_should_not_fail(self):
         response = self._subject.get('/api/v2/alerts', query_parameters={'alert_assets': 'some assert name'})

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -43,7 +43,7 @@ class TestsRestAlerts(TestCase):
         response = self._subject.create(f'/api/v2/alerts', body)
         self.assertEqual(201, response.status_code)
     
-    def test_create_alert_should_field_alert_title(self):
+    def test_create_alert_should_return_data_alert_title(self):
         body = {
             'alert_title': 'title',
             'alert_severity_id': 4,
@@ -52,6 +52,16 @@ class TestsRestAlerts(TestCase):
         }
         response = self._subject.create(f'/api/v2/alerts', body).json()
         self.assertEqual('title', response['alert_title'])
+    
+    def test_create_alert_should_return_data_alert_severity_id(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+        }
+        response = self._subject.create(f'/api/v2/alerts', body).json()
+        self.assertEqual(4, response['alert_severity_id'])
 
     def test_create_alert_should_return_400_when_alert_customer_id_is_missing(self):
         body = {

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -73,6 +73,16 @@ class TestsRestAlerts(TestCase):
         response = self._subject.create(f'/api/v2/alerts', body).json()
         self.assertEqual(3, response['alert_status_id'])
 
+    def test_create_alert_should_return_data_alert_customer_id(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+        }
+        response = self._subject.create(f'/api/v2/alerts', body).json()
+        self.assertEqual(1, response['alert_customer_id'])
+
     def test_create_alert_should_return_400_when_alert_customer_id_is_missing(self):
         body = {
             'alert_title': 'title',

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -103,6 +103,16 @@ class TestsRestAlerts(TestCase):
         response = user.create(f'/api/v2/alerts', body)
         self.assertEqual(403, response.status_code)
 
+    def test_create_alert_should_return_field_classification_id_null_when_not_provided(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+        }
+        response = self._subject.create(f'/api/v2/alerts', body).json()
+        self.assertIsNone(response['alert_classification_id'])
+
     def test_alerts_with_filter_alerts_assets_should_not_fail(self):
         response = self._subject.get('/api/v2/alerts', query_parameters={'alert_assets': 'some assert name'})
         self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -62,6 +62,16 @@ class TestsRestAlerts(TestCase):
         }
         response = self._subject.create(f'/api/v2/alerts', body).json()
         self.assertEqual(4, response['alert_severity_id'])
+    
+    def test_create_alert_should_return_data_alert_status_id(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+        }
+        response = self._subject.create(f'/api/v2/alerts', body).json()
+        self.assertEqual(3, response['alert_status_id'])
 
     def test_create_alert_should_return_400_when_alert_customer_id_is_missing(self):
         body = {

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -1,5 +1,5 @@
 #  IRIS Source Code
-#  Copyright (C) 2025 - DFIR-IRIS
+#  Copyright (C) 2023 - DFIR-IRIS
 #  contact@dfir-iris.org
 #
 #  This program is free software; you can redistribute it and/or

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -1,5 +1,5 @@
 #  IRIS Source Code
-#  Copyright (C) 2023 - DFIR-IRIS
+#  Copyright (C) 2025 - DFIR-IRIS
 #  contact@dfir-iris.org
 #
 #  This program is free software; you can redistribute it and/or
@@ -33,15 +33,15 @@ class TestsRestAlerts(TestCase):
             identifier = alert['alert_id']
             self._subject.create(f'/alerts/delete/{identifier}', {})
 
-    def test_create_alert_should_not_fail(self):
+    def test_create_alert_should_return_201(self):
         body = {
             'alert_title': 'title',
             'alert_severity_id': 4,
             'alert_status_id': 3,
-            'alert_customer_id': 1
+            'alert_customer_id': 1,
         }
-        response = self._subject.create('/alerts/add', body)
-        self.assertEqual(200, response.status_code)
+        response = self._subject.create(f'/api/v2/alerts', body)
+        self.assertEqual(201, response.status_code)
 
     def test_alerts_with_filter_alerts_assets_should_not_fail(self):
         response = self._subject.get('/api/v2/alerts', query_parameters={'alert_assets': 'some assert name'})

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -91,6 +91,17 @@ class TestsRestAlerts(TestCase):
         }
         response = self._subject.create(f'/api/v2/alerts', body)
         self.assertEqual(400, response.status_code)
+    
+    def test_create_alert_should_return_403_when_user_has_no_permission_to_alert(self):
+        user = self._subject.create_dummy_user()
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+        }
+        response = user.create(f'/api/v2/alerts', body)
+        self.assertEqual(403, response.status_code)
 
     def test_alerts_with_filter_alerts_assets_should_not_fail(self):
         response = self._subject.get('/api/v2/alerts', query_parameters={'alert_assets': 'some assert name'})


### PR DESCRIPTION
Implementation of  endpoint POST /api/v2/alerts to create an alert.

* tests
* deprecated POST /alerts/add

Note: this PR goes with the [PR#54](https://github.com/dfir-iris/iris-doc-src/pull/54) in iris-doc-src

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API v2 endpoint for alert creation that delivers consistent success responses and clearly defined error messages for issues like missing or unauthorized data.
  
- **Refactor**
  - Streamlined the alert creation workflow to improve reliability and enhance error handling for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->