### PR TITLE
Api v2 delete group

### DIFF
--- a/source/app/blueprints/rest/endpoints.py
+++ b/source/app/blueprints/rest/endpoints.py
@@ -20,7 +20,8 @@ from functools import wraps
 from flask_sqlalchemy.pagination import Pagination
 
 from app import app
-from app.blueprints.responses import response_error, response
+from app.blueprints.responses import response_error
+from app.blueprints.responses import response
 
 logger = app.logger
 

--- a/source/app/blueprints/rest/manage/manage_groups.py
+++ b/source/app/blueprints/rest/manage/manage_groups.py
@@ -131,6 +131,7 @@ def manage_groups_update(cur_id):
 
 
 @manage_groups_rest_blueprint.route('/manage/groups/delete/<int:cur_id>', methods=['POST'])
+@endpoint_deprecated('DELETE', '/api/v2/manage/groups/{identifier}')
 @ac_api_requires(Permissions.server_administrator)
 def manage_groups_delete(cur_id):
 

--- a/source/app/blueprints/rest/manage/manage_groups.py
+++ b/source/app/blueprints/rest/manage/manage_groups.py
@@ -93,6 +93,7 @@ def manage_groups_add():
 
 
 @manage_groups_rest_blueprint.route('/manage/groups/update/<int:cur_id>', methods=['POST'])
+@endpoint_deprecated('PUT', '/api/v2/manage/groups/{identifier}')
 @ac_api_requires(Permissions.server_administrator)
 def manage_groups_update(cur_id):
 

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -28,6 +28,7 @@ from app.blueprints.access_controls import wrap_with_permission_checks
 from app.schema.marshables import AuthorizationGroupSchema
 from app.business.groups import groups_create
 from app.business.groups import groups_get
+from app.business.groups import groups_update
 from app.models.authorization import Permissions
 from app.business.errors import ObjectNotFoundError
 
@@ -59,7 +60,15 @@ class Groups:
             return response_api_not_found()
 
     def update(self, identifier):
-        return response_api_success(None)
+        try:
+            group = groups_get(identifier)
+            request_data = request.get_json()
+            updated_group = self._load(request_data)
+            group = groups_update(updated_group)
+            result = self._schema.dump(group)
+            return response_api_success(result)
+        except ValidationError as e:
+            return response_api_error('Data error', data=e.messages)
 
 
 def create_groups_blueprint():

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -35,6 +35,7 @@ from app.iris_engine.access_control.iris_user import iris_current_user
 from app.iris_engine.access_control.utils import ac_flag_match_mask
 from app.iris_engine.access_control.utils import ac_ldp_group_update
 
+
 class Groups:
 
     def __init__(self):

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -89,9 +89,6 @@ class Groups:
             groups_delete(group)
             return response_api_deleted()
 
-        except ValidationError as e:
-            return response_api_error('Data error', data=e.messages)
-
         except ObjectNotFoundError:
             return response_api_not_found()
 

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -19,7 +19,7 @@
 from flask import Blueprint
 from flask import request
 from marshmallow import ValidationError
-from app import db
+
 from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_error

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -81,6 +81,10 @@ class Groups:
             return response_api_not_found()
 
 
+    def delete(self, identifier):
+        return response_api_success(None)
+
+
 def create_groups_blueprint():
     blueprint = Blueprint('rest_v2_groups', __name__, url_prefix='/groups')
     groups = Groups()
@@ -93,5 +97,8 @@ def create_groups_blueprint():
 
     update_group = wrap_with_permission_checks(groups.update, Permissions.server_administrator)
     blueprint.add_url_rule('/<int:identifier>', view_func=update_group, methods=['PUT'])
+
+    delete_group = wrap_with_permission_checks(groups.delete, Permissions.server_administrator)
+    blueprint.add_url_rule('/<int:identifier>', view_func=delete_group, methods=['DELETE'])
 
     return blueprint

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -67,8 +67,12 @@ class Groups:
             group = groups_update(updated_group)
             result = self._schema.dump(group)
             return response_api_success(result)
+
         except ValidationError as e:
             return response_api_error('Data error', data=e.messages)
