### PR TITLE
Api v2 delete notes directories

### DIFF
--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -168,8 +168,11 @@ def deprecated_add_asset(caseid):
     try:
         request_data = call_modules_hook('on_preload_asset_create', data=request.get_json(), caseid=caseid)
         ioc_links = request_data.get('ioc_links')
-        msg, asset = assets_create(caseid, request_data, ioc_links)
-        return response_success(msg, asset_schema.dump(asset))
+        asset = asset_schema.load(request_data)
+        msg, created_asset = assets_create(caseid, asset, ioc_links)
+        return response_success(msg, asset_schema.dump(created_asset))
+    except ValidationError as e:
+        return response_error('Data error', data=e.messages)
     except BusinessProcessingError as e:
         return response_error(e.get_message(), e.get_data())
 

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -167,7 +167,8 @@ def deprecated_add_asset(caseid):
     asset_schema = CaseAssetsSchema()
     try:
         request_data = call_modules_hook('on_preload_asset_create', data=request.get_json(), caseid=caseid)
-        msg, asset = assets_create(caseid, request_data)
+        ioc_links = request_data.get('ioc_links')
+        msg, asset = assets_create(caseid, request_data, ioc_links)
         return response_success(msg, asset_schema.dump(asset))
     except BusinessProcessingError as e:
         return response_error(e.get_message(), e.get_data())

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -166,7 +166,8 @@ def case_assets_state(caseid):
 def deprecated_add_asset(caseid):
     asset_schema = CaseAssetsSchema()
     try:
-        msg, asset = assets_create(caseid, request.get_json())
+        request_data = call_modules_hook('on_preload_asset_create', data=request.get_json(), caseid=caseid)
+        msg, asset = assets_create(caseid, request_data)
         return response_success(msg, asset_schema.dump(asset))
     except BusinessProcessingError as e:
         return response_error(e.get_message(), e.get_data())
@@ -300,7 +301,8 @@ def asset_update(cur_id, caseid):
         if not asset:
             return response_error("Invalid asset ID for this case")
 
-        result = assets_update(asset, request.get_json())
+        request_data = call_modules_hook('on_preload_asset_update', data=request.get_json(), caseid=caseid)
+        result = assets_update(asset, request_data)
 
         schema = CaseAssetsSchema()
         return response_success(f'Updated asset {result.asset_name}', schema.dump(result))

--- a/source/app/blueprints/rest/case/case_assets_routes.py
+++ b/source/app/blueprints/rest/case/case_assets_routes.py
@@ -31,7 +31,8 @@ from app.business.assets import assets_get
 from app.business.assets import assets_update
 from app.iris_engine.access_control.iris_user import iris_current_user
 from app.business.errors import BusinessProcessingError
-from app.datamgmt.case.case_assets_db import get_raw_assets, get_linked_iocs_finfo_from_asset
+from app.datamgmt.case.case_assets_db import get_raw_assets
+from app.datamgmt.case.case_assets_db import get_linked_iocs_finfo_from_asset
 from app.datamgmt.case.case_assets_db import add_comment_to_asset
 from app.datamgmt.case.case_assets_db import create_asset
 from app.datamgmt.case.case_assets_db import delete_asset_comment

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -300,7 +300,7 @@ def case_directory_delete(dir_id, caseid):
             return response_error(msg="Invalid directory ID")
 
         # Proceed to delete directory, but remove all associated notes and subdirectories recursively
-        has_succeed = delete_directory(directory, caseid)
+        has_succeed = delete_directory(directory)
         if has_succeed:
             track_activity(f"deleted directory \"{directory.name}\"", caseid=caseid)
             return response_success('Directory deleted')

--- a/source/app/blueprints/rest/case/case_notes_routes.py
+++ b/source/app/blueprints/rest/case/case_notes_routes.py
@@ -289,6 +289,7 @@ def case_directory_update(dir_id, caseid):
 
 
 @case_notes_rest_blueprint.route('/case/notes/directories/delete/<dir_id>', methods=['POST'])
