### PR TITLE
[FIX] Start nginx as root inside the container

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -42,8 +42,6 @@ RUN touch /var/run/nginx.pid && chown -R www-data:www-data /var/run/nginx.pid /v
 
 RUN mkdir -p /www/certs/
 
-USER www-data
-
 HEALTHCHECK --interval=5s --timeout=3s CMD curl --fail -k https://127.0.0.1:${INTERFACE_HTTPS_PORT:-443} || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Running reverse proxies like nginx as root is important for (at least) two reasons:
- being able to bind to ports under a specific "privileged port" threshold, usually 1024;
- opening certain files, like certificates, log file, a pid file.

Unless configured explicitly, the `www-data` user inside the container will not match the owner of the certificate, which will either require changing the file's owner or group (from inside the container, to make sure the user / group matches), or setting a permissive mode on the key file.

In IRIS' case, nginx should run as root to allow it to open the TLS private key file, which should have restrictive permissions (mode 0600).

nginx by default will fork and use the `setuid` / `setgid` system calls to change users of worker processes to a user with fewer privileges. The master process that still runs as root is (or at least should, in the absence of a critical bug) not handle user connections, and instead simply manage its workers.