+
+        except ObjectNotFoundError:
+            return response_api_not_found()
 
 
 def create_groups_blueprint():

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -88,7 +88,7 @@ class Groups:
             group = groups_get(identifier)
             groups_delete(group)
             return response_api_deleted()
-        
+
         except ValidationError as e:
             return response_api_error('Data error', data=e.messages)
 

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -75,6 +75,9 @@ class Groups:
             result = self._schema.dump(group)
             return response_api_success(result)
 
+        except ValidationError as e:
+            return response_api_error('Data error', data=e.messages)
+
         except ObjectNotFoundError:
             return response_api_not_found()
 

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -58,6 +58,9 @@ class Groups:
         except ObjectNotFoundError:
             return response_api_not_found()
 
+    def update(self, identifier):
+        return response_api_success(None)
+
 
 def create_groups_blueprint():
     blueprint = Blueprint('rest_v2_groups', __name__, url_prefix='/groups')
@@ -68,5 +71,8 @@ def create_groups_blueprint():
 
     get_group = wrap_with_permission_checks(groups.get, Permissions.server_administrator)
     blueprint.add_url_rule('/<int:identifier>', view_func=get_group, methods=['GET'])
+
+    update_group = wrap_with_permission_checks(groups.update, Permissions.server_administrator)
+    blueprint.add_url_rule('/<int:identifier>', view_func=update_group, methods=['PUT'])
 
     return blueprint

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -24,11 +24,14 @@ from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_not_found
+from app.blueprints.rest.endpoints import response_api_deleted
 from app.blueprints.access_controls import wrap_with_permission_checks
 from app.schema.marshables import AuthorizationGroupSchema
 from app.business.groups import groups_create
 from app.business.groups import groups_get
 from app.business.groups import groups_update
+from app.business.groups import groups_delete
+from app.models.authorization import Permissions
 from app.business.errors import ObjectNotFoundError
 from app.models.authorization import Permissions
 from app.iris_engine.access_control.iris_user import iris_current_user
@@ -80,9 +83,13 @@ class Groups:
         except ObjectNotFoundError:
             return response_api_not_found()
 
-
     def delete(self, identifier):
-        return response_api_success(None)
+        try :
+            group = groups_get(identifier)
+            groups_delete(group)
+            return response_api_deleted()
+        except ValidationError as e:
+            return response_api_error('Data error', data=e.messages)
 
 
 def create_groups_blueprint():

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -33,7 +33,6 @@ from app.business.groups import groups_update
 from app.business.groups import groups_delete
 from app.models.authorization import Permissions
 from app.business.errors import ObjectNotFoundError
-from app.models.authorization import Permissions
 from app.iris_engine.access_control.iris_user import iris_current_user
 from app.iris_engine.access_control.utils import ac_flag_match_mask
 from app.iris_engine.access_control.utils import ac_ldp_group_update

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -75,9 +75,6 @@ class Groups:
             result = self._schema.dump(group)
             return response_api_success(result)
 
-        except ValidationError as e:
-            return response_api_error('Data error', data=e.messages)
-
         except ObjectNotFoundError:
             return response_api_not_found()
 

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -67,12 +67,11 @@ class Groups:
             group = groups_get(identifier)
             request_data = request.get_json()
             request_data['group_id'] = identifier
-            if not ac_flag_match_mask(request_data['group_permissions'], Permissions.server_administrator.value) and ac_ldp_group_update(iris_current_user.id):
-                db.session.rollback()
-                return response_api_error('That might not be a good idea Dave', data='Update the group permissions will lock you out')
             updated_group = self._load(request_data, instance=group, partial=True)
-            group = groups_update(updated_group)
-            result = self._schema.dump(group)
+            if not ac_flag_match_mask(request_data['group_permissions'], Permissions.server_administrator.value) and ac_ldp_group_update(iris_current_user.id):
+                return response_api_error('That might not be a good idea Dave', data='Update the group permissions will lock you out')
+            groups_update()
+            result = self._schema.dump(updated_group)
             return response_api_success(result)
 
         except ValidationError as e:

--- a/source/app/blueprints/rest/v2/manage_routes/groups.py
+++ b/source/app/blueprints/rest/v2/manage_routes/groups.py
@@ -88,8 +88,12 @@ class Groups:
             group = groups_get(identifier)
             groups_delete(group)
             return response_api_deleted()