+@endpoint_deprecated('DELETE', '/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
 @ac_requires_case_identifier(CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_directory_delete(dir_id, caseid):

--- a/source/app/blueprints/rest/v2/case_objects/assets.py
+++ b/source/app/blueprints/rest/v2/case_objects/assets.py
@@ -88,8 +88,12 @@ class AssetsOperations:
         try:
             request_data = call_deprecated_on_preload_modules_hook('asset_create', request.get_json(), case_identifier)
             ioc_links = request_data.get('ioc_links')
-            _, asset = assets_create(case_identifier, request_data, ioc_links)
-            return response_api_created(self._schema.dump(asset))
+            asset = self._schema.load(request_data)
+            _, create_asset = assets_create(case_identifier, asset, ioc_links)
+            return response_api_created(self._schema.dump(create_asset))
+
+        except ValidationError as e:
+            return response_api_error('Data error', data=e.messages)
         except BusinessProcessingError as e:
             return response_api_error(e.get_message(), data=e.get_data())
 

--- a/source/app/blueprints/rest/v2/case_objects/assets.py
+++ b/source/app/blueprints/rest/v2/case_objects/assets.py
@@ -38,6 +38,7 @@ from app.business.assets import assets_delete
 from app.business.errors import BusinessProcessingError
 from app.business.errors import ObjectNotFoundError
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
+from app.iris_engine.module_handler.module_handler import call_deprecated_on_preload_modules_hook
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
 
@@ -84,7 +85,8 @@ class AssetsOperations:
             return ac_api_return_access_denied(caseid=case_identifier)
 
         try:
-            _, asset = assets_create(case_identifier, request.get_json())
+            request_data = call_deprecated_on_preload_modules_hook('asset_create', request.get_json(), case_identifier)
+            _, asset = assets_create(case_identifier, request_data)
             return response_api_created(self._schema.dump(asset))
         except BusinessProcessingError as e:
             return response_api_error(e.get_message(), data=e.get_data())
@@ -110,7 +112,8 @@ class AssetsOperations:
             if not ac_fast_check_current_user_has_case_access(asset.case_id, [CaseAccessLevel.full_access]):
                 return ac_api_return_access_denied(caseid=asset.case_id)
 
-            asset = assets_update(asset, request.get_json())
+            request_data = call_deprecated_on_preload_modules_hook('asset_update', request.get_json(), case_identifier)
+            asset = assets_update(asset, request_data)
 
             result = self._schema.dump(asset)
             return response_api_success(result)

--- a/source/app/blueprints/rest/v2/case_objects/assets.py
+++ b/source/app/blueprints/rest/v2/case_objects/assets.py
@@ -41,6 +41,103 @@ from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_
 from app.models.authorization import CaseAccessLevel
 from app.schema.marshables import CaseAssetsSchema
 
+
+class AssetsOperations:
+
+    def __init__(self):
+        self._schema = CaseAssetsSchema()
+
+    @staticmethod
+    def _get_asset_in_case(identifier, case_identifier):
+        asset = assets_get(identifier)
+        if asset.case_id != case_identifier:
+            raise ObjectNotFoundError
+        return asset
+
+    def list(self, case_identifier):
+        try:
+            if not ac_fast_check_current_user_has_case_access(case_identifier,
+                                                              [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+                return ac_api_return_access_denied(caseid=case_identifier)
+
+            pagination_parameters = parse_pagination_parameters(request)
+            fields = parse_fields_parameters(request)
+
+            assets = assets_filter(case_identifier, pagination_parameters, request.args.to_dict())
+
+            if fields:
+                asset_schema = CaseAssetsSchema(only=fields)
+            else:
+                asset_schema = self._schema
+
+            return response_api_paginated(asset_schema, assets)
+
+        except ObjectNotFoundError:
+            return response_api_not_found()
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message())
+
+    def create(self, case_identifier):
+        if not cases_exists(case_identifier):
+            return response_api_not_found()
+        if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=case_identifier)
+
+        try:
+            _, asset = assets_create(case_identifier, request.get_json())
+            return response_api_created(self._schema.dump(asset))
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message(), data=e.get_data())
+
+    def get(self, case_identifier, identifier):
+        try:
+            asset = self._get_asset_in_case(identifier, case_identifier)
+
+            if not ac_fast_check_current_user_has_case_access(asset.case_id,
+                                                              [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+                return ac_api_return_access_denied(caseid=asset.case_id)
+
+            return response_api_success(self._schema.dump(asset))
+        except ObjectNotFoundError:
+            return response_api_not_found()
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message())
+
+    def update(self,case_identifier, identifier):
+        try:
+            asset = self._get_asset_in_case(identifier, case_identifier)
+
+            if not ac_fast_check_current_user_has_case_access(asset.case_id, [CaseAccessLevel.full_access]):
+                return ac_api_return_access_denied(caseid=asset.case_id)
+
+            asset = assets_update(asset, request.get_json())
+
+            result = self._schema.dump(asset)
+            return response_api_success(result)
+
+        except ObjectNotFoundError:
+            return response_api_not_found()
+
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message(), data=e.get_data())
+
+    def delete(self, case_identifier, identifier):
+        try:
+            asset = self._get_asset_in_case(identifier, case_identifier)
+
+            # perform authz check
+            if not ac_fast_check_current_user_has_case_access(asset.case_id, [CaseAccessLevel.full_access]):
+                return ac_api_return_access_denied(caseid=asset.case_id)
+
+            assets_delete(asset)
+            return response_api_deleted()
+        except ObjectNotFoundError:
+            return response_api_not_found()
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message())
+
+
+assets_operations = AssetsOperations()
 case_assets_blueprint = Blueprint('case_assets',
                                   __name__,
                                   url_prefix='/<int:case_identifier>/assets')
