### PR TITLE
Improving helm chart

### DIFF
--- a/deploy/kubernetes/charts/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/templates/ingress.yaml
@@ -4,7 +4,12 @@ kind: Ingress
 metadata:
   name: {{ .Values.ingress.name }}
   annotations:
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- if .Values.ingress.sslRedirect }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- end }}
+    {{- with .Values.ingress.customAnnotations }}
+    {{ to toYaml . | nindent 4 }}
+    {{- else }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   rules:

--- a/deploy/kubernetes/charts/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/templates/ingress.yaml
@@ -39,7 +39,7 @@ spec:
                         {{- end }}
         {{- end }}
     {{- end }}
-  {{- if and .Values.ingress.tls.enabled (gt (len .Values.ingress.tls.hosts) 0) }}
+  {{- if and .Values.ingress.enableTls.enabled (gt (len .Values.ingress.tls.hosts) 0) }}
   tls:
     - hosts:
       {{- range .Values.ingress.tls.hosts }}

--- a/deploy/kubernetes/charts/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/templates/ingress.yaml
@@ -14,12 +14,24 @@ spec:
         paths:
         {{- range $path := $host.paths }}
         - path: {{ $path.path }}
-          pathType: Prefix
+          pathType: {{ default "ImplementationSpecific" $path.pathType}}
           backend:
             service:
-              name: {{ $path.serviceName }}
+              name: {{- if hasKey $path "serviceName" -}}
+                      {{- $path.serviceName | indent 1}}
+                    {{- else if hasKey $.Values.irisapp "name" -}}
+                      {{- $.Values.irisapp.name | indent 1}}
+                    {{- else -}}
+                      {{- fail "Missing 'serviceName' in ingress.hosts[].paths[] and no default in irisapp.name" }}
+                    {{- end }}
               port:
-                number: {{ $path.servicePort }}
+                number: {{- if hasKey $path "servicePort" -}}
+                          {{- printf "%v" $path.servicePort | indent 1}}
+                        {{- else if hasKey $.Values.irisapp.service "port" -}}
+                          {{- printf "%v" $.Values.irisapp.service.port | indent 1 }}
+                        {{- else -}}
+                          {{- fail "Missing 'servicePort' in ingress.hosts[].paths[] and no default in irisapp.service.port" }}
+                        {{- end }}
         {{- end }}
     {{- end }}
   {{- with .Values.ingress.tls }}

--- a/deploy/kubernetes/charts/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/templates/ingress.yaml
@@ -8,8 +8,8 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     {{- end }}
     {{- with .Values.ingress.customAnnotations }}
-    {{ to toYaml . | nindent 4 }}
-    {{- else }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   rules:

--- a/deploy/kubernetes/charts/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/templates/ingress.yaml
@@ -34,14 +34,12 @@ spec:
                         {{- end }}
         {{- end }}
     {{- end }}
-  {{- with .Values.ingress.tls }}
+  {{- if and .Values.ingress.tls.enabled (gt (len .Values.ingress.tls.hosts) 0) }}
   tls:
-  {{- range . }}
-  - hosts:
-    {{- range .hosts }}
-    - {{ . }}
-    {{- end }}
-    secretName: {{ .secretName }}
-  {{- end }}
+    - hosts:
+      {{- range .Values.ingress.tls.hosts }}
+      - {{ . }}
+      {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
 {{- end }}

--- a/deploy/kubernetes/charts/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -31,3 +32,4 @@ spec:
     secretName: {{ .secretName }}
   {{- end }}
   {{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/templates/iris_app.yaml
+++ b/deploy/kubernetes/charts/templates/iris_app.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -45,24 +46,17 @@ spec:
           command: ['nohup', './iris-entrypoint.sh', 'iriswebapp']
 
           env:
-
-          - name: POSTGRES_USER  # Setting Database username 
-            value: {{ .Values.irisapp.POSTGRES_USER| quote }}
-
-          - name:  POSTGRES_PASSWORDD # Setting Database password 
-            value: {{ .Values.irisapp.POSTGRES_PASSWORD | quote }}
-
-          - name:  POSTGRES_ADMIN_USER # Setting Database admin user 
-            value: {{ .Values.irisapp.POSTGRES_ADMIN_USER | quote }}
-
-          - name:  POSTGRES_ADMIN_PASSWORD # Setting Database admin password
-            value: {{ .Values.irisapp.POSTGRES_ADMIN_PASSWORD | quote }}
-
-          - name:  POSTGRES_PORT # Setting Database port
-            value: {{ .Values.irisapp.POSTGRES_PORT | quote }}
-
-          - name:  POSTGRES_SERVER # Setting Database server
-            value: {{ .Values.irisapp.POSTGRES_SERVER | quote }}
+          {{- range $key := list "POSTGRES_USER" "POSTGRES_PASSWORD" "POSTGRES_ADMIN_USER" "POSTGRES_ADMIN_PASSWORD" "POSTGRES_PORT" "POSTGRES_SERVER" }}
+          - name: {{ $key }}
+            {{- if and (hasKey $.Values.irisapp "envFromSecret") (has $key $.Values.irisapp.envFromSecret.keys) }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $.Values.irisapp.envFromSecret.name }}
+                key: {{ $key }}
+            {{- else }}
+            value: {{ index $.Values.irisapp $key | quote }}
+            {{- end }}
+          {{- end }}
 
           - name:  IRIS_SECRET_KEY 
             value: {{ .Values.irisapp.IRIS_SECRET_KEY | quote }}

--- a/deploy/kubernetes/charts/templates/iris_app.yaml
+++ b/deploy/kubernetes/charts/templates/iris_app.yaml
@@ -142,7 +142,7 @@ metadata:
   labels:
     app: {{ .Values.irisapp.app }}
 spec:
-  type: {{ .Values.irisapp.type }}
+  type: {{ .Values.irisapp.service.type }}
   ports:
    - port: {{ .Values.irisapp.service.port }}
      targetPort: {{ .Values.irisapp.service.targetPort }}

--- a/deploy/kubernetes/charts/templates/iris_worker.yaml
+++ b/deploy/kubernetes/charts/templates/iris_worker.yaml
@@ -61,6 +61,9 @@ spec:
             {{- end }}
           {{- end }}
 
+          - name: CELERY_BROKER
+            value: {{ .Values.irisworker.CELERY_BROKER | quote }}
+
           - name:  IRIS_SECRET_KEY
             value: {{ .Values.irisworker.IRIS_SECRET_KEY | quote }}
 

--- a/deploy/kubernetes/charts/templates/iris_worker.yaml
+++ b/deploy/kubernetes/charts/templates/iris_worker.yaml
@@ -49,23 +49,17 @@ spec:
           - name: DOCKERIZED
             value: {{ .Values.irisworker.DOCKERIZED | quote }}
 
-          - name: POSTGRES_USER
-            value: {{ .Values.irisworker.POSTGRES_USER | quote }}
-
-          - name:  POSTGRES_PASSWORDD
-            value: {{ .Values.irisworker.POSTGRES_PASSWORD | quote }}
-
-          - name:  POSTGRES_ADMIN_USER
-            value: {{ .Values.irisworker.POSTGRES_ADMIN_USER | quote }}
-
-          - name:  POSTGRES_ADMIN_PASSWORD
-            value: {{ .Values.irisworker.POSTGRES_ADMIN_PASSWORD | quote }}    
-
-          - name:  POSTGRES_PORT
-            value: {{ .Values.irisworker.POSTGRES_PORT | quote }}   
-
-          - name:  POSTGRES_SERVER
-            value: {{ .Values.irisworker.POSTGRES_SERVER | quote }}  
+          {{- range $key := list "POSTGRES_USER" "POSTGRES_PASSWORD" "POSTGRES_ADMIN_USER" "POSTGRES_ADMIN_PASSWORD" "POSTGRES_PORT" "POSTGRES_SERVER" }}
+          - name: {{ $key }}
+            {{- if and (hasKey $.Values.irisworker "envFromSecret") (has $key $.Values.irisworker.envFromSecret.keys) }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $.Values.irisworker.envFromSecret.name }}
+                key: {{ $key }}
+            {{- else }}
+            value: {{ index $.Values.irisworker $key | quote }}
+            {{- end }}
+          {{- end }}
 
           - name:  IRIS_SECRET_KEY
             value: {{ .Values.irisworker.IRIS_SECRET_KEY | quote }}

--- a/deploy/kubernetes/charts/templates/postgres.yaml
+++ b/deploy/kubernetes/charts/templates/postgres.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 ---    
 # Here I have used a hostpath
 # Local volumes can only be used as a statically created PersistentVolume. Dynamic provisioning is not supported.
@@ -108,3 +109,4 @@ spec:
   selector:
    app: {{ .Values.postgres.app }}
 ---  
+{{- end }}

--- a/deploy/kubernetes/charts/templates/rabbitmq.yaml
+++ b/deploy/kubernetes/charts/templates/rabbitmq.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rabbitmq.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -39,3 +40,4 @@ spec:
   selector:
     app: {{ .Values.rabbitmq.app }}
 ---
+{{- end }}

--- a/deploy/kubernetes/charts/values.yaml
+++ b/deploy/kubernetes/charts/values.yaml
@@ -1,6 +1,9 @@
 ## @section rabbitmq Configuration
 ##
 rabbitmq:
+  ## @param rabbitmq.enable Enable RabbitMQ deployment
+  ##
+  enable: true
   ## @param rabbitmq.app App name for rabbitmq
   ##
   app: rabbitmq
@@ -33,6 +36,9 @@ rabbitmq:
 ## @section PostgreSQL Configuration
 ##
 postgres:
+  ## @param postgres.enable Enable PostgreSQL deployment
+  ##
+  enable: true
   ## @param postgres.app PostgreSQL App
   ##
   app: postgres
@@ -125,6 +131,19 @@ irisapp:
   DB_RETRY_COUNT: 5
   DB_RETRY_DELAY: 5
   INTERFACE_HTTPS_PORT: 443
+  
+  ## @param irisapp.envFromSecret Environment variables from a secret
+  ##
+  envFromSecret:
+    name: postgres-secret
+    keys:
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_ADMIN_USER
+      - POSTGRES_ADMIN_PASSWORD
+      - POSTGRES_PORT
+      - POSTGRES_SERVER
+
   ## @param irisapp.securityContext securityContext for irisapp
   ##
   securityContext: {}
@@ -179,6 +198,19 @@ irisworker:
   POSTGRES_SERVER: postgres.<name_space>.svc.cluster.local
   IRIS_SECRET_KEY: AVerySuperSecretKey-SoNotThisOne
   IRIS_SECURITY_PASSWORD_SALT: ARandomSalt-NotThisOneEither
+  
+  ## @param irisapp.envFromSecret Environment variables from a secret
+  ##
+  envFromSecret:
+    name: postgres-secret
+    keys:
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_ADMIN_USER
+      - POSTGRES_ADMIN_PASSWORD
+      - POSTGRES_PORT
+      - POSTGRES_SERVER
+
   ## @param irisworker.securityContext securityContext for irisworker
   ##
   securityContext: {}

--- a/deploy/kubernetes/charts/values.yaml
+++ b/deploy/kubernetes/charts/values.yaml
@@ -111,9 +111,9 @@ irisapp:
   service:
     port: 8000
     
-  ## @param irisapp.type Iris Frontend Service type
-  ##
-  type: NodePort
+    ## @param irisapp.service.type Iris Frontend Service type
+    ##
+    type: NodePort
 
   ## @param  Iris Frontend Environments
   ##

--- a/deploy/kubernetes/charts/values.yaml
+++ b/deploy/kubernetes/charts/values.yaml
@@ -224,11 +224,13 @@ ingress:
   enabled: true
   name: iris-ingress
   className: nginx
-  annotations:
+  enableTls: false
+  sslRedirect: false
+  customAnnotations:
     # Add any annotations specific to your Ingress controller
-    kubernetes.io/ingress.class: nginx
+    # kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /$1
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
     - host: <host_name>
       paths:
@@ -237,6 +239,6 @@ ingress:
           serviceName: iriswebapp-app
           servicePort: 8000
   tls:
-    - secretName: iris-ingress-tls-secret
+    - secretName: <secret_name>
       hosts:
-        - <host_name>        
+        - <host_name>


### PR DESCRIPTION
This PR refactors the Helm chart to improve flexibility, security, and configuration clarity.
### Changes

    Adds ingress.enabled flag to allow disabling ingress resources.

    Introduces ingress.enableTls, sslRedirect, and customAnnotations for better ingress customization.

    Refactors environment variable injection for irisapp and irisworker to optionally use Kubernetes secrets instead of hard-coded values.

    Adds rabbitmq.enable and postgres.enable flags to conditionally deploy these services.

    Updates several templates and values.yaml structure for consistency and maintainability.

### Motivation

These changes simplify configuration, improve secret management, and make the chart easier to customize for different environments.

### Notes

    Some variable names and paths have changed (e.g. irisapp.type → irisapp.service.type).

    Updating your values.yaml may be required for compatibility.