### PR TITLE
Api v2 create note directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,14 @@ jobs:
           # TODO should move basic.env file, which is in directory tests, up. It's used in several places. Maybe, rename it into dev.env
           cp tests/data/basic.env .env
           docker compose --file docker-compose.dev.yml up --detach --wait
+      - name: Inspect development server start failure
+        if: ${{ failure() || cancelled() }}
+        run: |
+          docker ps --all
+          docker inspect --format "{{json .State}}" iriswebapp_db | jq
+          docker inspect --format "{{json .State}}" iriswebapp_nginx | jq
+          docker inspect --format "{{json .State}}" iriswebapp_app | jq
+          docker compose logs
       - name: Run tests
         working-directory: tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           # Even though, we use --env-file option when running docker compose, this is still necessary, because the compose has a env_file attribute :(
           # TODO should move basic.env file, which is in directory tests, up. It's used in several places. Maybe, rename it into dev.env
           cp tests/data/basic.env .env
-          docker compose --file docker-compose.dev.yml --env-file tests/data/basic.env up --detach
+          docker compose --file docker-compose.dev.yml --env-file tests/data/basic.env up --detach --wait
       - name: Generate GraphQL documentation
         run: |
           npx spectaql@^3.0.2 source/spectaql/config.yml
@@ -167,7 +167,7 @@ jobs:
           # Even though, we use --env-file option when running docker compose, this is still necessary, because the compose has a env_file attribute :(
           # TODO should move basic.env file, which is in directory tests, up. It's used in several places. Maybe, rename it into dev.env
           cp tests/data/basic.env .env
-          docker compose --file docker-compose.dev.yml up --detach
+          docker compose --file docker-compose.dev.yml up --detach --wait
       - name: Run tests
         working-directory: tests
         run: |
@@ -254,7 +254,7 @@ jobs:
         run: |
           # TODO should move basic.env file, which is in directory tests, up. It's used in several places. Maybe, rename it into dev.env
           cp tests/data/basic.env .env
-          docker compose --file docker-compose.dev.yml up --detach
+          docker compose --file docker-compose.dev.yml up --detach --wait
       - name: Run end to end tests
         working-directory: e2e
         run: npx playwright test

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -19,13 +19,11 @@ services:
   rabbitmq:
     image: rabbitmq:3-management-alpine
     container_name: iriswebapp_rabbitmq
-    restart: always
     networks:
       - iris_backend
 
   db:
     container_name: iriswebapp_db
-    restart: always
     environment:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
@@ -46,7 +44,6 @@ services:
       - iris-downloads:/home/iris/downloads
       - user_templates:/home/iris/user_templates
       - server_data:/home/iris/server_data
-    restart: always
     depends_on:
       - "rabbitmq"
       - "db"
@@ -68,7 +65,6 @@ services:
 
   worker:
     container_name: iriswebapp_worker
