### PR TITLE
[FIX] Fix check for sidebar collapse callback

### DIFF
--- a/ui/src/pages/common.js
+++ b/ui/src/pages/common.js
@@ -1703,7 +1703,7 @@ $('.toggle-sidebar').on('click', function() {
         $('.wrapper').removeClass('sidebar_minimize');
         get_request_api('/user/mini-sidebar/set/false')
             .then((data) => {
-                if (data.success !== 'success') {
+                if (data.status !== 'success') {
                     notify_api_request_error(data);
                 }
             });
@@ -1711,7 +1711,7 @@ $('.toggle-sidebar').on('click', function() {
         $('.wrapper').addClass('sidebar_minimize');
         get_request_api('/user/mini-sidebar/set/true')
             .then((data) => {
-                if (data.success !== 'success') {
+                if (data.status !== 'success') {
                     notify_api_request_error(data);
                 }
             });


### PR DESCRIPTION
The sidebar collapse functionality incorrectly checked if the `success` parameter in the response was equal to `success` (instead of the `status` parameter) causing it to display an error every time the sidebar toggle was used.