### PR TITLE
Api v2 get alert filter

### DIFF
--- a/source/app/blueprints/rest/filters_routes.py
+++ b/source/app/blueprints/rest/filters_routes.py
@@ -130,6 +130,7 @@ def filters_delete_route(filter_id) -> Response:
 
 
 @saved_filters_rest_blueprint.route('/filters/<int:filter_id>', methods=['GET'])
+@endpoint_deprecated('GET', '/api/v2/alerts-filters')
 @ac_api_requires()
 def filters_get_route(filter_id) -> Response:
     """

--- a/source/app/blueprints/rest/v2/alerts_filters.py
+++ b/source/app/blueprints/rest/v2/alerts_filters.py
@@ -53,7 +53,7 @@ class AlertsFiltersOperations:
 
         except ValidationError as e:
             return response_api_error('Data error', e.messages)
-    
+
     def get(self, identifier):
         try:
             saved_filter = get_filter_by_id(identifier)
@@ -61,7 +61,6 @@ class AlertsFiltersOperations:
 
         except ObjectNotFoundError:
             return response_api_not_found()
-
 
 
 alerts_filters_blueprint = Blueprint('alerts_filters_rest_v2', __name__, url_prefix='/alerts-filters')
@@ -72,6 +71,7 @@ alerts_filters_operations = AlertsFiltersOperations()
 @ac_api_requires()
 def create_alert_filter():
     return alerts_filters_operations.create()
+
 
 @alerts_filters_blueprint.get('/<int:identifier>')
 @ac_api_requires()

--- a/source/app/blueprints/rest/v2/alerts_filters.py
+++ b/source/app/blueprints/rest/v2/alerts_filters.py
@@ -30,8 +30,8 @@ from app.blueprints.iris_user import iris_current_user
 
 from app.schema.marshables import SavedFilterSchema
 from app.business.errors import ObjectNotFoundError
-from app.business.alerts_filters import add_alerts_filters
-from app.datamgmt.filters.filters_db import get_filter_by_id
+from app.business.alerts_filters import alerts_filters_add
+from app.business.alerts_filters import alerts_filters_get
 
 
 class AlertsFiltersOperations:
@@ -48,7 +48,7 @@ class AlertsFiltersOperations:
 
         try:
             new_saved_filter = self._load(request_data)
-            add_alerts_filters(new_saved_filter)
+            alerts_filters_add(new_saved_filter)
             return response_api_created(self._schema.dump(new_saved_filter))
 
         except ValidationError as e:
@@ -56,7 +56,7 @@ class AlertsFiltersOperations:
 
     def get(self, identifier):
         try:
-            saved_filter = get_filter_by_id(identifier)
+            saved_filter = alerts_filters_get(identifier)
             return response_api_success(self._schema.dump(saved_filter))
 
         except ObjectNotFoundError:

--- a/source/app/blueprints/rest/v2/alerts_filters.py
+++ b/source/app/blueprints/rest/v2/alerts_filters.py
@@ -53,7 +53,7 @@ class AlertsFiltersOperations:
 
         except ValidationError as e:
             return response_api_error('Data error', e.messages)
-    
+
     def get(self, identifier):
         try:
             saved_filter = alert_filter_get(identifier)

--- a/source/app/blueprints/rest/v2/alerts_filters.py
+++ b/source/app/blueprints/rest/v2/alerts_filters.py
@@ -30,8 +30,8 @@ from app.blueprints.iris_user import iris_current_user
 
 from app.schema.marshables import SavedFilterSchema
 from app.business.errors import ObjectNotFoundError
-from app.business.alerts_filters import alerts_filters_add
-from app.business.alerts_filters import alerts_filters_get
+from app.business.alerts_filters import alert_filter_add
+from app.business.alerts_filters import alert_filter_get
 
 
 class AlertsFiltersOperations:
@@ -48,17 +48,16 @@ class AlertsFiltersOperations:
 
         try:
             new_saved_filter = self._load(request_data)
-            alerts_filters_add(new_saved_filter)
+            alert_filter_add(new_saved_filter)
             return response_api_created(self._schema.dump(new_saved_filter))
 
         except ValidationError as e:
             return response_api_error('Data error', e.messages)
-
+    
     def get(self, identifier):
         try:
-            saved_filter = alerts_filters_get(identifier)
+            saved_filter = alert_filter_get(identifier)
             return response_api_success(self._schema.dump(saved_filter))
-
         except ObjectNotFoundError:
             return response_api_not_found()
 

--- a/source/app/business/alerts_filters.py
+++ b/source/app/business/alerts_filters.py
@@ -20,6 +20,7 @@ from app import db
 from app.datamgmt.filters.filters_db import get_filter_by_id
 from app.business.errors import ObjectNotFoundError
 
+
 def alert_filter_add(new_saved_filter):
     db.session.add(new_saved_filter)
     db.session.commit()

--- a/source/app/business/alerts_filters.py
+++ b/source/app/business/alerts_filters.py
@@ -18,12 +18,15 @@
 
 from app import db
 from app.datamgmt.filters.filters_db import get_filter_by_id
+from app.business.errors import ObjectNotFoundError
 
-
-def alerts_filters_add(new_saved_filter):
+def alert_filter_add(new_saved_filter):
     db.session.add(new_saved_filter)
     db.session.commit()
 
 
-def alerts_filters_get(identifier):
-    return get_filter_by_id(identifier)
+def alert_filter_get(identifier):
+    alert_filter = get_filter_by_id(identifier)
+    if not alert_filter:
+        raise ObjectNotFoundError()
+    return alert_filter

--- a/source/app/business/alerts_filters.py
+++ b/source/app/business/alerts_filters.py
@@ -1,0 +1,24 @@
+#  IRIS Source Code
+#  Copyright (C) 2024 - DFIR-IRIS
+#  contact@dfir-iris.org
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from app import db
+
+
+def add_alerts_filters(new_saved_filter):
+    db.session.add(new_saved_filter)
+    db.session.commit()

--- a/source/app/business/alerts_filters.py
+++ b/source/app/business/alerts_filters.py
@@ -19,9 +19,11 @@
 from app import db
 from app.datamgmt.filters.filters_db import get_filter_by_id
 
+
 def alerts_filters_add(new_saved_filter):
     db.session.add(new_saved_filter)
     db.session.commit()
 
+
 def alerts_filters_get(identifier):
-    return get_filter_by_id(identifier)    
+    return get_filter_by_id(identifier)

--- a/source/app/business/alerts_filters.py
+++ b/source/app/business/alerts_filters.py
@@ -17,8 +17,11 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from app import db
+from app.datamgmt.filters.filters_db import get_filter_by_id
 
-
-def add_alerts_filters(new_saved_filter):
+def alerts_filters_add(new_saved_filter):
     db.session.add(new_saved_filter)
     db.session.commit()
+
+def alerts_filters_get(identifier):
+    return get_filter_by_id(identifier)    

--- a/tests/tests_rest_alerts_filters.py
+++ b/tests/tests_rest_alerts_filters.py
@@ -188,3 +188,36 @@ class TestsRestAlertsFilters(TestCase):
         identifier = response['filter_id']
         response = self._subject.get(f'/api/v2/alerts-filters/{identifier}')
         self.assertEqual(200, response.status_code)
+
+    def test_get_alert_filter_should_return_filter_name(self):
+        filter_name = 'filter name'
+        body = {
+            'filter_is_private': 'true',
+            'filter_type': 'alerts',
+            'filter_name': filter_name,
+            'filter_description': 'filter description',
+            'filter_data' : {
+                'alert_tilte': 'filter name',
+                'alert_description': '',
+                'alert_source': '',
+                'alert_tags': '',
+                'alert_severity_id': '',
+                'alert_start_date': '',
+                'source_start_date': '',
+                'source_end_date': '',
+                'creation_end_date': '',
+                'creation_start_date': '',
+                'alert_assets': '',
+                'alert_iocs': '',
+                'alert_ids': '',
+                'source_reference': '',
+                'case_id': '',
+                'custom_conditions': '',
+
+            }
+        }
+
+        response = self._subject.create('/api/v2/alerts-filters', body).json()
+        identifier = response['filter_id']
+        response = self._subject.get(f'/api/v2/alerts-filters/{identifier}').json()
+        self.assertEqual(filter_name, response['filter_name'])

--- a/tests/tests_rest_alerts_filters.py
+++ b/tests/tests_rest_alerts_filters.py
@@ -227,3 +227,36 @@ class TestsRestAlertsFilters(TestCase):
     def test_get_alert_filter_should_return_404_when_alert_filter_not_found(self):
         response = self._subject.get(f'/api/v2/alerts-filters/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)
+
+    def test_get_alert_filter_should_return_404_when_user_has_not_created_alert_filter(self):
+        user = self._subject.create_dummy_user()
+        body = {
+            'filter_is_private': 'true',
+            'filter_type': 'alerts',
+            'filter_name': 'filter_name',
+            'filter_description': 'filter description',
+            'filter_data' : {
+                'alert_tilte': 'filter name',
+                'alert_description': '',
+                'alert_source': '',
+                'alert_tags': '',
+                'alert_severity_id': '',
+                'alert_start_date': '',
+                'source_start_date': '',
+                'source_end_date': '',
+                'creation_end_date': '',
+                'creation_start_date': '',
+                'alert_assets': '',
+                'alert_iocs': '',
+                'alert_ids': '',
+                'source_reference': '',
+                'case_id': '',
+                'custom_conditions': '',
+
+            }
+        }
+
+        response = self._subject.create('/api/v2/alerts-filters', body).json()
+        identifier = response['filter_id']
+        response = user.get(f'/api/v2/alerts-filters/{identifier}')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_alerts_filters.py
+++ b/tests/tests_rest_alerts_filters.py
@@ -183,8 +183,8 @@ class TestsRestAlertsFilters(TestCase):
 
             }
         }
-        user = self._subject.create_dummy_user()
-        response = user.create('/api/v2/alerts-filters', body).json()
+
+        response = self._subject.create('/api/v2/alerts-filters', body).json()
         identifier = response['filter_id']
         response = self._subject.get(f'/api/v2/alerts-filters/{identifier}')
         self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_alerts_filters.py
+++ b/tests/tests_rest_alerts_filters.py
@@ -19,6 +19,8 @@
 from unittest import TestCase
 from iris import Iris
 
+_IDENTIFIER_FOR_NONEXISTENT_OBJECT = 123456789
+
 
 class TestsRestAlertsFilters(TestCase):
 
@@ -221,3 +223,7 @@ class TestsRestAlertsFilters(TestCase):
         identifier = response['filter_id']
         response = self._subject.get(f'/api/v2/alerts-filters/{identifier}').json()
         self.assertEqual(filter_name, response['filter_name'])
+    
+    def test_get_alert_filter_should_return_404_when_alert_filter_not_found(self):
+        response = self._subject.get(f'/api/v2/alerts-filters/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
+        self.assertEqual(404, response.status_code)

--- a/tests/tests_rest_alerts_filters.py
+++ b/tests/tests_rest_alerts_filters.py
@@ -156,3 +156,35 @@ class TestsRestAlertsFilters(TestCase):
         }
         response = self._subject.create('/api/v2/alerts-filters', body).json()
         self.assertEqual(alert_title, response['filter_data']['alert_title'])
+
+    def test_get_alert_filter_should_return_200(self):
+        body = {
+            'filter_is_private': 'true',
+            'filter_type': 'alerts',
+            'filter_name': 'filter name',
+            'filter_description': 'filter description',
+            'filter_data' : {
+                'alert_tilte': 'filter name',
+                'alert_description': '',
+                'alert_source': '',
+                'alert_tags': '',
+                'alert_severity_id': '',
+                'alert_start_date': '',
+                'source_start_date': '',
+                'source_end_date': '',
+                'creation_end_date': '',
+                'creation_start_date': '',
+                'alert_assets': '',
+                'alert_iocs': '',
+                'alert_ids': '',
+                'source_reference': '',
+                'case_id': '',
+                'custom_conditions': '',
+
+            }
+        }
+        user = self._subject.create_dummy_user()
+        response = user.create('/api/v2/alerts-filters', body).json()
+        identifier = response['filter_id']
+        response = self._subject.get(f'/api/v2/alerts-filters/{identifier}')
+        self.assertEqual(200, response.status_code)

--- a/tests/tests_rest_alerts_filters.py
+++ b/tests/tests_rest_alerts_filters.py
@@ -223,7 +223,7 @@ class TestsRestAlertsFilters(TestCase):
         identifier = response['filter_id']
         response = self._subject.get(f'/api/v2/alerts-filters/{identifier}').json()
         self.assertEqual(filter_name, response['filter_name'])
-    
+
     def test_get_alert_filter_should_return_404_when_alert_filter_not_found(self):
         response = self._subject.get(f'/api/v2/alerts-filters/{_IDENTIFIER_FOR_NONEXISTENT_OBJECT}')
         self.assertEqual(404, response.status_code)


### PR DESCRIPTION
Implementation of endpoint `GET /api/v2/alerts-filters/{identifier}` to get alerts filters.

   *  Deprecated `GET /filters/<int:filter_id>`

Note: this PR is accompanied by the documentation https://github.com/dfir-iris/iris-doc-src/pull/87.