+        
         except ValidationError as e:
             return response_api_error('Data error', data=e.messages)
+
+        except ObjectNotFoundError:
+            return response_api_not_found()
 
 
 def create_groups_blueprint():

--- a/source/app/business/groups.py
+++ b/source/app/business/groups.py
@@ -21,6 +21,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.datamgmt.manage.manage_groups_db import create_group
 from app.datamgmt.manage.manage_groups_db import get_group_details
 from app.datamgmt.manage.manage_groups_db import update_group
+from app.datamgmt.manage.manage_groups_db import delete_group
 from app.business.errors import ObjectNotFoundError
 
 
@@ -40,3 +41,7 @@ def groups_get(identifier) -> Group:
 
 def groups_update():
     update_group()
+
+
+def groups_delete(group: Group):
+    delete_group(group)

--- a/source/app/business/groups.py
+++ b/source/app/business/groups.py
@@ -43,5 +43,6 @@ def groups_update():
     update_group()
 
 
+
 def groups_delete(group: Group):
     delete_group(group)

--- a/source/app/business/groups.py
+++ b/source/app/business/groups.py
@@ -43,6 +43,5 @@ def groups_update():
     update_group()
 
 
-
 def groups_delete(group: Group):
     delete_group(group)

--- a/source/app/business/groups.py
+++ b/source/app/business/groups.py
@@ -38,6 +38,5 @@ def groups_get(identifier) -> Group:
     return group
 
 
-def groups_update(group_updated: Group) -> Group:
+def groups_update():
     update_group()
-    return group_updated

--- a/source/app/business/groups.py
+++ b/source/app/business/groups.py
@@ -20,6 +20,7 @@ from app.models.authorization import Group
 from app.iris_engine.utils.tracker import track_activity
 from app.datamgmt.manage.manage_groups_db import create_group
 from app.datamgmt.manage.manage_groups_db import get_group_details
+from app.datamgmt.manage.manage_groups_db import update_group
 from app.business.errors import ObjectNotFoundError
 
 
@@ -35,3 +36,7 @@ def groups_get(identifier) -> Group:
     if not group:
         raise ObjectNotFoundError()
     return group
+
+def groups_update(group_updated: Group) -> Group:
+    update_group()
+    return group_updated

--- a/source/app/business/groups.py
+++ b/source/app/business/groups.py
@@ -37,6 +37,7 @@ def groups_get(identifier) -> Group:
         raise ObjectNotFoundError()
     return group
 
+
 def groups_update(group_updated: Group) -> Group:
     update_group()
     return group_updated

--- a/source/app/datamgmt/manage/manage_groups_db.py
+++ b/source/app/datamgmt/manage/manage_groups_db.py
@@ -42,6 +42,8 @@ def get_groups_list():
 
     return groups
 
+def update_group():
+    db.session.commit()
 
 def get_groups_list_hr_perms():
     groups = get_groups_list()

--- a/source/app/datamgmt/manage/manage_groups_db.py
+++ b/source/app/datamgmt/manage/manage_groups_db.py
@@ -42,8 +42,10 @@ def get_groups_list():
 
     return groups
 
+
 def update_group():
     db.session.commit()
+
 
 def get_groups_list_hr_perms():
     groups = get_groups_list()

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -176,3 +176,11 @@ class TestsRestGroups(TestCase):
     def test_delete_group_should_return_404_when_group_not_found(self):
         response = self._subject.delete(f'/api/v2/manage/groups/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)
+
+    def test_delete_group_should_return_403_when_user_is_denied_permission_to_access_group(self):
+        user = self._subject.create_dummy_user()
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.create('/api/v2/manage/groups', body).json()
+        identifier = response['group_id']
+        response = user.delete(f'/api/v2/manage/groups/{identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -119,3 +119,11 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'new_name', 'group_description': 'new_description', 'group_auto_follow' : True}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body).json()
         self.assertEqual(True, response['group_auto_follow'])
+    
+    def test_update_group_should_return_400_when_field_group_description_is_missing(self):
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.create('/api/v2/manage/groups', body).json()
+        identifier = response['group_id']
+        body = {'group_name': 'name'}
+        response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -94,3 +94,11 @@ class TestsRestGroups(TestCase):
         user = self._subject.create_dummy_user()
         response = user.get(f'/api/v2/manage/groups/{identifier}')
         self.assertEqual(403, response.status_code)
+
+    def test_update_group_should_return_200(self):
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.create('/api/v2/manage/groups', body).json()
+        identifier = response['group_id']
+        body = {'group_name': 'new_name'}
+        response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
+        self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -99,7 +99,7 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'name', 'group_description': 'description'}
         response = self._subject.create('/api/v2/manage/groups', body).json()
         identifier = response['group_id']
-        body = {'group_name': 'new_name', 'group_description': 'new_description'}
+        body = {'group_name': 'new_name', 'group_description': 'new_description', 'group_permissions': 1}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
         self.assertEqual(200, response.status_code)
 
@@ -108,7 +108,7 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'name', 'group_description': 'description'}
         response = self._subject.create('/api/v2/manage/groups', body).json()
         identifier = response['group_id']
