### PR TITLE
[IMP] Add liveness and readiness probes to iris_app and iris_worker

### DIFF
--- a/deploy/kubernetes/charts/Chart.yaml
+++ b/deploy/kubernetes/charts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/kubernetes/charts/templates/iris_app.yaml
+++ b/deploy/kubernetes/charts/templates/iris_app.yaml
@@ -108,6 +108,19 @@ spec:
           ports:
             - containerPort: 8000
 
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+
           volumeMounts:
             - mountPath: /home/iris/downloads
               name: iris-downloads  

--- a/deploy/kubernetes/charts/templates/iris_worker.yaml
+++ b/deploy/kubernetes/charts/templates/iris_worker.yaml
@@ -73,6 +73,26 @@ spec:
           - name: NUMBER_OF_CHILD
             value: {{ .Values.irisworker.NUMBER_OF_CHILD | quote }}
 
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  ps -eo cmd | grep -E "celery -A app.celery worker" | grep -Pv ^grep > /dev/null
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  ps -eo cmd | grep -E "celery -A app.celery worker" | grep -Pv ^grep > /dev/null
+            initialDelaySeconds: 15
+            periodSeconds: 10
 
           volumeMounts:
             - mountPath: /home/iris/downloads


### PR DESCRIPTION
Add simple liveness and readiness probes to iris_app and iris_worker to improve pod stability and recovery.