### PR TITLE
Api v2 get notes directories

### DIFF
--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -140,10 +140,16 @@ def case_note_save(cur_id, caseid):
 
     try:
         note = notes_get(cur_id)
-        note = notes_update(note, request.get_json())
+        request_data = call_modules_hook('on_preload_note_update', data=request.get_json(), caseid=note.note_case_id)
+
+        request_data['note_id'] = note.note_id
+        addnote_schema.load(request_data, partial=True, instance=note)
+        note = notes_update(note)
 
         return response_success(f"Note ID {cur_id} saved", data=addnote_schema.dump(note))
 
+    except ValidationError as e:
+        return response_error('Data error', e.messages)
     except BusinessProcessingError as e:
         return response_error(e.get_message(), data=e.get_data())
 

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -253,7 +253,7 @@ def case_directory_add(caseid):
 def case_directory_update(dir_id, caseid):
     try:
 
-        directory = get_directory(dir_id, caseid)
+        directory = get_directory(dir_id)
         if not directory:
             return response_error(msg="Invalid directory ID")
 
@@ -287,7 +287,7 @@ def case_directory_update(dir_id, caseid):
 def case_directory_delete(dir_id, caseid):
     try:
 
-        directory = get_directory(dir_id, caseid)
+        directory = get_directory(dir_id)
         if not directory:
             return response_error(msg="Invalid directory ID")
 

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -248,6 +248,7 @@ def case_directory_add(caseid):
 
 
 @case_notes_rest_blueprint.route('/case/notes/directories/update/<dir_id>', methods=['POST'])
