### PR TITLE
[IMP] Context does not switch if user requests the same context

### DIFF
--- a/ui/src/pages/common.js
+++ b/ui/src/pages/common.js
@@ -1822,6 +1822,13 @@ $(document).ready(function(){
     var data_sent = new Object();
     data_sent.ctx = $('#user_context').val();
     data_sent.ctx_h = $("#user_context option:selected").text();
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    let currentContext = urlParams.get("cid");
+    if (currentContext === data_sent.ctx) {
+            $('#modal_switch_context').modal('hide');
+            return;
+    }
     post_request_api(`/context/set?cid=${data_sent.ctx}`, data_sent)
     .done((data) => {
             if (api_request_failed(data)) {


### PR DESCRIPTION
This pull request is proposing that we close the modal when the user request the same context since there's no reason to reload the page. The current behavior does the following:

If your context is set to cid = 1 and you request a context change to the same cid the current behavior is that the page will say context switch and it will reload the page to the "new" context.