### PR TITLE
[IMP] Simplify environment variable injection in Helm charts using envFrom

### DIFF
--- a/deploy/kubernetes/charts/Chart.yaml
+++ b/deploy/kubernetes/charts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/kubernetes/charts/templates/iris_app.yaml
+++ b/deploy/kubernetes/charts/templates/iris_app.yaml
@@ -45,65 +45,59 @@ spec:
           imagePullPolicy: "{{ .Values.irisapp.imagePullPolicy }}"
           command: ['nohup', './iris-entrypoint.sh', 'iriswebapp']
 
+          envFrom:
+          {{- range $.Values.irisapp.envFromSecrets }}
+            - secretRef:
+                name: {{ .name }}
+          {{- end }}
+
           env:
-          {{- range $key := list "POSTGRES_USER" "POSTGRES_PASSWORD" "POSTGRES_ADMIN_USER" "POSTGRES_ADMIN_PASSWORD" "POSTGRES_PORT" "POSTGRES_SERVER" }}
-          - name: {{ $key }}
-            {{- if and (hasKey $.Values.irisapp "envFromSecret") (has $key $.Values.irisapp.envFromSecret.keys) }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $.Values.irisapp.envFromSecret.name }}
-                key: {{ $key }}
-            {{- else }}
-            value: {{ index $.Values.irisapp $key | quote }}
+            - name:  IRIS_SECRET_KEY
+              value: {{ .Values.irisapp.IRIS_SECRET_KEY | quote }}
+
+            - name:  IRIS_SECURITY_PASSWORD_SALT
+              value: {{ .Values.irisapp.IRIS_SECURITY_PASSWORD_SALT | quote }}
+
+            - name:  DB_RETRY_COUNT
+              value: {{ .Values.irisapp.DB_RETRY_COUNT | quote }}
+
+            - name:  DB_RETRY_DELAY
+              value: {{ .Values.irisapp.DB_RETRY_DELAY | quote }}
+
+            - name:  INTERFACE_HTTPS_PORT
+              value: {{ .Values.irisapp.INTERFACE_HTTPS_PORT | quote }}
+
+            - name:  IRIS_ADM_USERNAME
+              value: {{ .Values.irisapp.IRIS_ADM_USERNAME | quote }}
+
+            - name:  IRIS_ADM_PASSWORD
+              value: {{ .Values.irisapp.IRIS_ADM_PASSWORD | quote }}
+
+            {{- if eq .Values.irisapp.IRIS_AUTHENTICATION_TYPE "oidc" }}
+            - name: OIDC_ISSUER_URL
+              value: {{ .Values.irisapp.OIDC_ISSUER_URL | quote }}
+
+            - name: OIDC_CLIENT_ID
+              value: {{ .Values.irisapp.OIDC_CLIENT_ID | quote }}
+
+            - name: OIDC_CLIENT_SECRET
+              value: {{ .Values.irisapp.OIDC_CLIENT_SECRET | quote }}
+
+            - name: OIDC_AUTH_ENDPOINT
+              value: {{ .Values.irisapp.OIDC_AUTH_ENDPOINT | quote }}
+
+            - name: OIDC_TOKEN_ENDPOINT
+              value: {{ .Values.irisapp.OIDC_TOKEN_ENDPOINT | quote }}
+
+            - name: OIDC_END_SESSION_ENDPOINT
+              value: {{ .Values.irisapp.OIDC_END_SESSION_ENDPOINT | quote }}
+
+            - name: OIDC_MAPPING_USERGROUP
+              value: {{ .Values.irisapp.OIDC_MAPPING_USERGROUP | quote }}
+
+            - name: OIDC_MAPPING_ROLES
+              value: {{ .Values.irisapp.OIDC_MAPPING_ROLES | quote }}
             {{- end }}
-          {{- end }}
-
-          - name:  IRIS_SECRET_KEY 
-            value: {{ .Values.irisapp.IRIS_SECRET_KEY | quote }}
-
-          - name:  IRIS_SECURITY_PASSWORD_SALT 
-            value: {{ .Values.irisapp.IRIS_SECURITY_PASSWORD_SALT | quote }}
-
-          - name:  DB_RETRY_COUNT
-            value: {{ .Values.irisapp.DB_RETRY_COUNT | quote }}
-
-          - name:  DB_RETRY_DELAY
-            value: {{ .Values.irisapp.DB_RETRY_DELAY | quote }}
-
-          - name:  INTERFACE_HTTPS_PORT
-            value: {{ .Values.irisapp.INTERFACE_HTTPS_PORT | quote }}
-
-          - name:  IRIS_ADM_USERNAME
-            value: {{ .Values.irisapp.IRIS_ADM_USERNAME | quote }}
-
-          - name:  IRIS_ADM_PASSWORD
-            value: {{ .Values.irisapp.IRIS_ADM_PASSWORD | quote }}
-          
-          {{- if eq .Values.irisapp.IRIS_AUTHENTICATION_TYPE "oidc" }}
-          - name: OIDC_ISSUER_URL
-            value: {{ .Values.irisapp.OIDC_ISSUER_URL | quote }}
-
-          - name: OIDC_CLIENT_ID
-            value: {{ .Values.irisapp.OIDC_CLIENT_ID | quote }}
-
-          - name: OIDC_CLIENT_SECRET
-            value: {{ .Values.irisapp.OIDC_CLIENT_SECRET | quote }}
-
-          - name: OIDC_AUTH_ENDPOINT
-            value: {{ .Values.irisapp.OIDC_AUTH_ENDPOINT | quote }}
-
-          - name: OIDC_TOKEN_ENDPOINT
-            value: {{ .Values.irisapp.OIDC_TOKEN_ENDPOINT | quote }}
-
-          - name: OIDC_END_SESSION_ENDPOINT
-            value: {{ .Values.irisapp.OIDC_END_SESSION_ENDPOINT | quote }}
-
-          - name: OIDC_MAPPING_USERGROUP
-            value: {{ .Values.irisapp.OIDC_MAPPING_USERGROUP | quote }}
-
-          - name: OIDC_MAPPING_ROLES
-            value: {{ .Values.irisapp.OIDC_MAPPING_ROLES | quote }}
-          {{- end }}
           
           ports:
             - containerPort: 8000