-    restart: always
     command:
       [
         "./wait-for-iriswebapp.sh",
@@ -120,7 +116,6 @@ services:
       - "${INTERFACE_HTTPS_PORT:-443}:${INTERFACE_HTTPS_PORT:-443}"
     volumes:
       - "./certificates/web_certificates/:/www/certs/:ro"
-    restart: always
     depends_on:
       - "app"
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
       service: rabbitmq
     user: rabbitmq
     healthcheck:
-      test: rabbitmq-diagnostics check_port_connectivityAdd commentMore actions
+      test: rabbitmq-diagnostics check_port_connectivity || exit 1
       start_period: 60s
       start_interval: 1s
 
@@ -36,7 +36,7 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     healthcheck:
-      test: pg_isready -U postgres -d iris_db
+      test: pg_isready -U postgres -d iris_db || exit 1
       start_period: 60s
       start_interval: 1s
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,10 @@ services:
       file: docker-compose.base.yml
       service: rabbitmq
     user: rabbitmq
+    healthcheck:
+      test: rabbitmq-diagnostics check_port_connectivityAdd commentMore actions
+      start_period: 60s
+      start_interval: 1s
 
   db:
     extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -80,6 +80,10 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+    healthcheck:
+      test: celery -A app.celery inspect ping || exit 1
+      start_period: 60s
+      start_interval: 1s
 
   nginx:
     extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,6 +53,11 @@ services:
     volumes:
       - ./source/app:/iriswebapp/app
       - ./ui/dist:/iriswebapp/static
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
     healthcheck:
       test: curl --head --fail http://localhost:8000 || exit 1
       start_period: 60s
@@ -68,6 +73,13 @@ services:
     image: iriswebapp_app:develop
     volumes:
       - ./source/app:/iriswebapp/app
+    depends_on:
+      app:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
 
   nginx:
     extends:
@@ -79,6 +91,11 @@ services:
         NGINX_CONF_GID: 1234
         NGINX_CONF_FILE: ${NGINX_CONF_FILE:-nginx.conf}
     image: iriswebapp_nginx:develop
+    depends_on:
+      app:
+        condition: service_healthy
+      worker:
+        condition: service_healthy
 
   frontend:
     image: node:23-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     extends:
       file: docker-compose.base.yml
       service: rabbitmq
+    restart: always
+
 
   db:
     extends:
@@ -27,6 +29,7 @@ services:
       service: db
     image: ${DB_IMAGE_NAME:-ghcr.io/dfir-iris/iriswebapp_db}:${DB_IMAGE_TAG:-v2.4.20}
     build: docker/db/
+    restart: always
 
 
   app:
@@ -37,6 +40,7 @@ services:
     build:
       context: .
       dockerfile: docker/webApp/Dockerfile
+    restart: always
 
 
   worker:
@@ -47,6 +51,7 @@ services:
     build:
       context: .
       dockerfile: docker/webApp/Dockerfile
+    restart: always
 
 
   nginx:
@@ -59,6 +64,7 @@ services:
       args:
         NGINX_CONF_GID: 1234
         NGINX_CONF_FILE: nginx.conf
+    restart: always
 
 
 volumes:

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -212,6 +212,7 @@ def case_note_add(caseid):
 
 
 @case_notes_rest_blueprint.route('/case/notes/directories/add', methods=['POST'])
+@endpoint_deprecated('POST', '/api/v2/cases/{case_identifier}/notes-directories')
 @ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_directory_add(caseid):

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -203,7 +203,8 @@ def case_note_add(caseid):
 
     try:
 
-        note = notes_create(request_json=request.get_json(), case_identifier=caseid)
+        request_data = call_modules_hook('on_preload_note_create', data=request.get_json(), caseid=caseid)
+        note = notes_create(request_data, caseid)
 
         return response_success(f"Note ID {note.note_id} created", data=addnote_schema.dump(note))
 

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -16,7 +16,7 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import marshmallow
+from marshmallow import ValidationError
 from datetime import datetime
 from flask import Blueprint
 from flask import request
@@ -109,7 +109,7 @@ def case_note_detail(cur_id, caseid):
 
         return response_success(data=note)
 
-    except marshmallow.exceptions.ValidationError as e:
+    except ValidationError as e:
         return response_error(msg="Data error", data=e.messages)
 
 
@@ -204,9 +204,16 @@ def case_note_add(caseid):
     try:
 
         request_data = call_modules_hook('on_preload_note_create', data=request.get_json(), caseid=caseid)
-        note = notes_create(request_data, caseid)
+        note_schema = CaseNoteSchema()
+        note_schema.verify_directory_id(request_data, caseid=caseid)
+
+        note = note_schema.load(request_data)
+        note = notes_create(note, caseid)
 
         return response_success(f"Note ID {note.note_id} created", data=addnote_schema.dump(note))
+
+    except ValidationError as e:
+        raise BusinessProcessingError('Data error', e.messages)
 
     except BusinessProcessingError as e:
         return response_error(e.get_message(), data=e.get_data())
@@ -236,7 +243,7 @@ def case_directory_add(caseid):
         track_activity(f"added directory \"{new_directory.name}\"", caseid=caseid)
         return response_success('Directory added', data=directory_schema.dump(new_directory))
 
-    except marshmallow.exceptions.ValidationError as e:
+    except ValidationError as e:
         return response_error(msg="Data error", data=e.messages)
 
 
@@ -266,7 +273,7 @@ def case_directory_update(dir_id, caseid):
         track_activity(f"modified directory \"{new_directory.name}\"", caseid=caseid)
         return response_success('Directory modified', data=directory_schema.dump(new_directory))
 
-    except marshmallow.exceptions.ValidationError as e:
+    except ValidationError as e:
         return response_error(msg="Data error", data=e.messages)
 
     except Exception as e:
@@ -292,7 +299,7 @@ def case_directory_delete(dir_id, caseid):
 
         return response_error('Unable to delete directory')
 
-    except marshmallow.exceptions.ValidationError as e:
+    except ValidationError as e:
         return response_error(msg="Data error", data=e.messages)
 
 
@@ -419,7 +426,7 @@ def case_comment_note_add(cur_id, caseid):
         track_activity(f"note \"{note.note_title}\" commented", caseid=caseid)
         return response_success("Note commented", data=comment_schema.dump(comment))
 
-    except marshmallow.exceptions.ValidationError as e:
+    except ValidationError as e:
         return response_error(msg="Data error", data=e.normalized_messages())
 
 

--- a/source/app/blueprints/rest/v2/case_objects/notes.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes.py
@@ -60,7 +60,7 @@ class NotesCRUD:
             return ac_api_return_access_denied(caseid=case_identifier)
 
         try:
-            request_data = call_deprecated_on_preload_modules_hook('note_create',request.get_json(),
+            request_data = call_deprecated_on_preload_modules_hook('note_create', request.get_json(),
                                                                    case_identifier)
 
             note_schema = CaseNoteSchema()

--- a/source/app/blueprints/rest/v2/case_objects/notes.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes.py
@@ -60,8 +60,8 @@ class NotesCRUD:
             return ac_api_return_access_denied(caseid=case_identifier)
 
         try:
-            request_data = call_deprecated_on_preload_modules_hook('on_preload_note_create',
-                                                                   request.get_json(), case_identifier)
+            request_data = call_deprecated_on_preload_modules_hook('note_create',request.get_json(),
+                                                                   case_identifier)
 
             note_schema = CaseNoteSchema()
             note_schema.verify_directory_id(request_data, caseid=case_identifier)

--- a/source/app/blueprints/rest/v2/case_objects/notes.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes.py
@@ -37,6 +37,7 @@ from app.business.notes import notes_delete
 from app.business.cases import cases_exists
 from app.business.errors import BusinessProcessingError
 from app.business.errors import ObjectNotFoundError
+from app.iris_engine.module_handler.module_handler import call_deprecated_on_preload_modules_hook
 
 
 class NotesCRUD:
@@ -52,7 +53,9 @@ class NotesCRUD:
             return ac_api_return_access_denied(caseid=case_identifier)
 
         try:
-            note = notes_create(request.get_json(), case_identifier)
+            request_data = call_deprecated_on_preload_modules_hook('on_preload_note_create',
+                                                                   request.get_json(), case_identifier)
+            note = notes_create(request_data, case_identifier)
 
             return response_api_created(self._schema.dump(note))
 

--- a/source/app/blueprints/rest/v2/case_objects/notes.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes.py
@@ -54,7 +54,7 @@ def create_note(case_identifier):
         return ac_api_return_access_denied(caseid=case_identifier)
 
     try:
-        note = notes_create(request_json=request.get_json(), case_identifier=case_identifier)
+        note = notes_create(request.get_json(), case_identifier)
 
         schema = CaseNoteSchema()
         return response_api_created(schema.dump(note))

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -41,6 +41,8 @@ class NotesDirectories:
         request_data['case_id'] = case_identifier
 
         try:
+            if request_data.get('parent_id') is not None:
+                self._schema.verify_parent_id(request_data['parent_id'], case_id=case_identifier)
             directory = self._load(request_data)
 
             notes_directory_create(directory)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -42,6 +42,7 @@ class NotesDirectories:
 
     def create(self, case_identifier):
         request_data = request.get_json()
+        request_data.pop('id')
         request_data['case_id'] = case_identifier
         directory = self._load(request_data)
         notes_directory_create(directory)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -22,14 +22,7 @@ from flask import request
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import response_api_created
 from app.schema.marshables import CaseNoteDirectorySchema
-
-from app import db
-from app.iris_engine.utils.tracker import track_activity
-
-
-def notes_directory_create(directory):
-    db.session.add(directory)
-    db.session.commit()
+from app.business.notes_directories import notes_directory_create
 
 
 class NotesDirectories:
@@ -42,13 +35,13 @@ class NotesDirectories:
 
     def create(self, case_identifier):
         request_data = request.get_json()
-        request_data.pop('id')
+        request_data.pop('id', None)
         request_data['case_id'] = case_identifier
         directory = self._load(request_data)
+
         notes_directory_create(directory)
         result = self._schema.dump(directory)
 
-        track_activity(f"added directory '{directory.name}'", caseid=case_identifier)
         return response_api_created(result)
 
 

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -1,0 +1,38 @@
+#  IRIS Source Code
+#  Copyright (C) 2024 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from flask import Blueprint
+
+from app.blueprints.access_controls import ac_api_requires
+from app.blueprints.rest.endpoints import response_api_created
+
+
+class NotesDirectories:
+
+    def create(self, case_identifier):
+        return response_api_created(None)
+
+
+notes_directories = NotesDirectories()
+case_notes_directories_blueprint = Blueprint('case_notes_directoriesrest_v2', __name__, url_prefix='/<int:case_identifier>/notes-directories')
+
+
+@case_notes_directories_blueprint.post('')
+@ac_api_requires()
+def create_event(case_identifier):
+    return notes_directories.create(case_identifier)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -23,8 +23,10 @@ from marshmallow import ValidationError
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.endpoints import response_api_error
+from app.blueprints.rest.endpoints import response_api_not_found
 from app.schema.marshables import CaseNoteDirectorySchema
 from app.business.notes_directories import notes_directory_create
+from app.business.cases import cases_exists
 
 
 class NotesDirectories:
@@ -36,6 +38,9 @@ class NotesDirectories:
         return self._schema.load(request_data)
 
     def create(self, case_identifier):
+        if not cases_exists(case_identifier):
+            return response_api_not_found()
+
         request_data = request.get_json()
         request_data.pop('id', None)
         request_data['case_id'] = case_identifier

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -24,9 +24,12 @@ from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_not_found
+from app.blueprints.access_controls import ac_api_return_access_denied
 from app.schema.marshables import CaseNoteDirectorySchema
 from app.business.notes_directories import notes_directory_create
 from app.business.cases import cases_exists
+from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
+from app.models.authorization import CaseAccessLevel
 
 
 class NotesDirectories:
@@ -40,6 +43,8 @@ class NotesDirectories:
     def create(self, case_identifier):
         if not cases_exists(case_identifier):
             return response_api_not_found()
+        if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=case_identifier)
 
         request_data = request.get_json()
         request_data.pop('id', None)

--- a/source/app/blueprints/rest/v2/cases.py
+++ b/source/app/blueprints/rest/v2/cases.py
@@ -32,6 +32,7 @@ from app.blueprints.rest.parsing import parse_pagination_parameters
 from app.blueprints.rest.v2.case_objects.assets import case_assets_blueprint
 from app.blueprints.rest.v2.case_objects.iocs import case_iocs_blueprint
 from app.blueprints.rest.v2.case_objects.notes import case_notes_blueprint
+from app.blueprints.rest.v2.case_objects.notes_directories import case_notes_directories_blueprint
 from app.blueprints.rest.v2.case_objects.tasks import case_tasks_blueprint
 from app.blueprints.rest.v2.case_objects.evidences import case_evidences_blueprint
 from app.blueprints.rest.v2.case_objects.events import case_events_blueprint
@@ -56,6 +57,7 @@ cases_blueprint = Blueprint('cases',
                             url_prefix='/cases')
 cases_blueprint.register_blueprint(case_assets_blueprint)
 cases_blueprint.register_blueprint(case_iocs_blueprint)
+cases_blueprint.register_blueprint(case_notes_directories_blueprint)
 cases_blueprint.register_blueprint(case_notes_blueprint)
 cases_blueprint.register_blueprint(case_tasks_blueprint)
 cases_blueprint.register_blueprint(case_evidences_blueprint)

--- a/source/app/business/notes.py
+++ b/source/app/business/notes.py
@@ -36,21 +36,8 @@ from app.schema.marshables import CaseNoteSchema
 from app.util import add_obj_history_entry
 
 
-def _load(request_data):
+def notes_create(note: Notes, case_identifier):
     try:
-        note_schema = CaseNoteSchema()
-        return note_schema.load(request_data)
-    except ValidationError as e:
-        raise BusinessProcessingError('Data error', e.messages)
-
-
-def notes_create(request_data, case_identifier):
-    try:
-        note_schema = CaseNoteSchema()
-        note_schema.verify_directory_id(request_data, caseid=case_identifier)
-
-        note = _load(request_data)
-
         note.note_creationdate = datetime.utcnow()
         note.note_lastupdate = datetime.utcnow()
         note.note_user = iris_current_user.id
@@ -72,7 +59,7 @@ def notes_create(request_data, case_identifier):
         add_obj_history_entry(note, 'created note', commit=True)
         note = call_modules_hook('on_postload_note_create', data=note, caseid=case_identifier)
 
-        track_activity(f"created note \"{note.note_title}\"", caseid=case_identifier)
+        track_activity(f'created note "{note.note_title}"', caseid=case_identifier)
 
         return note
 

--- a/source/app/business/notes.py
+++ b/source/app/business/notes.py
@@ -44,15 +44,8 @@ def _load(request_data):
         raise BusinessProcessingError('Data error', e.messages)
 
 
-def notes_create(request_json, case_identifier):
-    """
-    Create a note.
-
-    :param request_json: The request data.
-    :param case_identifier: The case identifier.
-    """
+def notes_create(request_data, case_identifier):
     try:
-        request_data = call_modules_hook('on_preload_note_create', data=request_json, caseid=case_identifier)
         note_schema = CaseNoteSchema()
         note_schema.verify_directory_id(request_data, caseid=case_identifier)
 

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -1,0 +1,28 @@
+#  IRIS Source Code
+#  Copyright (C) 2024 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from app import db
+from app.iris_engine.utils.tracker import track_activity
+from app.models.models import NoteDirectory
+
+
+def notes_directory_create(directory: NoteDirectory):
+    db.session.add(directory)
+    db.session.commit()
+
+    track_activity(f'added directory "{directory.name}"', caseid=directory.case_id)

--- a/tests/docker_compose.py
+++ b/tests/docker_compose.py
@@ -18,8 +18,6 @@
 
 import subprocess
 
-_DOCKER_COMPOSE = ['docker', 'compose']
-
 
 class DockerCompose:
 
@@ -27,12 +25,6 @@ class DockerCompose:
         self._docker_compose_path = docker_compose_path
         self._docker_compose_file = docker_compose_file
 
-    def start(self):
-        subprocess.check_call(_DOCKER_COMPOSE + ['-f', self._docker_compose_file, 'up', '--detach'], cwd=self._docker_compose_path)
-
     def extract_logs(self, service):
-        return subprocess.check_output(_DOCKER_COMPOSE + ['-f', self._docker_compose_file, 'logs', '--no-color', service],
+        return subprocess.check_output(['docker', 'compose', '-f', self._docker_compose_file, 'logs', '--no-color', service],
                                        cwd=self._docker_compose_path, universal_newlines=True)
-
-    def stop(self):
-        subprocess.check_call(_DOCKER_COMPOSE + ['-f', self._docker_compose_file, 'down', '--volumes'], cwd=self._docker_compose_path)

--- a/tests/tests_rest_miscellaneous.py
+++ b/tests/tests_rest_miscellaneous.py
@@ -17,7 +17,6 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from unittest import TestCase
-from unittest import skip
 from iris import Iris
 
 from time import sleep
@@ -72,7 +71,6 @@ class TestsRestMiscellaneous(TestCase):
     #      - then it gets the Celery 'on_postload_case_create' task and merges the incoming case data with the state of database
     #        since, by then, the case has already been removed from database, on the identifier and the fields with a server_default are filled
     #        in particulier, client_id is None, and the code fails during the commit
-    @skip
     def test_delete_case_should_set_module_state_to_success(self):
         response = self._subject.get('/manage/modules/list').json()
         module_identifier = None

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -33,3 +33,9 @@ class TestsRestNotesDirectories(TestCase):
         body = {'name': 'directory_name'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
         self.assertEqual(201, response.status_code)
+
+    def test_create_note_directory_should_set_name(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        self.assertEqual('directory_name', response['name'])

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -50,3 +50,9 @@ class TestsRestNotesDirectories(TestCase):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', {})
         self.assertEqual(400, response.status_code)
+
+    def test_create_note_directory_should_return_400_when_field_type_is_incorrect(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 10}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -45,3 +45,8 @@ class TestsRestNotesDirectories(TestCase):
         body = {'name': 'directory_name', 'id': 124}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
         self.assertEqual(201, response.status_code)
+
+    def test_create_note_directory_should_return_400_when_field_name_is_missing(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', {})
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -1,0 +1,35 @@
+#  IRIS Source Code
+#  Copyright (C) 2023 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from unittest import TestCase
+from iris import Iris
+
+
+class TestsRestNotesDirectories(TestCase):
+
+    def setUp(self) -> None:
+        self._subject = Iris()
+
+    def tearDown(self):
+        self._subject.clear_database()
+
+    def test_create_note_directory_should_return_201(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
+        self.assertEqual(201, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -19,6 +19,8 @@
 from unittest import TestCase
 from iris import Iris
 
+_IDENTIFIER_FOR_NONEXISTENT_OBJECT = 123456789
+
 
 class TestsRestNotesDirectories(TestCase):
 
@@ -54,5 +56,11 @@ class TestsRestNotesDirectories(TestCase):
     def test_create_note_directory_should_return_400_when_field_type_is_incorrect(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'name': 10}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
+        self.assertEqual(400, response.status_code)
+
+    def test_create_note_directory_should_return_400_when_parent_id_does_not_exist(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name', 'parent_id': _IDENTIFIER_FOR_NONEXISTENT_OBJECT}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
         self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -39,3 +39,9 @@ class TestsRestNotesDirectories(TestCase):
         body = {'name': 'directory_name'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
         self.assertEqual('directory_name', response['name'])
+
+    def test_create_note_directory_should_ignore_field_id_when_set(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name', 'id': 124}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
+        self.assertEqual(201, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -64,3 +64,8 @@ class TestsRestNotesDirectories(TestCase):
         body = {'name': 'directory_name', 'parent_id': _IDENTIFIER_FOR_NONEXISTENT_OBJECT}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
         self.assertEqual(400, response.status_code)
+
+    def test_create_note_directory_should_return_404_when_case_does_not_exist(self):
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes-directories', body)
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -69,3 +69,11 @@ class TestsRestNotesDirectories(TestCase):
         body = {'name': 'directory_name'}
         response = self._subject.create(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes-directories', body)
         self.assertEqual(404, response.status_code)
+
+    def test_create_note_directory_should_return_403_when_user_has_no_access_to_case(self):
+        case_identifier = self._subject.create_dummy_case()
+
+        user = self._subject.create_dummy_user()
+        body = {'name': 'directory_name'}
+        response = user.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
+        self.assertEqual(403, response.status_code)


### PR DESCRIPTION
* Implementation of `POST /api/v2/cases/{case_identifier}/notes-directories`
* Deprecated `POST /case/notes/directories/add`
* Started to make the notes endpoints look more uniform with events (no adherence to `marshmallow` in the business layer, and introduction of a class with the CRUD operations)

Notes:
* this PR goes hand in hand with the documentation [PR#69](https://github.com/dfir-iris/iris-doc-src/pull/69) in `iris-doc-src`
* this PR is built on a branch which follows [PR#851](/dfir-iris/iris-web/pull/851), so it's preferable to merge the other one before.