### PR TITLE
Bug typos in helm chart templates and values

### DIFF
--- a/deploy/kubernetes/charts/templates/iris_app.yaml
+++ b/deploy/kubernetes/charts/templates/iris_app.yaml
@@ -46,13 +46,13 @@ spec:
 
           env:
 
-          - name: POSTGRES_USER  # Setting Database username 
+          - name: POSTGRES_USER  # Setting Database username
             value: {{ .Values.irisapp.POSTGRES_USER| quote }}
 
-          - name:  POSTGRES_PASSWORDD # Setting Database password 
+          - name:  POSTGRES_PASSWORD # Setting Database password
             value: {{ .Values.irisapp.POSTGRES_PASSWORD | quote }}
 
-          - name:  POSTGRES_ADMIN_USER # Setting Database admin user 
+          - name:  POSTGRES_ADMIN_USER # Setting Database admin user
             value: {{ .Values.irisapp.POSTGRES_ADMIN_USER | quote }}
 
           - name:  POSTGRES_ADMIN_PASSWORD # Setting Database admin password
@@ -64,10 +64,10 @@ spec:
           - name:  POSTGRES_SERVER # Setting Database server
             value: {{ .Values.irisapp.POSTGRES_SERVER | quote }}
 
-          - name:  IRIS_SECRET_KEY 
+          - name:  IRIS_SECRET_KEY
             value: {{ .Values.irisapp.IRIS_SECRET_KEY | quote }}
 
-          - name:  IRIS_SECURITY_PASSWORD_SALT 
+          - name:  IRIS_SECURITY_PASSWORD_SALT
             value: {{ .Values.irisapp.IRIS_SECURITY_PASSWORD_SALT | quote }}
 
           - name:  DB_RETRY_COUNT
@@ -84,7 +84,7 @@ spec:
 
           - name:  IRIS_ADM_PASSWORD
             value: {{ .Values.irisapp.IRIS_ADM_PASSWORD | quote }}
-          
+
           {{- if eq .Values.irisapp.IRIS_AUTHENTICATION_TYPE "oidc" }}
           - name: OIDC_ISSUER_URL
             value: {{ .Values.irisapp.OIDC_ISSUER_URL | quote }}
@@ -110,13 +110,13 @@ spec:
           - name: OIDC_MAPPING_ROLES
             value: {{ .Values.irisapp.OIDC_MAPPING_ROLES | quote }}
           {{- end }}
-          
+
           ports:
             - containerPort: 8000
 
           volumeMounts:
             - mountPath: /home/iris/downloads
-              name: iris-downloads  
+              name: iris-downloads
             - mountPath: /home/iris/user_templates
               name: user-templates
             - mountPath: /home/iris/server_data

--- a/deploy/kubernetes/charts/templates/iris_worker.yaml
+++ b/deploy/kubernetes/charts/templates/iris_worker.yaml
@@ -52,20 +52,20 @@ spec:
           - name: POSTGRES_USER
             value: {{ .Values.irisworker.POSTGRES_USER | quote }}
 
-          - name:  POSTGRES_PASSWORDD
+          - name:  POSTGRES_PASSWORD
             value: {{ .Values.irisworker.POSTGRES_PASSWORD | quote }}
 
           - name:  POSTGRES_ADMIN_USER
             value: {{ .Values.irisworker.POSTGRES_ADMIN_USER | quote }}
 
           - name:  POSTGRES_ADMIN_PASSWORD
-            value: {{ .Values.irisworker.POSTGRES_ADMIN_PASSWORD | quote }}    
+            value: {{ .Values.irisworker.POSTGRES_ADMIN_PASSWORD | quote }}
 
           - name:  POSTGRES_PORT
-            value: {{ .Values.irisworker.POSTGRES_PORT | quote }}   
+            value: {{ .Values.irisworker.POSTGRES_PORT | quote }}
 
           - name:  POSTGRES_SERVER
-            value: {{ .Values.irisworker.POSTGRES_SERVER | quote }}  
+            value: {{ .Values.irisworker.POSTGRES_SERVER | quote }}
 
           - name:  IRIS_SECRET_KEY
             value: {{ .Values.irisworker.IRIS_SECRET_KEY | quote }}
@@ -92,10 +92,10 @@ spec:
               readOnly: true
       volumes:
         - name: iris-downloads
-          emptyDir: {}  
+          emptyDir: {}
         - name: user-templates
           emptyDir: {}
-        - name: server-data 
+        - name: server-data
           emptyDir: {}
         - name: iris-ldap-certs
           secret:

--- a/deploy/kubernetes/charts/templates/postgres.yaml
+++ b/deploy/kubernetes/charts/templates/postgres.yaml
@@ -1,4 +1,4 @@
----    
+---
 # Here I have used a hostpath
 # Local volumes can only be used as a statically created PersistentVolume. Dynamic provisioning is not supported.
 # If you need to go with Dynamic volumes you may choose AWS EBS or EFS
@@ -67,13 +67,13 @@ spec:
           - name: POSTGRES_USER  # Setting Database username
             value: {{ .Values.postgres.POSTGRES_USER | quote }}
 
-          - name:  POSTGRES_PASSWORDD # Setting Database password
+          - name:  POSTGRES_PASSWORD # Setting Database password
             value: {{ .Values.postgres.POSTGRES_PASSWORD | quote }}
 
-          - name:  POSTGRES_ADMIN_USER # Setting Database admin user 
+          - name:  POSTGRES_ADMIN_USER # Setting Database admin user
             value: {{ .Values.postgres.POSTGRES_ADMIN_USER | quote }}
 
-          - name:  POSTGRES_ADMIN_PASSWORD # Setting Database admin password 
+          - name:  POSTGRES_ADMIN_PASSWORD # Setting Database admin password
             value: {{ .Values.postgres.POSTGRES_ADMIN_PASSWORD | quote }}
 
           - name:  POSTGRES_PORT # Setting Database port