--- a/deploy/kubernetes/charts/templates/iris_worker.yaml
+++ b/deploy/kubernetes/charts/templates/iris_worker.yaml
@@ -43,23 +43,18 @@ spec:
           image: "{{ .Values.irisworker.image}}:{{ .Values.irisworker.tag }}"
           imagePullPolicy: "{{ .Values.irisworker.imagePullPolicy }}"
           command: ['./wait-for-iriswebapp.sh', "{{ .Values.irisapp.name }}:{{ .Values.irisapp.service.port }}", './iris-entrypoint.sh', 'iris-worker']
+          
+          envFrom:
+          {{- range $.Values.irisworker.envFromSecrets }}
+            - secretRef:
+                name: {{ .name }}
+          {{- end }}
 
           env:
 
           - name: DOCKERIZED
             value: {{ .Values.irisworker.DOCKERIZED | quote }}
 
-          {{- range $key := list "POSTGRES_USER" "POSTGRES_PASSWORD" "POSTGRES_ADMIN_USER" "POSTGRES_ADMIN_PASSWORD" "POSTGRES_PORT" "POSTGRES_SERVER" }}
-          - name: {{ $key }}
-            {{- if and (hasKey $.Values.irisworker "envFromSecret") (has $key $.Values.irisworker.envFromSecret.keys) }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $.Values.irisworker.envFromSecret.name }}
-                key: {{ $key }}
-            {{- else }}
-            value: {{ index $.Values.irisworker $key | quote }}
-            {{- end }}
-          {{- end }}
 
           - name: CELERY_BROKER
             value: {{ .Values.irisworker.CELERY_BROKER | quote }}

--- a/deploy/kubernetes/charts/values.yaml
+++ b/deploy/kubernetes/charts/values.yaml
@@ -132,17 +132,11 @@ irisapp:
   DB_RETRY_DELAY: 5
   INTERFACE_HTTPS_PORT: 443
   
-  ## @param irisapp.envFromSecret Environment variables from a secret
+  ## @param irisapp.envFromSecrets List of secrets to load environment variables from
   ##
-  envFromSecret:
-    name: postgres-secret
-    keys:
-      - POSTGRES_USER
-      - POSTGRES_PASSWORD
-      - POSTGRES_ADMIN_USER
-      - POSTGRES_ADMIN_PASSWORD
-      - POSTGRES_PORT
-      - POSTGRES_SERVER
+  envFromSecrets:
+    - name: postgres-secret
+    # - name: extra-secret
 
   ## @param irisapp.securityContext securityContext for irisapp
   ##
@@ -199,17 +193,11 @@ irisworker:
   IRIS_SECRET_KEY: AVerySuperSecretKey-SoNotThisOne
   IRIS_SECURITY_PASSWORD_SALT: ARandomSalt-NotThisOneEither
   
-  ## @param irisapp.envFromSecret Environment variables from a secret
+  ## @param irisworker.envFromSecrets List of secrets to load environment variables from
   ##
-  envFromSecret:
-    name: postgres-secret
-    keys:
-      - POSTGRES_USER
-      - POSTGRES_PASSWORD
-      - POSTGRES_ADMIN_USER
-      - POSTGRES_ADMIN_PASSWORD
-      - POSTGRES_PORT
-      - POSTGRES_SERVER
+  envFromSecrets:
+    - name: postgres-secret
+    # - name: extra-secret
 
   ## @param irisworker.securityContext securityContext for irisworker
   ##


### PR DESCRIPTION
## Summary
This PR replaces the manual environment variable mapping logic in 
the irisapp and irisworker Helm charts with Kubernetes-native `envFrom` 
references. This allows the deployments to load environment variables 
directly from one or more secrets.

## Motivation
Previously, only a single secret could be used, and adding or removing 
environment variables required modifying the Helm template. Using `envFrom` 
simplifies the templates, improves maintainability, and aligns with 
Kubernetes best practices.

## Changes
- Replaced the loop for POSTGRES_* variables in irisapp with `envFrom`.
- Added support for multiple secrets in both irisapp and irisworker via `envFromSecrets`.
- Adjusted values.yaml comments to clarify plural/multiple secrets support.

## Benefits
- Cleaner and shorter Helm templates
- Multiple secret support
- No need to hardcode variable names
- Easier maintenance and consistency across environments
