### PR TITLE
Api v2 get user profile

### DIFF
--- a/source/app/blueprints/rest/profile_routes.py
+++ b/source/app/blueprints/rest/profile_routes.py
@@ -181,6 +181,7 @@ def profile_refresh_permissions_and_ac():
 
 
 @profile_rest_blueprint.route('/user/whoami', methods=['GET'])
+@endpoint_deprecated('GET', '/api/v2/me')
 @ac_api_requires()
 def profile_whoami():
     """Returns the current user's profile"""

--- a/source/app/blueprints/rest/v2/auth.py
+++ b/source/app/blueprints/rest/v2/auth.py
@@ -35,7 +35,6 @@ from app.blueprints.rest.endpoints import response_api_error, response_api_not_f
 from app.blueprints.rest.endpoints import response_api_success
 from app.business.auth import validate_ldap_login, validate_local_login, return_authed_user_info, generate_auth_tokens
 from app.iris_engine.utils.tracker import track_activity
-from app.schema.marshables import UserSchema
 
 
 auth_blueprint = Blueprint('auth', __name__, url_prefix='/auth')

--- a/source/app/blueprints/rest/v2/auth.py
+++ b/source/app/blueprints/rest/v2/auth.py
@@ -112,23 +112,6 @@ def logout():
     return redirect(not_authenticated_redirection_url('/'))
 
 