+@endpoint_deprecated('PUT', '/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
 @ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_directory_update(dir_id, caseid):

--- a/source/app/blueprints/rest/v2/case_objects/notes.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes.py
@@ -123,7 +123,7 @@ class NotesOperations:
             note = notes_get(identifier)
             if not ac_fast_check_current_user_has_case_access(note.note_case_id, [CaseAccessLevel.full_access]):
                 return ac_api_return_access_denied(caseid=note.note_case_id)
-            _check_note_and_case_identifier_match(note, case_identifier)
+            self._check_note_and_case_identifier_match(note, case_identifier)
 
             notes_delete(note)
             return response_api_deleted()

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -76,6 +76,9 @@ class NotesDirectories:
     def get(self, case_identifier, identifier):
         if not cases_exists(case_identifier):
             return response_api_not_found()
+        if not ac_fast_check_current_user_has_case_access(case_identifier,
+                                                          [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=case_identifier)
 
         try:
             note_directory = notes_directories_get(identifier)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -73,6 +73,9 @@ class NotesDirectories:
         except ValidationError as e:
             return response_api_error('Data error', data=e.normalized_messages())
 
+    def get(self, case_identifier, identifier):
+        return response_api_success(None)
+
     def update(self, case_identifier, identifier):
         if not cases_exists(case_identifier):
             return response_api_not_found()
@@ -107,6 +110,12 @@ case_notes_directories_blueprint = Blueprint('case_notes_directories_rest_v2', _
 @ac_api_requires()
 def create_note_directory(case_identifier):
     return notes_directories.create(case_identifier)
+
+
+@case_notes_directories_blueprint.get('/<int:identifier>')
+@ac_api_requires()
+def get_note_directory(case_identifier, identifier):
+    return notes_directories.get(case_identifier, identifier)
 
 
 @case_notes_directories_blueprint.put('/<int:identifier>')

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -74,6 +74,9 @@ class NotesDirectories:
             return response_api_error('Data error', data=e.normalized_messages())
 
     def get(self, case_identifier, identifier):
+        if not cases_exists(case_identifier):
+            return response_api_not_found()
+
         try:
             note_directory = notes_directories_get(identifier)
 

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -74,7 +74,10 @@ class NotesDirectories:
             return response_api_error('Data error', data=e.normalized_messages())
 
     def get(self, case_identifier, identifier):
-        return response_api_success(None)
+        note_directory = notes_directories_get(identifier)
+
+        result = self._schema.dump(note_directory)
+        return response_api_success(result)
 
     def update(self, case_identifier, identifier):
         if not cases_exists(case_identifier):

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -69,10 +69,13 @@ class NotesDirectories:
         directory = notes_directories_get(identifier)
         request_data = request.get_json()
 
-        new_directory = self._load(request_data, instance=directory, partial=True)
-        notes_directories_update(new_directory)
-        result = self._schema.dump(new_directory)
-        return response_api_success(result)
+        try:
+            new_directory = self._load(request_data, instance=directory, partial=True)
+            notes_directories_update(new_directory)
+            result = self._schema.dump(new_directory)
+            return response_api_success(result)
+        except ValidationError as e:
+            return response_api_error('Data error', data=e.normalized_messages())
 
 
 notes_directories = NotesDirectories()

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -22,6 +22,7 @@ from marshmallow import ValidationError
 
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import response_api_created
+from app.blueprints.rest.endpoints import response_api_success
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_not_found
 from app.blueprints.access_controls import ac_api_return_access_denied
@@ -62,6 +63,9 @@ class NotesDirectories:
         except ValidationError as e:
             return response_api_error('Data error', data=e.normalized_messages())
 
+    def update(self, case_identifier, identifier):
+        return response_api_success(None)
+
 
 notes_directories = NotesDirectories()
 case_notes_directories_blueprint = Blueprint('case_notes_directories_rest_v2', __name__, url_prefix='/<int:case_identifier>/notes-directories')
@@ -69,5 +73,11 @@ case_notes_directories_blueprint = Blueprint('case_notes_directories_rest_v2', _
 
 @case_notes_directories_blueprint.post('')
 @ac_api_requires()
-def create_event(case_identifier):
+def create_note_directory(case_identifier):
     return notes_directories.create(case_identifier)
+
+
+@case_notes_directories_blueprint.put('/<int:identifier>')
+@ac_api_requires()
+def update_note_directory(case_identifier, identifier):
+    return notes_directories.update(case_identifier, identifier)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -66,7 +66,7 @@ class NotesDirectories:
             return response_api_error('Data error', data=e.normalized_messages())
 
     def update(self, case_identifier, identifier):
-        directory = notes_directories_get(identifier, case_identifier)
+        directory = notes_directories_get(identifier)
         request_data = request.get_json()
 
         new_directory = self._load(request_data, instance=directory, partial=True)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -69,6 +69,8 @@ class NotesDirectories:
     def update(self, case_identifier, identifier):
         if not cases_exists(case_identifier):
             return response_api_not_found()
+        if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=case_identifier)
 
         try:
             directory = notes_directories_get(identifier)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -66,6 +66,9 @@ class NotesDirectories:
             return response_api_error('Data error', data=e.normalized_messages())
 
     def update(self, case_identifier, identifier):
+        if not cases_exists(case_identifier):
+            return response_api_not_found()
+
         directory = notes_directories_get(identifier)
         request_data = request.get_json()
 

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -74,10 +74,13 @@ class NotesDirectories:
             return response_api_error('Data error', data=e.normalized_messages())
 
     def get(self, case_identifier, identifier):
-        note_directory = notes_directories_get(identifier)
+        try:
+            note_directory = notes_directories_get(identifier)
 
-        result = self._schema.dump(note_directory)
-        return response_api_success(result)
+            result = self._schema.dump(note_directory)
+            return response_api_success(result)
+        except ObjectNotFoundError:
+            return response_api_not_found()
 
     def update(self, case_identifier, identifier):
         if not cases_exists(case_identifier):

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -70,6 +70,8 @@ class NotesDirectories:
         request_data = request.get_json()
 
         try:
+            if request_data.get('parent_id') is not None:
+                self._schema.verify_parent_id(request_data['parent_id'], case_id=case_identifier, current_id=identifier)
             new_directory = self._load(request_data, instance=directory, partial=True)
             notes_directories_update(new_directory)
             result = self._schema.dump(new_directory)

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -23,7 +23,6 @@ from app.datamgmt.case.case_notes_db import get_directory
 from app.business.errors import ObjectNotFoundError
 
 
-
 def notes_directories_create(directory: NoteDirectory):
     db.session.add(directory)
     db.session.commit()

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -30,8 +30,8 @@ def notes_directories_create(directory: NoteDirectory):
     track_activity(f'added directory "{directory.name}"', caseid=directory.case_id)
 
 
-def notes_directories_get(identifier, case_identifier) -> NoteDirectory:
-    directory = get_directory(identifier, case_identifier)
+def notes_directories_get(identifier) -> NoteDirectory:
+    directory = get_directory(identifier)
     if not directory:
         raise ObjectNotFoundError()
     return directory

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -38,13 +38,6 @@ def notes_directories_get(identifier) -> NoteDirectory:
     return directory
 
 
-def notes_directories_get_in_case(identifier, case_identifier) -> NoteDirectory:
-    directory = notes_directories_get(identifier)
-    if directory.case_id != case_identifier:
-        raise BusinessProcessingError(f'Note directory {directory.id} does not belong to case {case_identifier}')
-    return directory
-
-
 def notes_directories_update(directory: NoteDirectory):
     db.session.commit()
 

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -19,10 +19,24 @@
 from app import db
 from app.iris_engine.utils.tracker import track_activity
 from app.models.models import NoteDirectory
+from app.datamgmt.case.case_notes_db import get_directory
+from app.business.errors import ObjectNotFoundError
 
 
-def notes_directory_create(directory: NoteDirectory):
+
+def notes_directories_create(directory: NoteDirectory):
     db.session.add(directory)
     db.session.commit()
 
     track_activity(f'added directory "{directory.name}"', caseid=directory.case_id)
+
+
+def notes_directories_get(identifier, case_identifier) -> NoteDirectory:
+    directory = get_directory(identifier, case_identifier)
+    if not directory:
+        raise ObjectNotFoundError()
+    return directory
+
+
+def notes_directories_update(directory: NoteDirectory):
+    db.session.commit()

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -21,7 +21,6 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.models import NoteDirectory
 from app.datamgmt.case.case_notes_db import get_directory
 from app.business.errors import ObjectNotFoundError
-from app.business.errors import BusinessProcessingError
 
 
 def notes_directories_create(directory: NoteDirectory):

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -21,6 +21,7 @@ from app.iris_engine.utils.tracker import track_activity
 from app.models.models import NoteDirectory
 from app.datamgmt.case.case_notes_db import get_directory
 from app.business.errors import ObjectNotFoundError
+from app.business.errors import BusinessProcessingError
 
 
 def notes_directories_create(directory: NoteDirectory):
@@ -34,6 +35,13 @@ def notes_directories_get(identifier) -> NoteDirectory:
     directory = get_directory(identifier)
     if not directory:
         raise ObjectNotFoundError()
+    return directory
+
+
+def notes_directories_get_in_case(identifier, case_identifier) -> NoteDirectory:
+    directory = notes_directories_get(identifier)
+    if directory.case_id != case_identifier:
+        raise BusinessProcessingError(f'Note directory {directory.id} does not belong to case {case_identifier}')
     return directory
 
 

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -39,3 +39,5 @@ def notes_directories_get(identifier) -> NoteDirectory:
 
 def notes_directories_update(directory: NoteDirectory):
     db.session.commit()
+
+    track_activity(f'modified directory "{directory.name}"', caseid=directory.case_id)

--- a/source/app/datamgmt/case/case_notes_db.py
+++ b/source/app/datamgmt/case/case_notes_db.py
@@ -39,13 +39,10 @@ def get_note(note_id):
     return note
 
 
-def get_directory(directory_id, caseid):
-    directory = NoteDirectory.query.filter(and_(
-        NoteDirectory.id == directory_id,
-        NoteDirectory.case_id == caseid
+def get_directory(directory_id):
+    return NoteDirectory.query.filter(and_(
+        NoteDirectory.id == directory_id
     )).first()
-
-    return directory
 
 
 def delete_directory(directory, caseid):

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -128,3 +128,12 @@ class TestsRestNotesDirectories(TestCase):
         body = {'parent_id': identifier}
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body)
         self.assertEqual(400, response.status_code)
+
+    def test_update_note_directory_should_return_404_when_case_identifier_does_not_correspond_to_existing_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        response = self._subject.update(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes-directories/{identifier}', {})
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -78,7 +78,7 @@ class TestsRestNotesDirectories(TestCase):
         response = user.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
         self.assertEqual(403, response.status_code)
 
-    def test_get_not_directory_should_return_200(self):
+    def test_get_note_directory_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'name': 'directory_name'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
@@ -87,7 +87,7 @@ class TestsRestNotesDirectories(TestCase):
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
         self.assertEqual(200, response.status_code)
 
-    def test_get_not_directory_should_return_field_name(self):
+    def test_get_note_directory_should_return_field_name(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'name': 'directory_name'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
@@ -109,6 +109,16 @@ class TestsRestNotesDirectories(TestCase):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)
+
+    def test_get_note_directory_should_return_403_when_user_has_no_permission_to_access_to_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        user = self._subject.create_dummy_user()
+        response = user.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
+        self.assertEqual(403, response.status_code)
 
     def test_update_note_directory_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -118,3 +118,13 @@ class TestsRestNotesDirectories(TestCase):
         body = {'name': 123}
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body)
         self.assertEqual(400, response.status_code)
+
+    def test_update_note_directory_should_return_400_when_field_parent_id_is_the_current_identifier(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        body = {'parent_id': identifier}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body)
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -84,8 +84,7 @@ class TestsRestNotesDirectories(TestCase):
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
         identifier = response['id']
 
-        body = {}
-        response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body)
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', {})
         self.assertEqual(200, response.status_code)
 
     def test_update_note_directory_should_modify_name(self):
@@ -97,3 +96,15 @@ class TestsRestNotesDirectories(TestCase):
         body = {'name': 'new name'}
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body).json()
         self.assertEqual('new name', response['name'])
+
+    def test_update_note_directory_should_add_an_activity(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        body = {'name': 'new name'}
+        self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body)
+        activities = self._subject.get('/case/activities/list', {'cid': case_identifier}).json()
+        last_activity = activities['data'][0]['activity_desc']
+        self.assertEqual('Modified directory "new name"', last_activity)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -87,6 +87,15 @@ class TestsRestNotesDirectories(TestCase):
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
         self.assertEqual(200, response.status_code)
 
+    def test_get_not_directory_should_return_field_name(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}').json()
+        self.assertEqual('directory_name', response['name'])
+
     def test_update_note_directory_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'name': 'directory_name'}

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -153,3 +153,13 @@ class TestsRestNotesDirectories(TestCase):
         user = self._subject.create_dummy_user()
         response = user.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', {})
         self.assertEqual(403, response.status_code)
+
+    def test_update_note_directory_should_return_400_when_case_identifier_does_not_match_note_directory_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        case_identifier2 = self._subject.create_dummy_case()
+        response = self._subject.update(f'/api/v2/cases/{case_identifier2}/notes-directories/{identifier}', {})
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -137,3 +137,10 @@ class TestsRestNotesDirectories(TestCase):
 
         response = self._subject.update(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes-directories/{identifier}', {})
         self.assertEqual(404, response.status_code)
+
+    def test_update_note_directory_should_return_404_when_identifier_does_not_correspond_to_existing_note_directory(self):
+        case_identifier = self._subject.create_dummy_case()
+
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', {})
+        self.assertEqual(404, response.status_code)
+

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -144,3 +144,12 @@ class TestsRestNotesDirectories(TestCase):
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}', {})
         self.assertEqual(404, response.status_code)
 
+    def test_update_note_directory_should_return_403_when_user_has_no_access_to_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        user = self._subject.create_dummy_user()
+        response = user.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', {})
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -120,6 +120,16 @@ class TestsRestNotesDirectories(TestCase):
         response = user.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
         self.assertEqual(403, response.status_code)
 
+    def test_get_note_directory_should_return_400_when_case_identifier_does_not_match_event_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        case_identifier2 = self._subject.create_dummy_case()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier2}/notes-directories/{identifier}')
+        self.assertEqual(400, response.status_code)
+
     def test_update_note_directory_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'name': 'directory_name'}

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -120,7 +120,7 @@ class TestsRestNotesDirectories(TestCase):
         response = user.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
         self.assertEqual(403, response.status_code)
 