-        body = {'group_name': new_name, 'group_description': 'new_description'}
+        body = {'group_name': new_name, 'group_description': 'new_description', 'group_permissions': 1}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body).json()
         self.assertEqual(new_name, response['group_name'])
 
@@ -116,23 +116,15 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'name', 'group_description': 'description'}
         response = self._subject.create('/api/v2/manage/groups', body).json()
         identifier = response['group_id']
-        body = {'group_name': 'new_name', 'group_description': 'new_description', 'group_auto_follow' : True}
+        body = {'group_name': 'new_name', 'group_description': 'new_description', 'group_permissions': 1, 'group_auto_follow' : True}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body).json()
         self.assertEqual(True, response['group_auto_follow'])
-    
-    def test_update_group_should_return_400_when_field_group_description_is_missing(self):
-        body = {'group_name': 'name', 'group_description': 'description'}
-        response = self._subject.create('/api/v2/manage/groups', body).json()
-        identifier = response['group_id']
-        body = {'group_name': 'new_name'}
-        response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
-        self.assertEqual(400, response.status_code)
 
     def test_update_group_should_return_400_when_field_group_name_is_missing(self):
         body = {'group_name': 'name', 'group_description': 'description'}
         response = self._subject.create('/api/v2/manage/groups', body).json()
         identifier = response['group_id']
-        body = {'group_description': 'new_description'}
+        body = {'group_description': 'new_description', 'group_permissions': 1}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
         self.assertEqual(400, response.status_code)
 
@@ -141,11 +133,11 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'name', 'group_description': 'description'}
         response = self._subject.create('/api/v2/manage/groups', body).json()
         identifier = response['group_id']
-        body = {'group_description': 'new_description'}
+        body = {'group_description': 'new_description', 'group_permissions': 1}
         response = user.update(f'/api/v2/manage/groups/{identifier}', body)
         self.assertEqual(403, response.status_code)
 
     def test_update_group_should_return_404_when_group_not_found(self):
-        body = {'group_name': 'name', 'group_description': 'description'}
+        body = {'group_name': 'name', 'group_description': 'description', 'group_permissions': 1}
         response = self._subject.update(f'/api/v2/manage/groups/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', body)
         self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -164,3 +164,11 @@ class TestsRestGroups(TestCase):
         identifier = response['group_id']
         response = self._subject.delete(f'/api/v2/manage/groups/{identifier}')
         self.assertEqual(204, response.status_code)
+
+    def test_get_group_should_return_404_after_delete_group(self):
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.create('/api/v2/manage/groups', body).json()
+        identifier = response['group_id']
+        self._subject.delete(f'/api/v2/manage/groups/{identifier}')
+        response = self._subject.get(f'/api/v2/manage/groups/{identifier}')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -135,3 +135,12 @@ class TestsRestGroups(TestCase):
         body = {'group_description': 'new_description'}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
         self.assertEqual(400, response.status_code)
+
+    def test_update_group_should_return_403_when_user_has_no_permission_to_update_group(self):
+        user = self._subject.create_dummy_user()
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.create('/api/v2/manage/groups', body).json()
+        identifier = response['group_id']
+        body = {'group_description': 'new_description'}
+        response = user.update(f'/api/v2/manage/groups/{identifier}', body)
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -21,6 +21,7 @@ from unittest import TestCase
 from iris import Iris
 
 _IDENTIFIER_FOR_NONEXISTENT_OBJECT = 123456789
