### PR TITLE
V2 api alert similarity

### DIFF
--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -258,6 +258,7 @@ def alerts_get_route(alert_id) -> Response:
 
 @alerts_rest_blueprint.route('/alerts/similarities/<int:alert_id>', methods=['GET'])
 @ac_api_requires(Permissions.alerts_read)
+@endpoint_deprecated('GET', '/api/v2/alerts/{identifier}/related-alerts')
 def alerts_similarities_route(alert_id) -> Response:
     """
     Get an alert and similarities from the database

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -244,3 +244,10 @@ def delete_alert(identifier):
 
     except ObjectNotFoundError:
         return response_api_not_found()
+
+
+@alerts_blueprint.get('/<int:identifier>/related-alerts')
+@ac_api_requires()
+def get_related_alerts(identifier):
+
+    return response_api_success(None)

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -258,3 +258,6 @@ def get_related_alerts(identifier):
 
     except ValidationError as e:
         return response_api_error('Data error', data=e.messages)
+    
+    except ObjectNotFoundError:
+        return response_api_not_found()

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -258,6 +258,6 @@ def get_related_alerts(identifier):
 
     except ValidationError as e:
         return response_api_error('Data error', data=e.messages)
-    
+
     except ObjectNotFoundError:
         return response_api_not_found()

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -248,7 +248,7 @@ def delete_alert(identifier):
 
 
 @alerts_blueprint.get('/<int:identifier>/related-alerts')
-@ac_api_requires()
+@ac_api_requires(Permissions.alerts_read)
 def get_related_alerts(identifier):
 
     try:

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -38,6 +38,7 @@ from app.business.alerts import alerts_create
 from app.business.alerts import alerts_get
 from app.business.alerts import alerts_update
 from app.business.alerts import alerts_delete
+from app.business.alerts import alerts_related
 from app.business.errors import BusinessProcessingError
 from app.business.errors import ObjectNotFoundError
 from app.datamgmt.manage.manage_access_control_db import user_has_client_access
@@ -250,4 +251,10 @@ def delete_alert(identifier):
 @ac_api_requires()
 def get_related_alerts(identifier):
 
-    return response_api_success(None)
+    try:
+        alert = alerts_get(iris_current_user, identifier)
+        similarities = alerts_related(alert)
+        return response_api_success(similarities)
+
+    except ValidationError as e:
+        return response_api_error('Data error', data=e.messages)

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -117,5 +117,4 @@ def alerts_delete(alert: Alert):
 
 def alerts_related(alert: Alert):
 
-        similarities = get_related_alerts(alert.alert_customer_id, alert.assets, alert.iocs)
-        return similarities
+    return get_related_alerts(alert.alert_customer_id, alert.assets, alert.iocs)

--- a/source/app/business/alerts.py
+++ b/source/app/business/alerts.py
@@ -29,6 +29,7 @@ from app.datamgmt.alerts.alerts_db import delete_similar_alert_cache
 from app.datamgmt.alerts.alerts_db import delete_related_alerts_cache
 from app.datamgmt.alerts.alerts_db import get_alert_by_id
 from app.datamgmt.alerts.alerts_db import delete_alert
+from app.datamgmt.alerts.alerts_db import get_related_alerts
 from app.iris_engine.module_handler.module_handler import call_modules_hook
 from app.iris_engine.utils.tracker import track_activity
 from app.util import add_obj_history_entry
@@ -110,4 +111,11 @@ def alerts_delete(alert: Alert):
     delete_alert(alert)
 
     call_modules_hook('on_postload_alert_delete', data=alert.alert_id)
-    track_activity(f'delete alert #{alert.alert_id}', ctx_less=True)
+
+    track_activity(f"delete alert #{alert.alert_id}", ctx_less=True)
+
+
+def alerts_related(alert: Alert):
+
+        similarities = get_related_alerts(alert.alert_customer_id, alert.assets, alert.iocs)
+        return similarities

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -521,7 +521,7 @@ class TestsRestAlerts(TestCase):
         response = self._subject.get(f'/api/v2/alerts/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/related-alerts')
         self.assertEqual(404, response.status_code)
 
-    def test_get_related_alerts_should_return_403_when_user_has_no_permission_to_delete_alert(self):
+    def test_get_related_alerts_should_return_403_when_user_has_no_permission_to_get_alert(self):
         user = self._subject.create_dummy_user()
         body = {
             'alert_title': 'title',

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -481,3 +481,38 @@ class TestsRestAlerts(TestCase):
         identifier = response['alert_id']
         response = self._subject.get(f'/api/v2/alerts/{identifier}/related-alerts')
         self.assertEqual(200, response.status_code)
+
+    def test_get_related_alerts_should_return_two_alerts_identifier_in_iocs_table(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+            "alert_iocs": [{
+                "ioc_value": "Tarzan 5",
+                "ioc_description": "description of Tarzan",
+                "ioc_tlp_id": 1,
+                "ioc_type_id": 2,
+                "ioc_tags": "tag1,tag2",
+            }]
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        body = {
+            'alert_title': 'title_2',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+            "alert_iocs": [{
+                "ioc_value": "Tarzan 5",
+                "ioc_description": "description of Tarzan",
+                "ioc_tlp_id": 1,
+                "ioc_type_id": 2,
+                "ioc_tags": "tag1,tag2",
+            }]
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier2 = response['alert_id']
+        response = self._subject.get(f'/api/v2/alerts/{identifier}/related-alerts').json()
+        alert_ids=[identifier, identifier2]
+        self.assertEqual(alert_ids, response['iocs'])

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -533,3 +533,26 @@ class TestsRestAlerts(TestCase):
         identifier = response['alert_id']
         response = user.get(f'/api/v2/alerts/{identifier}/related-alerts')
         self.assertEqual(403, response.status_code)
+
+    def test_get_related_alerts_should_return_404_when_user_has_no_customer_access(self):
+        body = {
+            'group_name': 'Customer read',
+            'group_description': 'Group with customers can read alert',
+            'group_permissions': [_PERMISSION_ALERTS_READ]
+        }
+        response = self._subject.create('/manage/groups/add', body).json()
+        group_identifier = response['data']['group_id']
+        user = self._subject.create_dummy_user()
+        body = {'groups_membership': [group_identifier]}
+        self._subject.create(f'/manage/users/{user.get_identifier()}/groups/update', body)
+
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1,
+        }
+        response = self._subject.create('/api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        response = user.get(f'/api/v2/alerts/{identifier}/related-alerts')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -514,7 +514,7 @@ class TestsRestAlerts(TestCase):
         response = self._subject.create('api/v2/alerts', body).json()
         identifier2 = response['alert_id']
         response = self._subject.get(f'/api/v2/alerts/{identifier}/related-alerts').json()
-        alert_ids=[identifier, identifier2]
+        alert_ids = [identifier, identifier2]
         self.assertEqual(alert_ids, response['iocs'])
 
     def test_get_related_alerts_should_return_404_when_alert_not_found(self):

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -516,3 +516,7 @@ class TestsRestAlerts(TestCase):
         response = self._subject.get(f'/api/v2/alerts/{identifier}/related-alerts').json()
         alert_ids=[identifier, identifier2]
         self.assertEqual(alert_ids, response['iocs'])
+
+    def test_get_related_alerts_should_return_404_when_alert_not_found(self):
+        response = self._subject.get(f'/api/v2/alerts/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/related-alerts')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -520,3 +520,16 @@ class TestsRestAlerts(TestCase):
     def test_get_related_alerts_should_return_404_when_alert_not_found(self):
         response = self._subject.get(f'/api/v2/alerts/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}/related-alerts')
         self.assertEqual(404, response.status_code)
+
+    def test_get_related_alerts_should_return_403_when_user_has_no_permission_to_delete_alert(self):
+        user = self._subject.create_dummy_user()
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        response = user.get(f'/api/v2/alerts/{identifier}/related-alerts')
+        self.assertEqual(403, response.status_code)

--- a/tests/tests_rest_alerts.py
+++ b/tests/tests_rest_alerts.py
@@ -469,3 +469,15 @@ class TestsRestAlerts(TestCase):
         self._subject.delete(f'/api/v2/alerts/{identifier}')
         response = self._subject.get(f'/api/v2/alerts/{identifier}')
         self.assertEqual(404, response.status_code)
+
+    def test_get_related_alerts_should_return_200(self):
+        body = {
+            'alert_title': 'title',
+            'alert_severity_id': 4,
+            'alert_status_id': 3,
+            'alert_customer_id': 1
+        }
+        response = self._subject.create('api/v2/alerts', body).json()
+        identifier = response['alert_id']
+        response = self._subject.get(f'/api/v2/alerts/{identifier}/related-alerts')
+        self.assertEqual(200, response.status_code)


### PR DESCRIPTION
Implementation of endpoint GET /api/v2/alerts/{identifier}/related-alerts to get related alerts.

   *  Deprecated GET /alerts/similarities/{alert_id}

Note: this PR is accompanied by the documentation https://github.com/dfir-iris/iris-doc-src/pull/78.