### PR TITLE
[IMP] Add build configs in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       file: docker-compose.base.yml
       service: db
     image: ${DB_IMAGE_NAME:-ghcr.io/dfir-iris/iriswebapp_db}:${DB_IMAGE_TAG:-v2.4.20}
+    build: docker/db/
 
 
   app:
@@ -33,12 +34,19 @@ services:
       file: docker-compose.base.yml
       service: app
     image: ${APP_IMAGE_NAME:-ghcr.io/dfir-iris/iriswebapp_app}:${APP_IMAGE_TAG:-v2.4.20}
+    build:
+      context: .
+      dockerfile: docker/webApp/Dockerfile
+
 
   worker:
     extends:
       file: docker-compose.base.yml
       service: worker
     image: ${APP_IMAGE_NAME:-ghcr.io/dfir-iris/iriswebapp_app}:${APP_IMAGE_TAG:-v2.4.20}
+    build:
+      context: .
+      dockerfile: docker/webApp/Dockerfile
 
 
   nginx:
@@ -46,6 +54,11 @@ services:
       file: docker-compose.base.yml
       service: nginx
     image: ${NGINX_IMAGE_NAME:-ghcr.io/dfir-iris/iriswebapp_nginx}:${NGINX_IMAGE_TAG:-v2.4.20}
+    build:
+      context: docker/nginx/
+      args:
+        NGINX_CONF_GID: 1234
+        NGINX_CONF_FILE: nginx.conf
 
 
 volumes:


### PR DESCRIPTION
Having the option to easily build the containers locally is beneficial in various circumstances (e.g., newer versions of the base containers are required).

The ability to download the container images using the `pull` command is not affected by this change.

The IRIS already mention using `docker compose pull` before using `docker compose up` to start the containers, so users who follow the guide should not be affected.