### PR TITLE
V2 api update alert

### DIFF
--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -300,6 +300,7 @@ def alerts_similarities_route(alert_id) -> Response:
 
 
 @alerts_rest_blueprint.route('/alerts/update/<int:alert_id>', methods=['POST'])
+@endpoint_deprecated('PUT', '/api/v2/alerts/{identifier}')
 @ac_api_requires(Permissions.alerts_write)
 def alerts_update_route(alert_id) -> Response:
     """

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -194,7 +194,7 @@ def get_alert(identifier):
 
 
 @alerts_blueprint.put('/<int:identifier>')
-@ac_api_requires(Permissions.alerts_write)
+@ac_api_requires(Permissions.alerts_write, Permissions.alerts_read)
 def update_alert(identifier):
 
     try:

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -198,8 +198,8 @@ def get_alert(identifier):
 def update_alert(identifier):
 
     try:
-        request_data = request.get_json()
         alert = get_alert_by_id(identifier)
+        request_data = request.get_json()
         updated_alert = _load(request_data, instance=alert, partial=True)
         result = alerts_update(updated_alert, alert, iris_current_user, request_data, identifier)
         alert_schema = AlertSchema()
@@ -207,3 +207,6 @@ def update_alert(identifier):
 
     except ValidationError as e:
         return response_api_error('Data error', data=e.messages)
+    
+    except ObjectNotFoundError:
+        return response_api_not_found()

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -210,3 +210,6 @@ def update_alert(identifier):
 
     except ObjectNotFoundError:
         return response_api_not_found()
+
+    except BusinessProcessingError as e:
+        return response_api_error(e.get_message(), data=e.get_data())

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -228,7 +228,7 @@ def update_alert(identifier):
 
         if request_data.get('alert_owner_id') == "-1" or request_data.get('alert_owner_id') == -1:
             updated_alert.alert_owner_id = None
-        result = alerts_update(alert, updated_alert, activity_data, identifier, do_resolution_hook, do_status_hook)
+        result = alerts_update(alert, updated_alert, activity_data, do_resolution_hook, do_status_hook)
         alert_schema = AlertSchema()
         return response_api_success(alert_schema.dump(result))
 

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -235,5 +235,3 @@ def update_alert(identifier):
     except ValidationError as e:
         return response_api_error('Data error', data=e.messages)
 
-    except ObjectNotFoundError:
-        return response_api_not_found()

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -207,6 +207,6 @@ def update_alert(identifier):
 
     except ValidationError as e:
         return response_api_error('Data error', data=e.messages)
-    
+
     except ObjectNotFoundError:
         return response_api_not_found()

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -235,3 +235,5 @@ def update_alert(identifier):
     except ValidationError as e:
         return response_api_error('Data error', data=e.messages)
 
+    except ObjectNotFoundError:
+        return response_api_not_found()

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -202,7 +202,8 @@ def update_alert(identifier):
         alert = get_alert_by_id(identifier)
         updated_alert = _load(request_data, instance=alert, partial=True)
         result = alerts_update(updated_alert, alert, iris_current_user, request_data, identifier)
-        return response_api_success(result)
+        alert_schema = AlertSchema()
+        return response_api_success(alert_schema.dump(result))
 
     except ValidationError as e:
         return response_api_error('Data error', data=e.messages)

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -194,7 +194,7 @@ def get_alert(identifier):
 
 
 @alerts_blueprint.put('/<int:identifier>')
-@ac_api_requires(Permissions.alerts_write, Permissions.alerts_read)
+@ac_api_requires(Permissions.alerts_write)
 def update_alert(identifier):
 
     try:

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -228,7 +228,7 @@ def update_alert(identifier):
 
         if request_data.get('alert_owner_id') == "-1" or request_data.get('alert_owner_id') == -1:
             updated_alert.alert_owner_id = None
-        result = alerts_update(updated_alert, alert, activity_data, identifier, do_resolution_hook, do_status_hook)
+        result = alerts_update(alert, updated_alert, activity_data, identifier, do_resolution_hook, do_status_hook)
         alert_schema = AlertSchema()
         return response_api_success(alert_schema.dump(result))
 

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -228,7 +228,7 @@ def update_alert(identifier):
 
         if request_data.get('alert_owner_id') == "-1" or request_data.get('alert_owner_id') == -1:
             updated_alert.alert_owner_id = None
-        result = alerts_update(alert, updated_alert, activity_data, do_resolution_hook, do_status_hook)
+        result = alerts_update(updated_alert, activity_data, do_resolution_hook, do_status_hook)
         alert_schema = AlertSchema()
         return response_api_success(alert_schema.dump(result))
 

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -200,8 +200,6 @@ def update_alert(identifier):
         alert = alerts_get(iris_current_user, identifier)
         request_data = request.get_json()
         updated_alert = _load(request_data, instance=alert, partial=True)
-        do_resolution_hook = False
-        do_status_hook = False
         activity_data = []
 
         for key, value in request_data.items():
@@ -213,12 +211,6 @@ def update_alert(identifier):
             if type(value) is int:
                 value = str(value)
 
-            if old_value != value:
-                if key == "alert_resolution_status_id":
-                    do_resolution_hook = True
-                if key == 'alert_status_id':
-                    do_status_hook = True
-
                 if key not in ["alert_content", "alert_note"]:
                     activity_data.append(f"\"{key}\" from \"{old_value}\" to \"{value}\"")
                 else:
@@ -228,7 +220,7 @@ def update_alert(identifier):
 
         if request_data.get('alert_owner_id') == "-1" or request_data.get('alert_owner_id') == -1:
             updated_alert.alert_owner_id = None
-        result = alerts_update(updated_alert, activity_data, do_resolution_hook, do_status_hook)
+        result = alerts_update(alert, updated_alert, activity_data)
         alert_schema = AlertSchema()
         return response_api_success(alert_schema.dump(result))
 

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -228,7 +228,7 @@ def update_alert(identifier):
 
         if request_data.get('alert_owner_id') == "-1" or request_data.get('alert_owner_id') == -1:
             updated_alert.alert_owner_id = None
-        result = alerts_update(updated_alert, alert, iris_current_user, activity_data, identifier, do_resolution_hook, do_status_hook)
+        result = alerts_update(updated_alert, alert, activity_data, identifier, do_resolution_hook, do_status_hook)
         alert_schema = AlertSchema()
         return response_api_success(alert_schema.dump(result))
 

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -29,7 +29,6 @@ from app.blueprints.rest.endpoints import response_api_not_found
 from app.blueprints.rest.parsing import parse_comma_separated_identifiers
 from app.iris_engine.access_control.iris_user import iris_current_user
 from app.datamgmt.alerts.alerts_db import get_filtered_alerts
-from app.datamgmt.alerts.alerts_db import get_alert_by_id
 from app.models.authorization import Permissions
 from app.schema.marshables import AlertSchema
 from app.schema.marshables import IocSchema
@@ -198,7 +197,7 @@ def get_alert(identifier):
 def update_alert(identifier):
 
     try:
-        alert = get_alert_by_id(identifier)
+        alert = alerts_get(iris_current_user, identifier)
         request_data = request.get_json()
         updated_alert = _load(request_data, instance=alert, partial=True)
         result = alerts_update(updated_alert, alert, iris_current_user, request_data, identifier)

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -194,7 +194,7 @@ def get_alert(identifier):
 
 
 @alerts_blueprint.put('/<int:identifier>')
-@ac_api_requires()
+@ac_api_requires(Permissions.alerts_write)
 def update_alert(identifier):
 
     try:

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -189,3 +189,10 @@ def get_alert(identifier):
 
     except ObjectNotFoundError:
         return response_api_not_found()
+
+
+@alerts_blueprint.put('/<int:identifier>')
+@ac_api_requires()
+def update_alert(identifier):
+
+    return response_api_success(None)

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -73,10 +73,10 @@ def alerts_get(current_user, identifier) -> Alert:
 def alerts_update(updated_alert, alert, iris_current_user, data, identifier) -> Alert:
 
     if not alert:
-        raise ObjectNotFoundError()    
+        raise ObjectNotFoundError()   
     if not user_has_client_access(iris_current_user.id, alert.alert_customer_id):
         raise ObjectNotFoundError()
-    
+
     do_resolution_hook = False
     do_status_hook = False
 

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -70,7 +70,15 @@ def alerts_get(current_user, identifier) -> Alert:
     return alert
 
 
-def alerts_update(updated_alert: Alert, activity_data, do_resolution_hook, do_status_hook) -> Alert:
+def alerts_update(alert: Alert, updated_alert: Alert, activity_data) -> Alert:
+
+    do_resolution_hook = False
+    do_status_hook = False
+
+    if alert.alert_resolution_status_id != updated_alert.alert_resolution_status_id:
+        do_resolution_hook = True
+    if alert.alert_status_id != updated_alert.alert_status_id:
+        do_status_hook = True
 
     db.session.commit()
 
@@ -84,10 +92,10 @@ def alerts_update(updated_alert: Alert, activity_data, do_resolution_hook, do_st
 
     if activity_data:
         activity_data_as_string = ','.join(activity_data)
-        track_activity(f'updated alert #{updated_alert.alert_id}: {activity_data_as_string}', ctx_less=True)
+        track_activity(f'updated alert #{alert.alert_id}: {activity_data_as_string}', ctx_less=True)
         add_obj_history_entry(updated_alert, f'updated alert: {activity_data_as_string}')
     else:
-        track_activity(f'updated alert #{updated_alert.alert_id}', ctx_less=True)
+        track_activity(f'updated alert #{alert.alert_id}', ctx_less=True)
         add_obj_history_entry(updated_alert, 'updated alert')
 
     db.session.commit()

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -75,7 +75,6 @@ def alerts_update(updated_alert, alert, iris_current_user, data, identifier) -> 
 
     if not data:
         raise BusinessProcessingError('No JSON data provided')
-
     if not alert:
         raise ObjectNotFoundError()
     if not user_has_client_access(iris_current_user.id, alert.alert_customer_id):

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -72,6 +72,9 @@ def alerts_get(current_user, identifier) -> Alert:
 
 def alerts_update(updated_alert, alert, iris_current_user, data, identifier) -> Alert:
 
+    if not alert:
+        raise ObjectNotFoundError()
+    
     do_resolution_hook = False
     do_status_hook = False
 

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -69,6 +69,7 @@ def alerts_get(current_user, identifier) -> Alert:
 
     return alert
 
+
 def alerts_update(updated_alert, alert, iris_current_user, data, identifier) -> Alert:
 
     do_resolution_hook = False

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -30,6 +30,7 @@ from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.util import add_obj_history_entry
 from app.business.errors import ObjectNotFoundError
+from app.business.errors import BusinessProcessingError
 from app.datamgmt.manage.manage_access_control_db import user_has_client_access
 
 
@@ -71,6 +72,9 @@ def alerts_get(current_user, identifier) -> Alert:
 
 
 def alerts_update(updated_alert, alert, iris_current_user, data, identifier) -> Alert:
+
+    if not data:
+        raise BusinessProcessingError('No JSON data provided')
 
     if not alert:
         raise ObjectNotFoundError()

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -68,3 +68,55 @@ def alerts_get(current_user, identifier) -> Alert:
         raise ObjectNotFoundError()
 
     return alert
+
+def alerts_update(updated_alert, alert, iris_current_user, data, identifier) -> Alert:
+
+    do_resolution_hook = False
+    do_status_hook = False
+
+    activity_data = []
+    for key, value in data.items():
+        old_value = getattr(alert, key, None)
+
+        if type(old_value) is int:
+            old_value = str(old_value)
+
+        if type(value) is int:
+            value = str(value)
+
+        if old_value != value:
+            if key == "alert_resolution_status_id":
+                do_resolution_hook = True
+            if key == 'alert_status_id':
+                do_status_hook = True
+
+            if key not in ["alert_content", "alert_note"]:
+                activity_data.append(f"\"{key}\" from \"{old_value}\" to \"{value}\"")
+            else:
+                activity_data.append(f"\"{key}\"")
+    if data.get('alert_owner_id') is None and updated_alert.alert_owner_id is None:
+        updated_alert.alert_owner_id = iris_current_user.id
+
+    if data.get('alert_owner_id') == "-1" or data.get('alert_owner_id') == -1:
+        updated_alert.alert_owner_id = None
+
+    db.session.commit()
+
+    updated_alert = call_modules_hook('on_postload_alert_update', data=updated_alert)
+
+    if do_resolution_hook:
+        updated_alert = call_modules_hook('on_postload_alert_resolution_update', data=updated_alert)
+
+    if do_status_hook:
+        updated_alert = call_modules_hook('on_postload_alert_status_update', data=updated_alert)
+
+    if activity_data:
+        activity_data_as_string = ','.join(activity_data)
+        track_activity(f'updated alert #{identifier}: {activity_data_as_string}', ctx_less=True)
+        add_obj_history_entry(updated_alert, f'updated alert: {activity_data_as_string}')
+    else:
+        track_activity(f'updated alert #{identifier}', ctx_less=True)
+        add_obj_history_entry(updated_alert, 'updated alert')
+
+    db.session.commit()
+    return alert

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -71,12 +71,7 @@ def alerts_get(current_user, identifier) -> Alert:
     return alert
 
 
-def alerts_update(updated_alert: Alert, alert: Alert, iris_current_user, activity_data, identifier, do_resolution_hook, do_status_hook) -> Alert:
-
-    if not alert:
-        raise ObjectNotFoundError()
-    if not user_has_client_access(iris_current_user.id, alert.alert_customer_id):
-        raise ObjectNotFoundError()
+def alerts_update(updated_alert: Alert, alert: Alert, activity_data, identifier, do_resolution_hook, do_status_hook) -> Alert:
 
     db.session.commit()
 

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -30,7 +30,6 @@ from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.util import add_obj_history_entry
 from app.business.errors import ObjectNotFoundError
-from app.business.errors import BusinessProcessingError
 from app.datamgmt.manage.manage_access_control_db import user_has_client_access
 
 

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -73,7 +73,7 @@ def alerts_get(current_user, identifier) -> Alert:
 def alerts_update(updated_alert, alert, iris_current_user, data, identifier) -> Alert:
 
     if not alert:
-        raise ObjectNotFoundError()   
+        raise ObjectNotFoundError()
     if not user_has_client_access(iris_current_user.id, alert.alert_customer_id):
         raise ObjectNotFoundError()
 

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -71,7 +71,7 @@ def alerts_get(current_user, identifier) -> Alert:
     return alert
 
 
-def alerts_update(updated_alert, alert, iris_current_user, data, identifier) -> Alert:
+def alerts_update(updated_alert: Alert, alert: Alert, iris_current_user, data, identifier) -> Alert:
 
     if not data:
         raise BusinessProcessingError('No JSON data provided')

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -70,7 +70,7 @@ def alerts_get(current_user, identifier) -> Alert:
     return alert
 
 
-def alerts_update(updated_alert: Alert, alert: Alert, activity_data, identifier, do_resolution_hook, do_status_hook) -> Alert:
+def alerts_update(alert: Alert, updated_alert: Alert, activity_data, identifier, do_resolution_hook, do_status_hook) -> Alert:
 
     db.session.commit()
 

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -70,7 +70,7 @@ def alerts_get(current_user, identifier) -> Alert:
     return alert
 
 
-def alerts_update(alert: Alert, updated_alert: Alert, activity_data, do_resolution_hook, do_status_hook) -> Alert:
+def alerts_update(updated_alert: Alert, activity_data, do_resolution_hook, do_status_hook) -> Alert:
 
     db.session.commit()
 
@@ -84,11 +84,11 @@ def alerts_update(alert: Alert, updated_alert: Alert, activity_data, do_resoluti
 
     if activity_data:
         activity_data_as_string = ','.join(activity_data)
-        track_activity(f'updated alert #{alert.alert_id}: {activity_data_as_string}', ctx_less=True)
+        track_activity(f'updated alert #{updated_alert.alert_id}: {activity_data_as_string}', ctx_less=True)
         add_obj_history_entry(updated_alert, f'updated alert: {activity_data_as_string}')
     else:
-        track_activity(f'updated alert #{alert.alert_id}', ctx_less=True)
+        track_activity(f'updated alert #{updated_alert.alert_id}', ctx_less=True)
         add_obj_history_entry(updated_alert, 'updated alert')
 
     db.session.commit()
-    return alert
+    return updated_alert

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -80,8 +80,6 @@ def alerts_update(alert: Alert, updated_alert: Alert, activity_data) -> Alert:
     if alert.alert_status_id != updated_alert.alert_status_id:
         do_status_hook = True
 
-    db.session.commit()
-
     updated_alert = call_modules_hook('on_postload_alert_update', data=updated_alert)
 
     if do_resolution_hook:

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -70,7 +70,7 @@ def alerts_get(current_user, identifier) -> Alert:
     return alert
 
 
-def alerts_update(alert: Alert, updated_alert: Alert, activity_data, identifier, do_resolution_hook, do_status_hook) -> Alert:
+def alerts_update(alert: Alert, updated_alert: Alert, activity_data, do_resolution_hook, do_status_hook) -> Alert:
 
     db.session.commit()
 
@@ -84,10 +84,10 @@ def alerts_update(alert: Alert, updated_alert: Alert, activity_data, identifier,
 
     if activity_data:
         activity_data_as_string = ','.join(activity_data)
-        track_activity(f'updated alert #{identifier}: {activity_data_as_string}', ctx_less=True)
+        track_activity(f'updated alert #{alert.alert_id}: {activity_data_as_string}', ctx_less=True)
         add_obj_history_entry(updated_alert, f'updated alert: {activity_data_as_string}')
     else:
-        track_activity(f'updated alert #{identifier}', ctx_less=True)
+        track_activity(f'updated alert #{alert.alert_id}', ctx_less=True)
         add_obj_history_entry(updated_alert, 'updated alert')
 
     db.session.commit()

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -73,6 +73,8 @@ def alerts_get(current_user, identifier) -> Alert:
 def alerts_update(updated_alert, alert, iris_current_user, data, identifier) -> Alert:
 
     if not alert:
+        raise ObjectNotFoundError()    
+    if not user_has_client_access(iris_current_user.id, alert.alert_customer_id):
         raise ObjectNotFoundError()
     
     do_resolution_hook = False

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -71,43 +71,12 @@ def alerts_get(current_user, identifier) -> Alert:
     return alert
 
 
-def alerts_update(updated_alert: Alert, alert: Alert, iris_current_user, data, identifier) -> Alert:
+def alerts_update(updated_alert: Alert, alert: Alert, iris_current_user, activity_data, identifier, do_resolution_hook, do_status_hook) -> Alert:
 
-    if not data:
-        raise BusinessProcessingError('No JSON data provided')
     if not alert:
         raise ObjectNotFoundError()
     if not user_has_client_access(iris_current_user.id, alert.alert_customer_id):
         raise ObjectNotFoundError()
-
-    do_resolution_hook = False
-    do_status_hook = False
-
-    activity_data = []
-    for key, value in data.items():
-        old_value = getattr(alert, key, None)
-
-        if type(old_value) is int:
-            old_value = str(old_value)
-
-        if type(value) is int:
-            value = str(value)
-
-        if old_value != value:
-            if key == "alert_resolution_status_id":
-                do_resolution_hook = True
-            if key == 'alert_status_id':
-                do_status_hook = True
-
-            if key not in ["alert_content", "alert_note"]:
-                activity_data.append(f"\"{key}\" from \"{old_value}\" to \"{value}\"")
-            else:
-                activity_data.append(f"\"{key}\"")
-    if data.get('alert_owner_id') is None and updated_alert.alert_owner_id is None:
-        updated_alert.alert_owner_id = iris_current_user.id
-
-    if data.get('alert_owner_id') == "-1" or data.get('alert_owner_id') == -1:
-        updated_alert.alert_owner_id = None
 
     db.session.commit()
 

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -349,3 +349,20 @@ class TestsRestAlerts(TestCase):
         alert_context = {'context_key': 'key'}
         response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_context' : alert_context}).json()
         self.assertEqual(alert_context, response['alert_context'])
+
+    def test_update_alert_should_update_alert_source_content(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        alert_source_content = {
+            '_id': '603f704aaf7417985bbf3b22',
+            'contextId': '206e2965-6533-48a6-ba9e-794364a84bf9',
+            'description': 'Contoso user performed 11 suspicious activities MITRE'
+        }
+        response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_source_content' : alert_source_content}).json()
+        self.assertEqual(alert_source_content, response['alert_source_content'])

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -318,7 +318,7 @@ class TestsRestAlerts(TestCase):
         body = {
             'group_name': 'Customer create',
             'group_description': 'Group with customers can create alert',
-            'group_permissions': [_PERMISSION_ALERTS_WRITE, _PERMISSION_ALERTS_READ]
+            'group_permissions': [_PERMISSION_ALERTS_WRITE]
         }
         response = self._subject.create('/manage/groups/add', body).json()
         group_identifier = response['data']['group_id']

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -267,7 +267,7 @@ class TestsRestAlerts(TestCase):
         }
         response = self._subject.create('api/v2/alerts', body).json()
         identifier = response['alert_id']
-        response = self._subject.update(f'/api/v2/alerts/{identifier}', {})
+        response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_title' : 'new_title'})
         self.assertEqual(200, response.status_code)
 
     def test_update_alert_should_return_alert_title(self):
@@ -296,6 +296,18 @@ class TestsRestAlerts(TestCase):
         uuid = response['alert_uuid']
         response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_title' : alert_title}).json()
         self.assertEqual(uuid, response['alert_uuid'])
+
+    def test_update_alert_should_return_no_data_provided(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        response = self._subject.update(f'/api/v2/alerts/{identifier}', {})
+        self.assertEqual(400, response.status_code)
 
     def test_update_alert_should_return_404_when_alert_not_found(self):
         response = self._subject.update(f'/api/v2/alerts/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', {'alert_title' : 'alert_title'})
@@ -334,5 +346,5 @@ class TestsRestAlerts(TestCase):
         }
         response = self._subject.create('/api/v2/alerts', body).json()
         identifier = response['alert_id']
-        response = user.update(f'/api/v2/alerts/{identifier}', {})
+        response = user.update(f'/api/v2/alerts/{identifier}', {'alert_title' : 'new_title'})
         self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -269,3 +269,16 @@ class TestsRestAlerts(TestCase):
         identifier = response['alert_id']
         response = self._subject.update(f'/api/v2/alerts/{identifier}', {})
         self.assertEqual(200, response.status_code)
+
+    def test_update_alert_should_return_alert_title(self):
+        alert_title = 'new_title'
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_title' : alert_title}).json()
+        self.assertEqual(alert_title, response['alert_title'])

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -271,7 +271,6 @@ class TestsRestAlerts(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_update_alert_should_return_alert_title(self):
-        alert_title = 'new_title'
         body = {
             'alert_title': 'title',
             'alert_severity_id': 4,
@@ -280,6 +279,7 @@ class TestsRestAlerts(TestCase):
         }
         response = self._subject.create('api/v2/alerts', body).json()
         identifier = response['alert_id']
+        alert_title = 'new_title'
         response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_title' : alert_title}).json()
         self.assertEqual(alert_title, response['alert_title'])
     
@@ -336,3 +336,16 @@ class TestsRestAlerts(TestCase):
         identifier = response['alert_id']
         response = user.update(f'/api/v2/alerts/{identifier}', {'alert_title' : 'new_title'})
         self.assertEqual(404, response.status_code)
+
+    def test_update_alert_should_update_alert_context(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        alert_context = {'context_key': 'key'}
+        response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_context' : alert_context}).json()
+        self.assertEqual(alert_context, response['alert_context'])

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -314,7 +314,7 @@ class TestsRestAlerts(TestCase):
         response = user.update(f'/api/v2/alerts/{identifier}', {})
         self.assertEqual(403, response.status_code)
 
-    def test_get_alert_should_return_404_when_user_has_no_customer_access(self):
+    def test_update_alert_should_return_404_when_user_has_no_customer_access(self):
         body = {
             'group_name': 'Customer create',
             'group_description': 'Group with customers can create alert',

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -297,18 +297,6 @@ class TestsRestAlerts(TestCase):
         response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_title' : alert_title}).json()
         self.assertEqual(uuid, response['alert_uuid'])
 
-    def test_update_alert_should_return_400_when_no_data_provided(self):
-        body = {
-            'alert_title': 'title',
-            'alert_severity_id': 4,
-            'alert_status_id': 3,
-            'alert_customer_id': 1
-        }
-        response = self._subject.create('api/v2/alerts', body).json()
-        identifier = response['alert_id']
-        response = self._subject.update(f'/api/v2/alerts/{identifier}', {})
-        self.assertEqual(400, response.status_code)
-
     def test_update_alert_should_return_404_when_alert_not_found(self):
         response = self._subject.update(f'/api/v2/alerts/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', {'alert_title' : 'alert_title'})
         self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -296,3 +296,7 @@ class TestsRestAlerts(TestCase):
         uuid = response['alert_uuid']
         response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_title' : alert_title}).json()
         self.assertEqual(uuid, response['alert_uuid'])
+
+    def test_update_alert_should_return_404_when_alert_not_found(self):
+        response = self._subject.update(f'/api/v2/alerts/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', {'alert_title' : 'alert_title'})
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -282,3 +282,17 @@ class TestsRestAlerts(TestCase):
         identifier = response['alert_id']
         response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_title' : alert_title}).json()
         self.assertEqual(alert_title, response['alert_title'])
+    
+    def test_update_alert_should_return_alert_uuid(self):
+        alert_title = 'new_title'
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        uuid = response['alert_uuid']
+        response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_title' : alert_title}).json()
+        self.assertEqual(uuid, response['alert_uuid'])

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -297,7 +297,7 @@ class TestsRestAlerts(TestCase):
         response = self._subject.update(f'/api/v2/alerts/{identifier}', {'alert_title' : alert_title}).json()
         self.assertEqual(uuid, response['alert_uuid'])
 
-    def test_update_alert_should_return_no_data_provided(self):
+    def test_update_alert_should_return_400_when_no_data_provided(self):
         body = {
             'alert_title': 'title',
             'alert_severity_id': 4,

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -257,3 +257,15 @@ class TestsRestAlerts(TestCase):
         identifier = response['alert_id']
         response = user.get(f'/api/v2/alerts/{identifier}')
         self.assertEqual(404, response.status_code)
+
+    def test_update_alert_should_return_200(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        response = self._subject.update(f'/api/v2/alerts/{identifier}', {})
+        self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -300,3 +300,16 @@ class TestsRestAlerts(TestCase):
     def test_update_alert_should_return_404_when_alert_not_found(self):
         response = self._subject.update(f'/api/v2/alerts/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', {'alert_title' : 'alert_title'})
         self.assertEqual(404, response.status_code)
+
+    def test_update_alert_should_return_403_when_user_has_no_permission_to_read_alert(self):
+        user = self._subject.create_dummy_user()
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        response = user.update(f'/api/v2/alerts/{identifier}', {})
+        self.assertEqual(403, response.status_code)


### PR DESCRIPTION
Implementation of `PUT /api/v2/alerts/{identifier}`.

* Deprecated `POST /alert/update/{alert_id}`
* creation of the `alerts_update` method in the business layer
* tests

Note: this PR goes hand in hand with its documentation [PR#61](https://github.com/dfir-iris/iris-doc-src/pull/61)