### PR TITLE
[ADD] Added server setting for forcing prompts before user deletes an object

### DIFF
--- a/source/app/alembic/versions/afcff5ebcf7c_added_force_confirmation_before_delete_.py
+++ b/source/app/alembic/versions/afcff5ebcf7c_added_force_confirmation_before_delete_.py
@@ -8,6 +8,7 @@ Create Date: 2025-06-12 00:33:12.873850
 from alembic import op
 import sqlalchemy as sa
 
+from app.alembic.alembic_utils import _table_has_column
 
 # revision identifiers, used by Alembic.
 revision = 'afcff5ebcf7c'
@@ -17,8 +18,23 @@ depends_on = None
 
 
 def upgrade():
-    pass
+    if not _table_has_column(
+        "server_settings",
+        "force_confirmation_before_delete",
+    ):
+        op.add_column(
+            "server_settings",
+            sa.Column(
+                "force_confirmation_before_delete",
+                sa.Boolean,
+                default=False,
+            ),
+        )
 
 
 def downgrade():
-    pass
+    if _table_has_column(
+        "server_settings",
+        "force_confirmation_before_delete",
+    ):
+        op.drop_column("server_settings", "force_confirmation_before_delete")

--- a/source/app/alembic/versions/afcff5ebcf7c_added_force_confirmation_before_delete_.py
+++ b/source/app/alembic/versions/afcff5ebcf7c_added_force_confirmation_before_delete_.py
@@ -1,0 +1,24 @@
+"""Added force_confirmation_before_delete to ServerSettings
+
+Revision ID: afcff5ebcf7c
+Revises: d5a720d1b99b
+Create Date: 2025-06-12 00:33:12.873850
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'afcff5ebcf7c'
+down_revision = 'd5a720d1b99b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/source/app/alembic/versions/d5a720d1b99b_add_alerts_indexes.py
+++ b/source/app/alembic/versions/d5a720d1b99b_add_alerts_indexes.py
@@ -28,7 +28,7 @@ def upgrade():
             op.create_index('idx_alerts_source_event_time', 'alerts', ['alert_source_event_time'])
         if not index_exists('alerts', 'idx_alerts_customer_id'):
             op.create_index('idx_alerts_customer_id', 'alerts', ['alert_customer_id'])
-        if not index_exists('alerts', 'alert_source_ref'):
+        if not index_exists('alerts', 'idx_alert_source_ref'):
             op.create_index('idx_alert_source_ref', 'alerts', ['alert_source_ref'])
 
     # Adding indexes to the Ioc table

--- a/source/app/blueprints/pages/manage/templates/manage_srv_settings.html
+++ b/source/app/blueprints/pages/manage/templates/manage_srv_settings.html
@@ -156,6 +156,18 @@
                                             </div>
                                         </div>
                                     </div>
+                                    <h2 class="mt-4">Prompt Confirmation Box Before Deleting Objects</h2>
+                                    <p>If set, users are required to answer a confirmation before deleting an object</p>
+                                    <div class="row mb-4">
+                                        <div class="col-12">
+                                            <div class="form-check">
+                                                <label class="form-check-label">
+                                                    <input class="form-check-input" type="checkbox" id="force_confirmation_before_delete" name="force_confirmation_before_delete" {% if settings.force_confirmation_before_delete %}checked{% endif %}>
+                                                    <span class="form-check-sign">Force confirmation before deleting objects</span>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
                             </form>
                             <div class="float-right mt-4">
                                 <button class="btn btn-outline-primary float-right" id="save_srv_settings" type="button" onclick="update_settings()">Save changes</button>

--- a/source/app/blueprints/rest/profile_routes.py
+++ b/source/app/blueprints/rest/profile_routes.py
@@ -32,6 +32,7 @@ from app.iris_engine.access_control.utils import ac_get_effective_permissions_of
 from app.iris_engine.access_control.utils import ac_recompute_effective_ac
 from app.iris_engine.utils.tracker import track_activity
 from app.models.authorization import Permissions
+from app.models.models import ServerSettings
 from app.schema.marshables import UserSchema
 from app.schema.marshables import BasicUserSchema
 from app.blueprints.access_controls import ac_api_requires
@@ -184,7 +185,12 @@ def profile_whoami():
         return response_error("Invalid user ID")
 
     user_schema = BasicUserSchema()
-    return response_success(data=user_schema.dump(user))
+    data = user_schema.dump(user)
+    srv_settings = ServerSettings.query.first()
+
+    if srv_settings.force_confirmation_before_delete:
+        data["has_deletion_confirmation"] = True
+    return response_success(data=data)
 
 
 @profile_rest_blueprint.route('/user/is-admin', methods=['GET'])

--- a/source/app/models/models.py
+++ b/source/app/models/models.py
@@ -706,6 +706,7 @@ class ServerSettings(db.Model):
     password_policy_digit = Column(Boolean)
     password_policy_special_chars = Column(Text)
     enforce_mfa = Column(Boolean)
+    force_confirmation_before_delete = Column(Boolean)
 
 
 class Comments(db.Model):

--- a/ui/src/pages/common.js
+++ b/ui/src/pages/common.js
@@ -1719,6 +1719,11 @@ $('.toggle-sidebar').on('click', function() {
 });
 
 function do_deletion_prompt(message, force_prompt=false) {
+    // The whoami object needs to be refreshed to verify that the users
+    // has_deletion_confirmation value has not changed. For example,
+    // the global setting on the server to force confirmation might
+    // have been turned on during the user session.
+    userWhoamiRequest(true)
     if (userWhoami.has_deletion_confirmation || force_prompt) {
             return new Promise((resolve, reject) => {
                 swal({

--- a/ui/src/pages/manage.server.settings.js
+++ b/ui/src/pages/manage.server.settings.js
@@ -6,7 +6,7 @@ function update_settings() {
     data_sent['password_policy_lower_case'] = $('#password_policy_lower_case').is(":checked");
     data_sent['password_policy_digit'] = $('#password_policy_digit').is(":checked");
     data_sent['enforce_mfa'] = $('#enforce_mfa').is(":checked");
-    data_sent['force_confirmation_before_delete'] = $('force_confirmation_before_delete').is(":checked");
+    data_sent['force_confirmation_before_delete'] = $('#force_confirmation_before_delete').is(":checked");
     data_sent['password_policy_min_length'] = $('#password_policy_min_length').val().toString();
 
     post_request_api('/manage/settings/update', JSON.stringify(data_sent), true)

--- a/ui/src/pages/manage.server.settings.js
+++ b/ui/src/pages/manage.server.settings.js
@@ -6,6 +6,7 @@ function update_settings() {
     data_sent['password_policy_lower_case'] = $('#password_policy_lower_case').is(":checked");
     data_sent['password_policy_digit'] = $('#password_policy_digit').is(":checked");
     data_sent['enforce_mfa'] = $('#enforce_mfa').is(":checked");
+    data_sent['force_confirmation_before_delete'] = $('force_confirmation_before_delete').is(":checked");
     data_sent['password_policy_min_length'] = $('#password_policy_min_length').val().toString();
 
     post_request_api('/manage/settings/update', JSON.stringify(data_sent), true)


### PR DESCRIPTION
The following adds a checkbox within the server settings page to allow an administrator to force users to confirm before deleting objects instead of users having to check a setting within their profile section. This is not the best solution as it would make more sense to have a server api rather than inject  the value of the force_confirmation_before_delete to the user when it is enabled; however, this is an easier approach for now.

![Screenshot From 2025-05-28 21-52-41](https://github.com/user-attachments/assets/7f87ffeb-2f5f-47c9-be66-15d93c0848ab)