@@ -49,109 +146,28 @@ case_assets_blueprint = Blueprint('case_assets',
 @case_assets_blueprint.get('')
 @ac_api_requires()
 def case_list_assets(case_identifier):
-
-    try:
-        if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
-            return ac_api_return_access_denied(caseid=case_identifier)
-
-        pagination_parameters = parse_pagination_parameters(request)
-        fields = parse_fields_parameters(request)
-
-        assets = assets_filter(case_identifier, pagination_parameters, request.args.to_dict())
-
-        if fields:
-            asset_schema = CaseAssetsSchema(only=fields)
-        else:
-            asset_schema = CaseAssetsSchema()
-
-        return response_api_paginated(asset_schema, assets)
-
-    except ObjectNotFoundError:
-        return response_api_not_found()
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message())
+    return assets_operations.list(case_identifier)
 
 
 @case_assets_blueprint.post('')
 @ac_api_requires()
 def add_asset(case_identifier):
-
-    if not cases_exists(case_identifier):
-        return response_api_not_found()
-    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
-        return ac_api_return_access_denied(caseid=case_identifier)
-
-    asset_schema = CaseAssetsSchema()
-    try:
-        _, asset = assets_create(case_identifier, request.get_json())
-        return response_api_created(asset_schema.dump(asset))
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message(), data=e.get_data())
+    return assets_operations.create(case_identifier)
 
 
 @case_assets_blueprint.get('/<int:identifier>')
 @ac_api_requires()
 def get_asset(case_identifier, identifier):
-
-    asset_schema = CaseAssetsSchema()
-
-    try:
-        asset = assets_get(identifier)
-        _check_asset_and_case_identifier_match(asset, case_identifier)
-
-        if not ac_fast_check_current_user_has_case_access(asset.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
-            return ac_api_return_access_denied(caseid=asset.case_id)
-
-        return response_api_success(asset_schema.dump(asset))
-    except ObjectNotFoundError:
-        return response_api_not_found()
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message())
+    return assets_operations.get(case_identifier, identifier)
 
 
 @case_assets_blueprint.put('/<int:identifier>')
 @ac_api_requires()
 def update_asset(case_identifier, identifier):
