### PR TITLE
Issue758 for develop

### DIFF
--- a/source/app/datamgmt/manage/manage_attribute_db.py
+++ b/source/app/datamgmt/manage/manage_attribute_db.py
@@ -15,11 +15,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 import json
 import logging as logger
 from sqlalchemy.orm.attributes import flag_modified
 
-from app import db, app
+from app import db
+from app import app
 from app.models.models import CaseAssets
 from app.models.models import CaseReceivedFile
 from app.models.models import CaseTasks

--- a/source/app/datamgmt/manage/manage_attribute_db.py
+++ b/source/app/datamgmt/manage/manage_attribute_db.py
@@ -148,16 +148,14 @@ def add_tab_attribute_field(obj, tab_name, field_name, field_type, field_value, 
         attribute[tab_name] = {}
 
     attr = {
-        field_name: {
-            "mandatory": mandatory if mandatory is not None else False,
-            "type": field_type,
-            "value": field_value
-        }
+        "mandatory": mandatory if mandatory is not None else False,
+        "type": field_type,
+        "value": field_value
     }
     if field_options:
-        attr[field_name]['options'] = field_options
+        attr['options'] = field_options
 
-    attribute[tab_name][field_name] = attr[field_name]
+    attribute[tab_name][field_name] = attr
 
     obj.custom_attributes = attribute
 

--- a/source/app/templates/modals/modal_attributes_nav.html
+++ b/source/app/templates/modals/modal_attributes_nav.html
@@ -7,7 +7,7 @@
 
         {% for ca in attributes %}
             <li class="nav-item submenu">
-                <a class="nav-link"  data-toggle="pill" href="#{{  ca.lower() | replace(' ', '_' ) }}{{page_uid}}{{ loop.index }}" role="tab" aria-controls="{{  ca.lower() | replace(' ', '_' ) }}_{{page_uid}}{{ loop.index }}" aria-selected="false">{{ca}}</a>
+                <a class="nav-link"  data-toggle="pill" href="#{{  ca.lower() | replace(' ', '_' ) }}_{{page_uid}}{{ loop.index }}" role="tab" aria-controls="{{  ca.lower() | replace(' ', '_' ) }}_{{page_uid}}{{ loop.index }}" aria-selected="false">{{ca}}</a>
             </li>
         {% endfor %}
 


### PR DESCRIPTION
Fixes #758 in develop and adds an end to end test to avoid future regression.

Performed some minor code simplification for method `add_tab_attribute_field`. It's a bit risky, since there is no easy way to have a test cover this part of code. So, if you can, would it be possible for you to check that either MISP or VT reports are correctly displayed on IOC after this PR is merged?