### PR TITLE
Fixed IOC custom attributes not being displayed in IOC edition modal

### DIFF
--- a/source/app/templates/modals/modal_attributes_nav.html
+++ b/source/app/templates/modals/modal_attributes_nav.html
@@ -7,7 +7,7 @@
 
         {% for ca in attributes %}
             <li class="nav-item submenu">
-                <a class="nav-link"  data-toggle="pill" href="#{{  ca.lower() | replace(' ', '_' ) }}{{page_uid}}{{ loop.index }}" role="tab" aria-controls="{{  ca.lower() | replace(' ', '_' ) }}_{{page_uid}}{{ loop.index }}" aria-selected="false">{{ca}}</a>
+                <a class="nav-link"  data-toggle="pill" href="#{{  ca.lower() | replace(' ', '_' ) }}_{{page_uid}}{{ loop.index }}" role="tab" aria-controls="{{  ca.lower() | replace(' ', '_' ) }}_{{page_uid}}{{ loop.index }}" aria-selected="false">{{ca}}</a>
             </li>
         {% endfor %}
 


### PR DESCRIPTION
Should fix #758, #774 and #799.
Could you, please, still check?