-    try:
-        asset = assets_get(identifier)
-        _check_asset_and_case_identifier_match(asset, case_identifier)
-
-        if not ac_fast_check_current_user_has_case_access(asset.case_id, [CaseAccessLevel.full_access]):
-            return ac_api_return_access_denied(caseid=asset.case_id)
-
-        asset = assets_update(asset, request.get_json())
-
-        asset_schema = CaseAssetsSchema()
-        result = asset_schema.dump(asset)
-        return response_api_success(result)
-
-    except ObjectNotFoundError:
-        return response_api_not_found()
-
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message(), data=e.get_data())
+    return assets_operations.update(case_identifier, identifier)
 
 
 @case_assets_blueprint.delete('/<int:identifier>')
 @ac_api_requires()
 def delete_asset(case_identifier, identifier):
-
-    try:
-        asset = assets_get(identifier)
-        _check_asset_and_case_identifier_match(asset, case_identifier)
-
-        # perform authz check
-        if not ac_fast_check_current_user_has_case_access(asset.case_id, [CaseAccessLevel.full_access]):
-            return ac_api_return_access_denied(caseid=asset.case_id)
-
-        assets_delete(asset)
-        return response_api_deleted()
-    except ObjectNotFoundError:
-        return response_api_not_found()
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message())
-
-
-def _check_asset_and_case_identifier_match(asset, case_identifier):
-    if asset.case_id != case_identifier:
-        raise ObjectNotFoundError
+    return assets_operations.delete(case_identifier, identifier)

--- a/source/app/blueprints/rest/v2/case_objects/assets.py
+++ b/source/app/blueprints/rest/v2/case_objects/assets.py
@@ -87,7 +87,8 @@ class AssetsOperations:
 
         try:
             request_data = call_deprecated_on_preload_modules_hook('asset_create', request.get_json(), case_identifier)
-            _, asset = assets_create(case_identifier, request_data)
+            ioc_links = request_data.get('ioc_links')
+            _, asset = assets_create(case_identifier, request_data, ioc_links)
             return response_api_created(self._schema.dump(asset))
         except BusinessProcessingError as e:
             return response_api_error(e.get_message(), data=e.get_data())

--- a/source/app/blueprints/rest/v2/case_objects/assets.py
+++ b/source/app/blueprints/rest/v2/case_objects/assets.py
@@ -103,7 +103,7 @@ class AssetsOperations:
         except BusinessProcessingError as e:
             return response_api_error(e.get_message())
 
-    def update(self,case_identifier, identifier):
+    def update(self, case_identifier, identifier):
         try:
             asset = self._get_asset_in_case(identifier, case_identifier)
 

--- a/source/app/blueprints/rest/v2/case_objects/notes.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes.py
@@ -139,7 +139,7 @@ class NotesOperations:
             return response_api_not_found()
 
 
-notesOperations = NotesOperations()
+notes_operations = NotesOperations()
 case_notes_blueprint = Blueprint('case_notes',
                                  __name__,
                                  url_prefix='/<int:case_identifier>/notes')
@@ -148,22 +148,22 @@ case_notes_blueprint = Blueprint('case_notes',
 @case_notes_blueprint.post('')
 @ac_api_requires()
 def create_note(case_identifier):
-    return notesOperations.create(case_identifier)
+    return notes_operations.create(case_identifier)
 
 
 @case_notes_blueprint.get('/<int:identifier>')
 @ac_api_requires()
 def get_note(case_identifier, identifier):
-    return notesOperations.get(case_identifier, identifier)
+    return notes_operations.get(case_identifier, identifier)
 
 
 @case_notes_blueprint.put('<int:identifier>')
 @ac_api_requires()
 def update_note(case_identifier, identifier):
-    return notesOperations.update(case_identifier, identifier)
+    return notes_operations.update(case_identifier, identifier)
 
 
 @case_notes_blueprint.delete('<int:identifier>')
 @ac_api_requires()
 def delete_note(case_identifier, identifier):
-    return notesOperations.delete(case_identifier, identifier)
+    return notes_operations.delete(case_identifier, identifier)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -118,9 +118,12 @@ class NotesDirectories:
             return response_api_error('Data error', data=e.get_data())
 
     def delete(self, case_identifier, identifier):
-        directory = self._get_note_directory_in_case(identifier, case_identifier)
-        notes_directories_delete(directory)
-        return response_api_deleted()
+        try:
+            directory = self._get_note_directory_in_case(identifier, case_identifier)
+            notes_directories_delete(directory)
+            return response_api_deleted()
+        except ObjectNotFoundError:
+            return response_api_not_found()
 
 
 notes_directories = NotesDirectories()

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -118,6 +118,9 @@ class NotesDirectories:
             return response_api_error('Data error', data=e.get_data())
 
     def delete(self, case_identifier, identifier):
+        if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=case_identifier)
+
         try:
             directory = self._get_note_directory_in_case(identifier, case_identifier)
             notes_directories_delete(directory)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -23,6 +23,7 @@ from marshmallow import ValidationError
 from app.blueprints.access_controls import ac_api_requires
 from app.blueprints.rest.endpoints import response_api_created
 from app.blueprints.rest.endpoints import response_api_success