+_PERMISSION_SERVER_ADMINISTRATOR = 0x2
 
 
 class TestsRestGroups(TestCase):

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -99,7 +99,7 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'name', 'group_description': 'description'}
         response = self._subject.create('/api/v2/manage/groups', body).json()
         identifier = response['group_id']
-        body = {'group_name': 'new_name'}
+        body = {'group_name': 'new_name', 'group_description': 'new_description'}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
         self.assertEqual(200, response.status_code)
 

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -143,17 +143,17 @@ class TestsRestGroups(TestCase):
         response = self._subject.update(f'/api/v2/manage/groups/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', body)
         self.assertEqual(404, response.status_code)
 
-#    def test_update_group_when_new_user_in_group_with_permissions_admin(self):
-#        body = {
-#            'group_name': 'Customer server administrator',
-#            'group_description': 'Group with permission server administrator',
-#            'group_permissions': [_PERMISSION_SERVER_ADMINISTRATOR]
-#        }
-#        response = self._subject.create('/manage/groups/add', body).json()
-#        group_identifier = response['data']['group_id']
-#        user = self._subject.create_dummy_user()
-#        body = {'groups_membership': [group_identifier]}
-#        self._subject.create(f'/manage/users/{user.get_identifier()}/groups/update', body)
-#        body = {'group_name': 'new_name', 'group_description': 'new_description', 'group_permissions': 0x0}
-#        response = user.update(f'/api/v2/manage/groups/{group_identifier}', body)
-#        self.assertEqual(200, response.status_code)
+    def test_update_group_should_return_400_when_new_user_in_group_with_permissions_admin(self):
+        body = {
+            'group_name': 'Customer server administrator',
+            'group_description': 'Group with permission server administrator',
+            'group_permissions': [_PERMISSION_SERVER_ADMINISTRATOR]
+        }
+        response = self._subject.create('/manage/groups/add', body).json()
+        group_identifier = response['data']['group_id']
+        user = self._subject.create_dummy_user()
+        body = {'groups_membership': [group_identifier]}
+        self._subject.create(f'/manage/users/{user.get_identifier()}/groups/update', body)
+        body = {'group_name': 'new_name', 'group_description': 'new_description', 'group_permissions': 0x0}
+        response = user.update(f'/api/v2/manage/groups/{group_identifier}', body)
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -144,3 +144,8 @@ class TestsRestGroups(TestCase):
         body = {'group_description': 'new_description'}
         response = user.update(f'/api/v2/manage/groups/{identifier}', body)
         self.assertEqual(403, response.status_code)
+
+    def test_update_group_should_return_404_when_group_not_found(self):
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.update(f'/api/v2/manage/groups/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', body)
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -102,3 +102,12 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'new_name'}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
         self.assertEqual(200, response.status_code)
+
+    def test_update_group_should_return_field_groupe_name(self):
+        new_name = 'new_name'
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.create('/api/v2/manage/groups', body).json()
+        identifier = response['group_id']
+        body = {'group_name': new_name, 'group_description': 'new_description'}
+        response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body).json()
+        self.assertEqual(new_name, response['group_name'])

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -158,9 +158,9 @@ class TestsRestGroups(TestCase):
         response = user.update(f'/api/v2/manage/groups/{group_identifier}', body)
         self.assertEqual(400, response.status_code)
 
-    def test_delete_group_should_return_200(self):
+    def test_delete_group_should_return_204(self):
         body = {'group_name': 'name', 'group_description': 'description'}
         response = self._subject.create('/api/v2/manage/groups', body).json()
         identifier = response['group_id']
         response = self._subject.delete(f'/api/v2/manage/groups/{identifier}')
