### PR TITLE
Test reactivation: race condition with celery queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,14 @@ jobs:
           # TODO should move basic.env file, which is in directory tests, up. It's used in several places. Maybe, rename it into dev.env
           cp tests/data/basic.env .env
           docker compose --file docker-compose.dev.yml up --detach --wait
+      - name: Inspect development server start failure
+        if: ${{ failure() || cancelled() }}
+        run: |
+          docker ps --all
+          docker inspect --format "{{json .State}}" iriswebapp_db | jq
+          docker inspect --format "{{json .State}}" iriswebapp_nginx | jq
+          docker inspect --format "{{json .State}}" iriswebapp_app | jq
+          docker compose logs
       - name: Run tests
         working-directory: tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           # Even though, we use --env-file option when running docker compose, this is still necessary, because the compose has a env_file attribute :(
           # TODO should move basic.env file, which is in directory tests, up. It's used in several places. Maybe, rename it into dev.env
           cp tests/data/basic.env .env
-          docker compose --file docker-compose.dev.yml --env-file tests/data/basic.env up --detach
+          docker compose --file docker-compose.dev.yml --env-file tests/data/basic.env up --detach --wait
       - name: Generate GraphQL documentation
         run: |
           npx spectaql@^3.0.2 source/spectaql/config.yml
@@ -167,7 +167,7 @@ jobs:
           # Even though, we use --env-file option when running docker compose, this is still necessary, because the compose has a env_file attribute :(
           # TODO should move basic.env file, which is in directory tests, up. It's used in several places. Maybe, rename it into dev.env
           cp tests/data/basic.env .env
-          docker compose --file docker-compose.dev.yml up --detach
+          docker compose --file docker-compose.dev.yml up --detach --wait
       - name: Run tests
         working-directory: tests
         run: |
@@ -254,7 +254,7 @@ jobs:
         run: |
           # TODO should move basic.env file, which is in directory tests, up. It's used in several places. Maybe, rename it into dev.env
           cp tests/data/basic.env .env
-          docker compose --file docker-compose.dev.yml up --detach
+          docker compose --file docker-compose.dev.yml up --detach --wait
       - name: Run end to end tests
         working-directory: e2e
         run: npx playwright test

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -19,13 +19,11 @@ services:
   rabbitmq:
     image: rabbitmq:3-management-alpine
     container_name: iriswebapp_rabbitmq
-    restart: always
     networks:
       - iris_backend
 
   db:
     container_name: iriswebapp_db
-    restart: always
     environment:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
@@ -46,7 +44,6 @@ services:
       - iris-downloads:/home/iris/downloads
       - user_templates:/home/iris/user_templates
       - server_data:/home/iris/server_data
-    restart: always
     depends_on:
       - "rabbitmq"
       - "db"
@@ -68,7 +65,6 @@ services:
 
   worker:
     container_name: iriswebapp_worker