+from app.blueprints.rest.endpoints import response_api_deleted
 from app.blueprints.rest.endpoints import response_api_error
 from app.blueprints.rest.endpoints import response_api_not_found
 from app.blueprints.access_controls import ac_api_return_access_denied
@@ -115,6 +116,9 @@ class NotesDirectories:
         except BusinessProcessingError as e:
             return response_api_error('Data error', data=e.get_data())
 
+    def delete(self, case_identifier, identifier):
+        return response_api_deleted()
+
 
 notes_directories = NotesDirectories()
 case_notes_directories_blueprint = Blueprint('case_notes_directories_rest_v2', __name__, url_prefix='/<int:case_identifier>/notes-directories')
@@ -136,3 +140,8 @@ def get_note_directory(case_identifier, identifier):
 @ac_api_requires()
 def update_note_directory(case_identifier, identifier):
     return notes_directories.update(case_identifier, identifier)
+
+@case_notes_directories_blueprint.delete('<int:identifier>')
+@ac_api_requires()
+def delete_note_directory(case_identifier, identifier):
+    return notes_directories.delete(case_identifier, identifier)

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -141,6 +141,7 @@ def get_note_directory(case_identifier, identifier):
 def update_note_directory(case_identifier, identifier):
     return notes_directories.update(case_identifier, identifier)
 
+
 @case_notes_directories_blueprint.delete('<int:identifier>')
 @ac_api_requires()
 def delete_note_directory(case_identifier, identifier):

--- a/source/app/blueprints/rest/v2/case_objects/notes_directories.py
+++ b/source/app/blueprints/rest/v2/case_objects/notes_directories.py
@@ -33,6 +33,7 @@ from app.schema.marshables import CaseNoteDirectorySchema
 from app.business.notes_directories import notes_directories_create
 from app.business.notes_directories import notes_directories_get
 from app.business.notes_directories import notes_directories_update
+from app.business.notes_directories import notes_directories_delete
 from app.business.cases import cases_exists
 from app.iris_engine.access_control.utils import ac_fast_check_current_user_has_case_access
 from app.models.authorization import CaseAccessLevel
@@ -117,6 +118,8 @@ class NotesDirectories:
             return response_api_error('Data error', data=e.get_data())
 
     def delete(self, case_identifier, identifier):