-    def test_get_note_directory_should_return_400_when_case_identifier_does_not_match_event_case(self):
+    def test_get_note_directory_should_return_404_when_case_identifier_does_not_match_event_case(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'name': 'directory_name'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
@@ -128,7 +128,7 @@ class TestsRestNotesDirectories(TestCase):
 
         case_identifier2 = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier2}/notes-directories/{identifier}')
-        self.assertEqual(400, response.status_code)
+        self.assertEqual(404, response.status_code)
 
     def test_update_note_directory_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
@@ -206,7 +206,7 @@ class TestsRestNotesDirectories(TestCase):
         response = user.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', {})
         self.assertEqual(403, response.status_code)
 
-    def test_update_note_directory_should_return_400_when_case_identifier_does_not_match_note_directory_case(self):
+    def test_update_note_directory_should_return_404_when_case_identifier_does_not_match_note_directory_case(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'name': 'directory_name'}
         response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
@@ -214,4 +214,4 @@ class TestsRestNotesDirectories(TestCase):
 
         case_identifier2 = self._subject.create_dummy_case()
         response = self._subject.update(f'/api/v2/cases/{case_identifier2}/notes-directories/{identifier}', {})
-        self.assertEqual(400, response.status_code)
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -87,3 +87,13 @@ class TestsRestNotesDirectories(TestCase):
         body = {}
         response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body)
         self.assertEqual(200, response.status_code)
