### PR TITLE
[FIX]: correct enableTls evaluation in ingress template

### DIFF
--- a/deploy/kubernetes/charts/Chart.yaml
+++ b/deploy/kubernetes/charts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/kubernetes/charts/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/templates/ingress.yaml
@@ -39,7 +39,7 @@ spec:
                         {{- end }}
         {{- end }}
     {{- end }}
-  {{- if and .Values.ingress.enableTls.enabled (gt (len .Values.ingress.tls.hosts) 0) }}
+  {{- if and .Values.ingress.enableTls (gt (len .Values.ingress.tls.hosts) 0) }}
   tls:
     - hosts:
       {{- range .Values.ingress.tls.hosts }}


### PR DESCRIPTION
Fixes the Helm ingress template which incorrectly accessed enableTls as an object. 
Now it correctly evaluates the boolean value from values.yaml, preventing rendering errors.