-    restart: always
     command:
       [
         "./wait-for-iriswebapp.sh",
@@ -120,7 +116,6 @@ services:
       - "${INTERFACE_HTTPS_PORT:-443}:${INTERFACE_HTTPS_PORT:-443}"
     volumes:
       - "./certificates/web_certificates/:/www/certs/:ro"
-    restart: always
     depends_on:
       - "app"
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
       service: rabbitmq
     user: rabbitmq
     healthcheck:
-      test: rabbitmq-diagnostics check_port_connectivityAdd commentMore actions
+      test: rabbitmq-diagnostics check_port_connectivity || exit 1
       start_period: 60s
       start_interval: 1s
 
@@ -36,7 +36,7 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     healthcheck:
-      test: pg_isready -U postgres -d iris_db
+      test: pg_isready -U postgres -d iris_db || exit 1
       start_period: 60s
       start_interval: 1s
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,10 @@ services:
       file: docker-compose.base.yml
       service: rabbitmq
     user: rabbitmq
+    healthcheck:
+      test: rabbitmq-diagnostics check_port_connectivityAdd commentMore actions
+      start_period: 60s
+      start_interval: 1s
 
   db:
     extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -80,6 +80,10 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+    healthcheck:
+      test: celery -A app.celery inspect ping || exit 1
+      start_period: 60s
+      start_interval: 1s
 
   nginx:
     extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,6 +53,11 @@ services:
     volumes:
       - ./source/app:/iriswebapp/app
       - ./ui/dist:/iriswebapp/static
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
     healthcheck:
       test: curl --head --fail http://localhost:8000 || exit 1
       start_period: 60s
@@ -68,6 +73,13 @@ services:
     image: iriswebapp_app:develop
     volumes:
       - ./source/app:/iriswebapp/app
+    depends_on:
+      app:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
 
   nginx:
     extends:
@@ -79,6 +91,11 @@ services:
         NGINX_CONF_GID: 1234
         NGINX_CONF_FILE: ${NGINX_CONF_FILE:-nginx.conf}
     image: iriswebapp_nginx:develop
+    depends_on:
+      app:
+        condition: service_healthy
+      worker:
+        condition: service_healthy
 
   frontend:
     image: node:23-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     extends:
       file: docker-compose.base.yml
       service: rabbitmq
+    restart: always
+
 
   db:
     extends:
@@ -27,6 +29,7 @@ services:
       service: db
     image: ${DB_IMAGE_NAME:-ghcr.io/dfir-iris/iriswebapp_db}:${DB_IMAGE_TAG:-v2.4.20}
     build: docker/db/
+    restart: always
 
 
   app:
@@ -37,6 +40,7 @@ services:
     build:
       context: .
       dockerfile: docker/webApp/Dockerfile
+    restart: always
 
 
   worker:
@@ -47,6 +51,7 @@ services:
     build:
       context: .
       dockerfile: docker/webApp/Dockerfile
+    restart: always
 
 
   nginx:
@@ -59,6 +64,7 @@ services:
       args:
         NGINX_CONF_GID: 1234
         NGINX_CONF_FILE: nginx.conf
+    restart: always
 
 
 volumes:

--- a/tests/docker_compose.py
+++ b/tests/docker_compose.py
@@ -18,8 +18,6 @@
 
 import subprocess
 
-_DOCKER_COMPOSE = ['docker', 'compose']
-
 
 class DockerCompose:
 
@@ -27,12 +25,6 @@ class DockerCompose:
         self._docker_compose_path = docker_compose_path
         self._docker_compose_file = docker_compose_file
 
-    def start(self):
-        subprocess.check_call(_DOCKER_COMPOSE + ['-f', self._docker_compose_file, 'up', '--detach'], cwd=self._docker_compose_path)
-
     def extract_logs(self, service):
-        return subprocess.check_output(_DOCKER_COMPOSE + ['-f', self._docker_compose_file, 'logs', '--no-color', service],
+        return subprocess.check_output(['docker', 'compose', '-f', self._docker_compose_file, 'logs', '--no-color', service],
                                        cwd=self._docker_compose_path, universal_newlines=True)
-
-    def stop(self):
-        subprocess.check_call(_DOCKER_COMPOSE + ['-f', self._docker_compose_file, 'down', '--volumes'], cwd=self._docker_compose_path)

--- a/tests/tests_rest_miscellaneous.py
+++ b/tests/tests_rest_miscellaneous.py
@@ -17,7 +17,6 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from unittest import TestCase
-from unittest import skip
 from iris import Iris
 
 from time import sleep
@@ -72,7 +71,6 @@ class TestsRestMiscellaneous(TestCase):
     #      - then it gets the Celery 'on_postload_case_create' task and merges the incoming case data with the state of database
     #        since, by then, the case has already been removed from database, on the identifier and the fields with a server_default are filled
     #        in particulier, client_id is None, and the code fails during the commit
-    @skip
     def test_delete_case_should_set_module_state_to_success(self):
         response = self._subject.get('/manage/modules/list').json()
         module_identifier = None


### PR DESCRIPTION
* put back test which was previously skipped before of race condition, when the workers are slow to start
* added healthchecks to services in the dev docker-compose and depends conditioned on the fact that services are healthy (maybe this could be put in the base docker-compose, as this might also be useful in production)
* moved restart always policy down into the production docker compose, as I prefer to see and investigate failures when they happen during testing
* wait for dockers to be healthy whenever starting the docker compose in any of the tests of the CI