+        directory = self._get_note_directory_in_case(identifier, case_identifier)
+        notes_directories_delete(directory)
         return response_api_deleted()
 
 

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -98,9 +98,7 @@ def assets_filter(case_identifier, pagination_parameters: PaginationParameters, 
         raise BusinessProcessingError(str(e))
 
 
-def assets_update(current_asset: CaseAssets, request_data: dict):
-    request_data['asset_id'] = current_asset.asset_id
-    asset = _load(request_data, instance=current_asset, partial=True)
+def assets_update(asset: CaseAssets):
 
     if case_assets_db_exists(asset):
         raise BusinessProcessingError('Data error', data='Asset with same value and type already exists')

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -47,8 +47,7 @@ def _load(request_data, **kwargs):
         raise BusinessProcessingError('Data error', data=e.messages)
 
 
-def assets_create(case_identifier, request_json):
-    request_data = call_modules_hook('on_preload_asset_create', data=request_json, caseid=case_identifier)
+def assets_create(case_identifier, request_data):
     asset = _load(request_data)
     asset.case_id = case_identifier
 
@@ -99,9 +98,8 @@ def assets_filter(case_identifier, pagination_parameters: PaginationParameters, 
         raise BusinessProcessingError(str(e))
 
 
-def assets_update(asset: CaseAssets, request_json: dict):
+def assets_update(asset: CaseAssets, request_data: dict):
     caseid = asset.case_id
-    request_data = call_modules_hook('on_preload_asset_update', data=request_json, caseid=caseid)
 
     request_data['asset_id'] = asset.asset_id
 

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -16,7 +16,6 @@
 #  along with this program; if not, write to the Free Software Foundation,
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from marshmallow.exceptions import ValidationError
 from flask_sqlalchemy.pagination import Pagination
 
 from app import db
@@ -35,20 +34,10 @@ from app.datamgmt.case.case_assets_db import set_ioc_links
 from app.datamgmt.case.case_assets_db import delete_asset
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
-from app.schema.marshables import CaseAssetsSchema
 from app.util import add_obj_history_entry
 
 
-def _load(request_data, **kwargs):
-    try:
-        add_assets_schema = CaseAssetsSchema()
-        return add_assets_schema.load(request_data, **kwargs)
-    except ValidationError as e:
-        raise BusinessProcessingError('Data error', data=e.messages)
-
-
-def assets_create(case_identifier, request_data, ioc_links):
-    asset = _load(request_data)
+def assets_create(case_identifier, asset: CaseAssets, ioc_links):
     asset.case_id = case_identifier
 
     if case_assets_db_exists(asset):

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -32,7 +32,6 @@ from app.datamgmt.case.case_assets_db import filter_assets
 from app.datamgmt.case.case_assets_db import case_assets_db_exists
 from app.datamgmt.case.case_assets_db import create_asset
 from app.datamgmt.case.case_assets_db import set_ioc_links
-from app.datamgmt.case.case_assets_db import get_linked_iocs_finfo_from_asset
 from app.datamgmt.case.case_assets_db import delete_asset
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
@@ -86,18 +85,6 @@ def assets_get(identifier) -> CaseAssets:
         raise ObjectNotFoundError()
 
     return asset
-
-
-def assets_get_detailed(identifier):
-    asset = assets_get(identifier)
-
-    # TODO this is a code smell: shouldn't have schemas in the business layer + the CaseAssetsSchema is instantiated twice
-    case_assets_schema = CaseAssetsSchema()
-    data = case_assets_schema.dump(asset)
-
-    asset_iocs = get_linked_iocs_finfo_from_asset(identifier)
-    data['linked_ioc'] = [row._asdict() for row in asset_iocs]
-    return data
 
 
 def assets_filter(case_identifier, pagination_parameters: PaginationParameters, request_parameters: dict) -> Pagination:

--- a/source/app/business/assets.py
+++ b/source/app/business/assets.py
@@ -47,7 +47,7 @@ def _load(request_data, **kwargs):
         raise BusinessProcessingError('Data error', data=e.messages)
 
 
-def assets_create(case_identifier, request_data):
+def assets_create(case_identifier, request_data, ioc_links):
     asset = _load(request_data)
     asset.case_id = case_identifier
 
@@ -55,8 +55,8 @@ def assets_create(case_identifier, request_data):
         raise BusinessProcessingError('Asset with same value and type already exists')
     asset = create_asset(asset=asset, caseid=case_identifier, user_id=iris_current_user.id)
     # TODO should the custom attributes be set?
-    if request_data.get('ioc_links'):
-        errors, _ = set_ioc_links(request_data.get('ioc_links'), asset.asset_id)
+    if ioc_links:
+        errors, _ = set_ioc_links(ioc_links, asset.asset_id)
         if errors:
             raise BusinessProcessingError('Encountered errors while linking IOC. Asset has still been created.')
     asset = call_modules_hook('on_postload_asset_create', data=asset, caseid=case_identifier)

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -19,8 +19,9 @@
 from app import db
 from app.iris_engine.utils.tracker import track_activity
 from app.models.models import NoteDirectory
-from app.datamgmt.case.case_notes_db import get_directory
 from app.business.errors import ObjectNotFoundError
+from app.datamgmt.case.case_notes_db import get_directory
+from app.datamgmt.case.case_notes_db import delete_directory
 
 
 def notes_directories_create(directory: NoteDirectory):
@@ -41,3 +42,8 @@ def notes_directories_update(directory: NoteDirectory):
     db.session.commit()
 
     track_activity(f'modified directory "{directory.name}"', caseid=directory.case_id)
+
+
+def notes_directories_delete(directory: NoteDirectory):
+    delete_directory(directory, directory.case_id)
+    track_activity(f'deleted directory "{directory.name}"', caseid=directory.case_id)

--- a/source/app/business/notes_directories.py
+++ b/source/app/business/notes_directories.py
@@ -45,5 +45,5 @@ def notes_directories_update(directory: NoteDirectory):
 
 
 def notes_directories_delete(directory: NoteDirectory):
-    delete_directory(directory, directory.case_id)
+    delete_directory(directory)
     track_activity(f'deleted directory "{directory.name}"', caseid=directory.case_id)

--- a/source/app/datamgmt/case/case_notes_db.py
+++ b/source/app/datamgmt/case/case_notes_db.py
@@ -45,16 +45,16 @@ def get_directory(directory_id):
     )).first()
 
 