+
+    def test_update_note_directory_should_modify_name(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        body = {'name': 'new name'}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body).json()
+        self.assertEqual('new name', response['name'])

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -96,6 +96,11 @@ class TestsRestNotesDirectories(TestCase):
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}').json()
         self.assertEqual('directory_name', response['name'])
 
+    def test_get_note_directory_should_return_404_when_note_directory_does_not_exist(self):
+        case_identifier = self._subject.create_dummy_case()
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
+        self.assertEqual(404, response.status_code)
+
     def test_update_note_directory_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'name': 'directory_name'}

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -78,6 +78,15 @@ class TestsRestNotesDirectories(TestCase):
         response = user.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
         self.assertEqual(403, response.status_code)
 
+    def test_get_not_directory_should_return_200(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
+        self.assertEqual(200, response.status_code)
+
     def test_update_note_directory_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
         body = {'name': 'directory_name'}

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -108,3 +108,13 @@ class TestsRestNotesDirectories(TestCase):
         activities = self._subject.get('/case/activities/list', {'cid': case_identifier}).json()
         last_activity = activities['data'][0]['activity_desc']
         self.assertEqual('Modified directory "new name"', last_activity)
+
+    def test_update_note_directory_should_return_400_when_field_name_is_not_a_string(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        body = {'name': 123}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body)
+        self.assertEqual(400, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -96,6 +96,15 @@ class TestsRestNotesDirectories(TestCase):
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}').json()
         self.assertEqual('directory_name', response['name'])
 
+    def test_get_note_directory_should_return_404_when_case_does_not_exist(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        response = self._subject.get(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes-directories/{identifier}')
+        self.assertEqual(404, response.status_code)
+
     def test_get_note_directory_should_return_404_when_note_directory_does_not_exist(self):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -77,3 +77,13 @@ class TestsRestNotesDirectories(TestCase):
         body = {'name': 'directory_name'}
         response = user.create(f'/api/v2/cases/{case_identifier}/notes-directories', body)
         self.assertEqual(403, response.status_code)
+
+    def test_update_note_directory_should_return_200(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        body = {}
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}', body)
+        self.assertEqual(200, response.status_code)


### PR DESCRIPTION
Implementation of `GET /api/v2/cases/{case_identifier}/notes-directories/{identifier}`

Goes with accompanying documentation [PR#74](https://github.com/dfir-iris/iris-doc-src/pull/74)