### PR TITLE
Deprecated POST /user/tasks/status/update

### DIFF
--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -162,6 +162,7 @@ def view_gtask(cur_id):
 
 
 @dashboard_rest_blueprint.route('/user/tasks/status/update', methods=['POST'])
+@endpoint_deprecated('PUT', '/api/v2/cases/{case_identifier}/tasks/{identifier}')
 @ac_api_requires()
 @ac_requires_case_identifier()
 def utask_statusupdate(caseid):

--- a/tests/tests_rest_tasks.py
+++ b/tests/tests_rest_tasks.py
@@ -143,6 +143,15 @@ class TestsRestTasks(TestCase):
                                         {'task_title': 'new title', 'task_status_id': 1, 'task_assignees_id': []}).json()
         self.assertEqual('new title', response['task_title'])
 
+    def test_update_task_should_update_status_id(self):
+        case_identifier = self._subject.create_dummy_case()
+        body = {'task_assignees_id': [], 'task_status_id': 1, 'task_title': 'dummy title'}
+        response = self._subject.create(f'/api/v2/cases/{case_identifier}/tasks', body).json()
+        identifier = response['id']
+        response = self._subject.update(f'/api/v2/cases/{case_identifier}/tasks/{identifier}',
+                                        {'task_title': 'dummy title', 'task_status_id': 2, 'task_assignees_id': []}).json()
+        self.assertEqual(2, response['task_status_id'])
+
     def test_get_tasks_should_return_200(self):
         case_identifier = self._subject.create_dummy_case()
         response = self._subject.get(f'/api/v2/cases/{case_identifier}/tasks')


### PR DESCRIPTION
 in favor of PUT /api/v2/cases/{case_identifier}/tasks/{identifier}