-# TODO - We should have /api/v2/users/{identifier}. For now keeping it since the route doesn't exist elsewhere
-@auth_blueprint.route('/whoami', methods=['GET'])
-def whoami():
-    """
-    Returns information about the currently authenticated user.
-    """
-
-    # Ensure we are authenticated
-    if not iris_current_user.is_authenticated:
-        return response_api_error("Unauthenticated")
-
-    # Return the current_user dict
-    return response_api_success(data=UserSchema(only=[
-        'id', 'user_name', 'user_login', 'user_email'
-    ]).dump(iris_current_user))
-
-
 @auth_blueprint.post('/refresh-token')
 def refresh_token_endpoint():
     """

--- a/source/app/blueprints/rest/v2/case_objects/evidences.py
+++ b/source/app/blueprints/rest/v2/case_objects/evidences.py
@@ -48,9 +48,11 @@ class EvidencesOperations:
         self._schema = CaseEvidenceSchema()
 
     @staticmethod
-    def _check_evidence_and_case_identifier_match(evidence: CaseReceivedFile, case_identifier):
+    def _get_evidence_in_case(identifier, case_identifier):
+        evidence = evidences_get(identifier)
         if evidence.case_id != case_identifier:
             raise BusinessProcessingError(f'Evidence {evidence.id} does not belong to case {case_identifier}')
+        return evidence
 
     def list(self, case_identifier):
         if not cases_exists(case_identifier):
@@ -88,8 +90,7 @@ class EvidencesOperations:
             return response_api_not_found()
 
         try:
-            evidence = evidences_get(identifier)
-            self._check_evidence_and_case_identifier_match(evidence, case_identifier)
+            evidence = self._get_evidence_in_case(identifier, case_identifier)
 
             if not ac_fast_check_current_user_has_case_access(evidence.case_id,
                                                               [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
@@ -106,8 +107,7 @@ class EvidencesOperations:
             return response_api_not_found()
 
         try:
-            evidence = evidences_get(identifier)
-            self._check_evidence_and_case_identifier_match(evidence, case_identifier)
+            evidence = self._get_evidence_in_case(identifier, case_identifier)
             if not ac_fast_check_current_user_has_case_access(evidence.case_id, [CaseAccessLevel.full_access]):
                 return ac_api_return_access_denied(caseid=evidence.case_id)
 
@@ -125,8 +125,7 @@ class EvidencesOperations:
             return response_api_not_found()
 
         try:
-            evidence = evidences_get(identifier)
-            self._check_evidence_and_case_identifier_match(evidence, case_identifier)
+            evidence = self._get_evidence_in_case(identifier, case_identifier)
             if not ac_fast_check_current_user_has_case_access(evidence.case_id, [CaseAccessLevel.full_access]):
                 return ac_api_return_access_denied(caseid=evidence.case_id)
 

--- a/source/app/blueprints/rest/v2/case_objects/evidences.py
+++ b/source/app/blueprints/rest/v2/case_objects/evidences.py
@@ -39,7 +39,6 @@ from app.business.evidences import evidences_get
 from app.business.evidences import evidences_update
 from app.business.evidences import evidences_filter
 from app.business.evidences import evidences_delete
-from app.models.models import CaseReceivedFile
 
 
 class EvidencesOperations:
@@ -141,6 +140,7 @@ class EvidencesOperations:
 evidences_operations = EvidencesOperations()
 case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_prefix='/<int:case_identifier>/evidences')
 
+
 @case_evidences_blueprint.get('')
 @ac_api_requires()
 def get_evidences(case_identifier):
@@ -152,6 +152,7 @@ def get_evidences(case_identifier):
 def create_evidence(case_identifier):
     return evidences_operations.create(case_identifier)
 
+
 @case_evidences_blueprint.get('/<int:identifier>')
 @ac_api_requires()
 def get_evidence(case_identifier, identifier):
@@ -162,6 +163,7 @@ def get_evidence(case_identifier, identifier):
 @ac_api_requires()
 def update_evidence(case_identifier, identifier):
     return evidences_operations.update(case_identifier, identifier)
+
 
 @case_evidences_blueprint.delete('/<int:identifier>')
 @ac_api_requires()

--- a/source/app/blueprints/rest/v2/case_objects/evidences.py
+++ b/source/app/blueprints/rest/v2/case_objects/evidences.py
@@ -42,111 +42,129 @@ from app.business.evidences import evidences_delete
 from app.models.models import CaseReceivedFile
 
 
-case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_prefix='/<int:case_identifier>/evidences')
+class EvidencesOperations:
 
+    def __init__(self):
+        self._schema = CaseEvidenceSchema()
+
+    @staticmethod
+    def _check_evidence_and_case_identifier_match(evidence: CaseReceivedFile, case_identifier):
+        if evidence.case_id != case_identifier:
+            raise BusinessProcessingError(f'Evidence {evidence.id} does not belong to case {case_identifier}')
+
+    def list(self, case_identifier):
+        if not cases_exists(case_identifier):
+            return response_api_not_found()
+
+        if not ac_fast_check_current_user_has_case_access(case_identifier,
+                                                          [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=case_identifier)
+
+        pagination_parameters = parse_pagination_parameters(request, default_order_by='date_added',
+                                                            default_direction='desc')
+        try:
+            evidences = evidences_filter(case_identifier, pagination_parameters)
+
+            return response_api_paginated(self._schema, evidences)
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message(), data=e.get_data())
+
+    def create(self, case_identifier):
+
+        if not cases_exists(case_identifier):
+            return response_api_not_found()
+        if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
+            return ac_api_return_access_denied(caseid=case_identifier)
+
+        try:
+            evidence = evidences_create(case_identifier, request.get_json())
+
+            return response_api_created(self._schema.dump(evidence))
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message(), data=e.get_data())
+
+    def get(self, case_identifier, identifier):
+        if not cases_exists(case_identifier):
+            return response_api_not_found()
+
+        try:
+            evidence = evidences_get(identifier)
+            self._check_evidence_and_case_identifier_match(evidence, case_identifier)
+
+            if not ac_fast_check_current_user_has_case_access(evidence.case_id,
+                                                              [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
+                return ac_api_return_access_denied(caseid=evidence.case_id)
+
+            return response_api_success(self._schema.dump(evidence))
+        except ObjectNotFoundError:
+            return response_api_not_found()
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message(), data=e.get_data())
+
+    def update(self, case_identifier, identifier):
+        if not cases_exists(case_identifier):
+            return response_api_not_found()
+
+        try:
+            evidence = evidences_get(identifier)
+            self._check_evidence_and_case_identifier_match(evidence, case_identifier)
+            if not ac_fast_check_current_user_has_case_access(evidence.case_id, [CaseAccessLevel.full_access]):
+                return ac_api_return_access_denied(caseid=evidence.case_id)
+
+            evidence = evidences_update(evidence, request.get_json())
+
+            result = self._schema.dump(evidence)
+            return response_api_success(result)
+        except ObjectNotFoundError:
+            return response_api_not_found()
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message(), data=e.get_data())
+
+    def delete(self, case_identifier, identifier):
+        if not cases_exists(case_identifier):
+            return response_api_not_found()
+
+        try:
+            evidence = evidences_get(identifier)
+            self._check_evidence_and_case_identifier_match(evidence, case_identifier)
+            if not ac_fast_check_current_user_has_case_access(evidence.case_id, [CaseAccessLevel.full_access]):
+                return ac_api_return_access_denied(caseid=evidence.case_id)
+
+            evidences_delete(evidence)
+
+            return response_api_deleted()
+        except ObjectNotFoundError:
+            return response_api_not_found()
+        except BusinessProcessingError as e:
+            return response_api_error(e.get_message(), data=e.get_data())
+
+
+evidences_operations = EvidencesOperations()
+case_evidences_blueprint = Blueprint('case_evidences_rest_v2', __name__, url_prefix='/<int:case_identifier>/evidences')
 
 @case_evidences_blueprint.get('')
 @ac_api_requires()
 def get_evidences(case_identifier):
-    if not cases_exists(case_identifier):
-        return response_api_not_found()
-
-    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
-        return ac_api_return_access_denied(caseid=case_identifier)
-
-    pagination_parameters = parse_pagination_parameters(request, default_order_by='date_added', default_direction='desc')
-    try:
-        evidences = evidences_filter(case_identifier, pagination_parameters)
-
-        evidence_schema = CaseEvidenceSchema()
-        return response_api_paginated(evidence_schema, evidences)
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message(), data=e.get_data())
+    return evidences_operations.list(case_identifier)
 
 
 @case_evidences_blueprint.post('')
 @ac_api_requires()
 def create_evidence(case_identifier):
-
-    if not cases_exists(case_identifier):
-        return response_api_not_found()
-    if not ac_fast_check_current_user_has_case_access(case_identifier, [CaseAccessLevel.full_access]):
-        return ac_api_return_access_denied(caseid=case_identifier)
-
-    try:
-        evidence = evidences_create(case_identifier, request.get_json())
-
-        evidence_schema = CaseEvidenceSchema()
-        return response_api_created(evidence_schema.dump(evidence))
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message(), data=e.get_data())
-
+    return evidences_operations.create(case_identifier)
 
 @case_evidences_blueprint.get('/<int:identifier>')
 @ac_api_requires()
 def get_evidence(case_identifier, identifier):
-    if not cases_exists(case_identifier):
-        return response_api_not_found()
-
-    try:
-        evidence = evidences_get(identifier)
-        _check_evidence_and_case_identifier_match(evidence, case_identifier)
-
-        if not ac_fast_check_current_user_has_case_access(evidence.case_id, [CaseAccessLevel.read_only, CaseAccessLevel.full_access]):
-            return ac_api_return_access_denied(caseid=evidence.case_id)
-
-        evidence_schema = CaseEvidenceSchema()
-        return response_api_success(evidence_schema.dump(evidence))
-    except ObjectNotFoundError:
-        return response_api_not_found()
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message(), data=e.get_data())
+    return evidences_operations.get(case_identifier, identifier)
 
 
 @case_evidences_blueprint.put('/<int:identifier>')
 @ac_api_requires()
 def update_evidence(case_identifier, identifier):
-    if not cases_exists(case_identifier):
-        return response_api_not_found()
-
-    try:
-        evidence = evidences_get(identifier)
-        if not ac_fast_check_current_user_has_case_access(evidence.case_id, [CaseAccessLevel.full_access]):
-            return ac_api_return_access_denied(caseid=evidence.case_id)
-        _check_evidence_and_case_identifier_match(evidence, case_identifier)
-
-        evidence = evidences_update(evidence, request.get_json())
-
-        schema = CaseEvidenceSchema()
-        result = schema.dump(evidence)
-        return response_api_success(result)
-    except ObjectNotFoundError:
-        return response_api_not_found()
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message(), data=e.get_data())
-
+    return evidences_operations.update(case_identifier, identifier)
 
 @case_evidences_blueprint.delete('/<int:identifier>')
 @ac_api_requires()
 def delete_evidence(case_identifier, identifier):
-    if not cases_exists(case_identifier):
-        return response_api_not_found()
-
-    try:
-        evidence = evidences_get(identifier)
-        _check_evidence_and_case_identifier_match(evidence, case_identifier)
-        if not ac_fast_check_current_user_has_case_access(evidence.case_id, [CaseAccessLevel.full_access]):
-            return ac_api_return_access_denied(caseid=evidence.case_id)
-
-        evidences_delete(evidence)
-
-        return response_api_deleted()
-    except ObjectNotFoundError:
-        return response_api_not_found()
-    except BusinessProcessingError as e:
-        return response_api_error(e.get_message(), data=e.get_data())
-
-
-def _check_evidence_and_case_identifier_match(evidence: CaseReceivedFile, case_identifier):
-    if evidence.case_id != case_identifier:
-        raise BusinessProcessingError(f'Evidence {evidence.id} does not belong to case {case_identifier}')
+    return evidences_operations.delete(case_identifier, identifier)

--- a/source/app/blueprints/rest/v2/profile.py
+++ b/source/app/blueprints/rest/v2/profile.py
@@ -35,6 +35,11 @@ class ProfileOperations:
         self._schema = UserSchemaForAPIV2()
         self._update_request_schema = UserSchemaForAPIV2(exclude=['user_is_service_account', 'user_active', 'uuid'])
 
+    def get(self):
+        user = users_get(iris_current_user.id)
+        result = self._schema.dump(user)
+        return response_api_success(result)
+
     def update(self):
         try:
             user = users_get(iris_current_user.id)
@@ -50,6 +55,12 @@ class ProfileOperations:
 
 profile_operations = ProfileOperations()
 profile_blueprint = Blueprint('profile_rest_v2', __name__, url_prefix='/me')
+
+
+@profile_blueprint.get('')
+@ac_api_requires()
+def get_profile():
+    return profile_operations.get()
 
 
 @profile_blueprint.put('')

--- a/tests/tests_rest_profile.py
+++ b/tests/tests_rest_profile.py
@@ -28,6 +28,10 @@ class TestsRestProfile(TestCase):
     def tearDown(self):
         self._subject.clear_database()
 
+    def test_get_me_should_return_200(self):
+        response = self._subject.get('/api/v2/me')
+        self.assertEqual(200, response.status_code)
+
     def test_update_me_should_return_200(self):
         response = self._subject.update('/api/v2/me', {})
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
Implement endpoint `GET /api/v2/me` to get the user profile.

* removed `GET api/v2/auth/whoami`
* deprecated `GET /user/whoami`
* cleaned up cases evidence to be uniform with the way other API v2 endpoints are coded

This PR goes hand in hand with documentation [PR#77](https://github.com/dfir-iris/iris-doc-src/pull/77)