-def delete_directory(directory, caseid):
+def delete_directory(directory: NoteDirectory):
     # Proceed to delete directory, but remove all associated notes and subdirectories recursively
     if directory:
         # Delete all notes in the directory
         for note in directory.notes:
-            delete_note(note.note_id, caseid)
+            delete_note(note.note_id, directory.case_id)
 
         # Delete all subdirectories
         for subdirectory in directory.subdirectories:
-            delete_directory(subdirectory, caseid)
+            delete_directory(subdirectory)
 
         # Delete the directory
         db.session.delete(directory)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -243,3 +243,13 @@ class TestsRestNotesDirectories(TestCase):
 
         response = self._subject.delete(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes-directories/{identifier}')
         self.assertEqual(404, response.status_code)
+
+    def test_delete_note_directory_should_return_403_when_user_has_no_access_to_case(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        user = self._subject.create_dummy_user()
+        response = user.delete(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -234,3 +234,12 @@ class TestsRestNotesDirectories(TestCase):
 
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
         self.assertEqual(404, response.status_code)
+
+    def test_delete_note_directory_should_return_404_when_case_does_not_exist(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        response = self._subject.delete(f'/api/v2/cases/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/notes-directories/{identifier}')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -224,3 +224,13 @@ class TestsRestNotesDirectories(TestCase):
 
         response = self._subject.delete(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
         self.assertEqual(204, response.status_code)
+
+    def test_get_note_directory_should_return_404_after_note_directory_has_been_deleted(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+        self._subject.delete(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
+
+        response = self._subject.get(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_notes_directories.py
+++ b/tests/tests_rest_notes_directories.py
@@ -215,3 +215,12 @@ class TestsRestNotesDirectories(TestCase):
         case_identifier2 = self._subject.create_dummy_case()
         response = self._subject.update(f'/api/v2/cases/{case_identifier2}/notes-directories/{identifier}', {})
         self.assertEqual(404, response.status_code)
+
+    def test_delete_note_directory_should_return_204(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'name': 'directory_name'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/notes-directories', body).json()
+        identifier = response['id']
+
+        response = self._subject.delete(f'/api/v2/cases/{case_identifier}/notes-directories/{identifier}')
+        self.assertEqual(204, response.status_code)


### PR DESCRIPTION
Implementation of `DELETE /api/v2/cases/{case_identifier}/notes-directories/{identifier}`.
* Deprecated `POST /case/notes/directories/delete/{directory_id}`
* Cleaned up API v2 assets to follow the same code organization as other endpoints
* Removed adherence of assets business layer to `marshmallow` and `marshables`

Note: this PR goes with documentation [PR#75](https://github.com/dfir-iris/iris-doc-src/pull/75)