@@ -107,4 +107,4 @@ spec:
    - port: {{ .Values.postgres.service.port }}
   selector:
    app: {{ .Values.postgres.app }}
----  
+---

--- a/deploy/kubernetes/charts/values.yaml
+++ b/deploy/kubernetes/charts/values.yaml
@@ -1,4 +1,4 @@
-## @section rabbitmq Configuration
+# @section rabbitmq Configuration
 ##
 rabbitmq:
   ## @param rabbitmq.app App name for rabbitmq
@@ -28,7 +28,7 @@ rabbitmq:
   ## @param rabbitmq.podSecurityContext podSecurityContext for rabbitmq
   ##
   podSecurityContext: {}
-   
+
 
 ## @section PostgreSQL Configuration
 ##
@@ -41,9 +41,9 @@ postgres:
   name: postgres
   ## @param postgres.image PostgreSQL Image
   ##
-  image: <postgres_image>
+  image: postgres
   ## @param postgres.tag PostgreSQL Tag
-  tag: <tag>
+  tag: 15.14
   ## @param postgres.imagePullPolicy PostgreSQL PullPolicy
   ##
   imagePullPolicy: "IfNotPresent"
@@ -53,8 +53,8 @@ postgres:
   ## @param postgres.resources Resources for postgres
   ##
   resources: {}
-  
-  
+
+
   ## @param postgres.service PostgreSQL Service
   ##
   service:
@@ -64,7 +64,7 @@ postgres:
   ##
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
-  POSTGRES_ADMIN_USER: raptor
+  POSTGRES_ADMIN_USER: postgres
   POSTGRES_ADMIN_PASSWORD: postgres
   POSTGRES_DB: iris_db
   POSTGRES_PORT: 5432
@@ -86,10 +86,10 @@ irisapp:
   name: iriswebapp-app
   ## @param irisapp.image Iris Frontend Image
   ##
-  image: <irisapp_image>
+  image: ghcr.io/dfir-iris/iriswebapp_app
   ## @param irisapp.tag Iris Frontend Tag
   ##
-  tag: <tag>
+  tag: v2.4.22
   ## @param irisapp.imagePullPolicy Iris Frontend imagePullPolicy
   ##
   imagePullPolicy: "IfNotPresent"
@@ -104,23 +104,23 @@ irisapp:
   ##
   service:
     port: 8000
-    
+
   ## @param irisapp.type Iris Frontend Service type
   ##
   type: NodePort
 
   ## @param  Iris Frontend Environments
   ##
-  POSTGRES_USER: raptor
+  POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
-  POSTGRES_ADMIN_USER: raptor
+  POSTGRES_ADMIN_USER: postgres
   POSTGRES_ADMIN_PASSWORD: postgres
   POSTGRES_PORT: 5432
-  POSTGRES_SERVER: postgres.<name_space>.svc.cluster.local
+  POSTGRES_SERVER: postgres.test.svc.cluster.local
   IRIS_SECRET_KEY: AVerySuperSecretKey-SoNotThisOne
   IRIS_SECURITY_PASSWORD_SALT: ARandomSalt-NotThisOneEither
   IRIS_ADM_USERNAME: administrator
-  # Must be 12 characters minimum and contains a capital letter and a number. 
+  # Must be 12 characters minimum and contains a capital letter and a number.
   IRIS_ADM_PASSWORD: Hello12345!
   DB_RETRY_COUNT: 5
   DB_RETRY_DELAY: 5
@@ -148,17 +148,17 @@ irisapp:
 ##
 irisworker:
   ## @param irisworker.app Iris Backend App
-  ##    
+  ##
   app: iriswebapp-worker
   ## @param irisworker.name Iris Backend Name
   ##
   name: iriswebapp-worker
   ## @param irisworker.image Iris Backend Image
   ##
-  image: <irisworker_image>
+  image: ghcr.io/dfir-iris/iriswebapp_app
   ## @param irisworker.tag Iris Backend Tag
   ##
-  tag: <tag>
+  tag: v2.4.22
   ## @param irisworker.imagePullPolicy Iris Backend imagePullPolicy
   ##
   imagePullPolicy: "IfNotPresent"
@@ -171,12 +171,12 @@ irisworker:
 
   ## @param  Iris Backend Environments
   ##
-  POSTGRES_USER: raptor
+  POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
-  POSTGRES_ADMIN_USER: raptor
+  POSTGRES_ADMIN_USER: postgres
   POSTGRES_ADMIN_PASSWORD: postgres
   POSTGRES_PORT: 5432
-  POSTGRES_SERVER: postgres.<name_space>.svc.cluster.local
+  POSTGRES_SERVER: postgres.test.svc.cluster.local
   IRIS_SECRET_KEY: AVerySuperSecretKey-SoNotThisOne
   IRIS_SECURITY_PASSWORD_SALT: ARandomSalt-NotThisOneEither
   ## @param irisworker.securityContext securityContext for irisworker
@@ -198,7 +198,7 @@ ingress:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
-    - host: <host_name>
+    - host: iris.lan
       paths:
         - path: /(.*)
           pathType: ImplementationSpecific
@@ -207,4 +207,4 @@ ingress:
   tls:
     - secretName: iris-ingress-tls-secret
       hosts:
-        - <host_name>        
+        -  iris.lan


### PR DESCRIPTION
Made recommended changes based on issue #768.

The default values added to the helm chart are up for discussion. I wanted to ensure at least the image is specified without users needing to look up the correct value for each pod deployed. Furthermore, set the default value of the postgres user/admin to postgres it was declared differently in different sections (some said raptors vs other did not).