-        self.assertEqual(200, response.status_code)
+        self.assertEqual(204, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -21,7 +21,6 @@ from unittest import TestCase
 from iris import Iris
 
 _IDENTIFIER_FOR_NONEXISTENT_OBJECT = 123456789
-_PERMISSION_SERVER_ADMINISTRATOR = 0x2
 
 
 class TestsRestGroups(TestCase):

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -103,7 +103,7 @@ class TestsRestGroups(TestCase):
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
         self.assertEqual(200, response.status_code)
 
-    def test_update_group_should_return_field_groupe_name(self):
+    def test_update_group_should_return_field_group_name(self):
         new_name = 'new_name'
         body = {'group_name': 'name', 'group_description': 'description'}
         response = self._subject.create('/api/v2/manage/groups', body).json()
@@ -111,3 +111,11 @@ class TestsRestGroups(TestCase):
         body = {'group_name': new_name, 'group_description': 'new_description'}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body).json()
         self.assertEqual(new_name, response['group_name'])
+
+    def test_update_group_should_return_field_group_auto_follow(self):
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.create('/api/v2/manage/groups', body).json()
+        identifier = response['group_id']
+        body = {'group_name': 'new_name', 'group_description': 'new_description', 'group_auto_follow' : True}
+        response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body).json()
+        self.assertEqual(True, response['group_auto_follow'])

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -172,3 +172,7 @@ class TestsRestGroups(TestCase):
         self._subject.delete(f'/api/v2/manage/groups/{identifier}')
         response = self._subject.get(f'/api/v2/manage/groups/{identifier}')
         self.assertEqual(404, response.status_code)
+
+    def test_delete_group_should_return_404_when_group_not_found(self):
+        response = self._subject.delete(f'/api/v2/manage/groups/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -21,6 +21,7 @@ from unittest import TestCase
 from iris import Iris
 
 _IDENTIFIER_FOR_NONEXISTENT_OBJECT = 123456789
+_PERMISSION_SERVER_ADMINISTRATOR = 0x2
 
 
 class TestsRestGroups(TestCase):
@@ -141,3 +142,18 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'name', 'group_description': 'description', 'group_permissions': 1}
         response = self._subject.update(f'/api/v2/manage/groups/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', body)
         self.assertEqual(404, response.status_code)
+
+#    def test_update_group_when_new_user_in_group_with_permissions_admin(self):
+#        body = {
+#            'group_name': 'Customer server administrator',
+#            'group_description': 'Group with permission server administrator',
+#            'group_permissions': [_PERMISSION_SERVER_ADMINISTRATOR]
+#        }
+#        response = self._subject.create('/manage/groups/add', body).json()
+#        group_identifier = response['data']['group_id']
+#        user = self._subject.create_dummy_user()
+#        body = {'groups_membership': [group_identifier]}
+#        self._subject.create(f'/manage/users/{user.get_identifier()}/groups/update', body)
+#        body = {'group_name': 'new_name', 'group_description': 'new_description', 'group_permissions': 0x0}
+#        response = user.update(f'/api/v2/manage/groups/{group_identifier}', body)
+#        self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -157,3 +157,10 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'new_name', 'group_description': 'new_description', 'group_permissions': 0x0}
         response = user.update(f'/api/v2/manage/groups/{group_identifier}', body)
         self.assertEqual(400, response.status_code)
+
+    def test_delete_group_should_return_200(self):
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.create('/api/v2/manage/groups', body).json()
+        identifier = response['group_id']
+        response = self._subject.delete(f'/api/v2/manage/groups/{identifier}')
+        self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_groups.py
+++ b/tests/tests_rest_groups.py
@@ -124,6 +124,14 @@ class TestsRestGroups(TestCase):
         body = {'group_name': 'name', 'group_description': 'description'}
         response = self._subject.create('/api/v2/manage/groups', body).json()
         identifier = response['group_id']
-        body = {'group_name': 'name'}
+        body = {'group_name': 'new_name'}
+        response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
+        self.assertEqual(400, response.status_code)
+
+    def test_update_group_should_return_400_when_field_group_name_is_missing(self):
+        body = {'group_name': 'name', 'group_description': 'description'}
+        response = self._subject.create('/api/v2/manage/groups', body).json()
+        identifier = response['group_id']
+        body = {'group_description': 'new_description'}
         response = self._subject.update(f'/api/v2/manage/groups/{identifier}', body)
         self.assertEqual(400, response.status_code)


### PR DESCRIPTION
Implementation of `DELETE  /api/v2/alerts/{identifier}`.

* deprecated `POST /manage/groups/delete/{group_id} `.