### PR TITLE
[IMP] Delete "nohup" command for IRIS webapp

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -39,7 +39,7 @@ services:
 
   app:
     container_name: iriswebapp_app
-    command: ["nohup", "./iris-entrypoint.sh", "iriswebapp"]
+    command: ["./iris-entrypoint.sh", "iriswebapp"]
     volumes:
       - ./certificates/rootCA/irisRootCACert.pem:/etc/irisRootCACert.pem:ro
       - ./certificates/:/home/iris/certificates/:ro


### PR DESCRIPTION
The "nohup" command is used to set up signal blocking for the HUP signal for a command. Traditionally, the HUP signal is sent to a process when a tty closes, and is unlikely to affect a process running inside a container.

It appears that the same command is used for EKS and Kubernetes, but as I don't have the resources to test them currently, I have left them unchanged (they are unlikely to cause any issues, though).