### PR TITLE
[ADD] Add traefik support

### DIFF
--- a/deploy/kubernetes/charts/Chart.yaml
+++ b/deploy/kubernetes/charts/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/kubernetes/charts/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.ingress.enabled (not .Values.ingress.traefik.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/deploy/kubernetes/charts/templates/ingress_route.yaml
+++ b/deploy/kubernetes/charts/templates/ingress_route.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingress.traefik.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ .Values.ingress.name }}
+  {{- with .Values.ingress.customAnnotations }}
+  annotations:
+  {{- range $k, $v := . }}
+    {{- if not (hasPrefix "nginx.ingress.kubernetes.io" $k) }}
+    {{ $k }}: {{ $v }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+spec:
+  entryPoints:
+    - {{ .Values.ingress.traefik.entryPoint | default "web" }}
+  routes:
+  {{- range $host := .Values.ingress.hosts }}
+    {{- range $path := $host.paths }}
+    - kind: Rule
+      match: >
+        Host(`{{ $host.host }}`) && PathPrefix(`{{ $path.path }}`)
+      services:
+        - name: {{ $.Values.irisapp.name }}
+          port: {{ $.Values.irisapp.service.port }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/values.yaml
+++ b/deploy/kubernetes/charts/values.yaml
@@ -224,6 +224,9 @@ ingress:
   enabled: true
   name: iris-ingress
   className: nginx
+  traefik:
+    enabled: false
+    entryPoint: web
   enableTls: false
   sslRedirect: false
   customAnnotations:


### PR DESCRIPTION
# Summary

This PR adds optional support for Traefik by introducing a new IngressRoute template.
Charts can now render either a standard Kubernetes Ingress or a Traefik IngressRoute, depending on configuration.

# Key Changes

Added ingress_route.yaml to render a traefik.io/v1alpha1 IngressRoute when ingress.traefik.enabled = true.

Updated ingress.yaml to render only when Traefik is disabled.

Extended values.yaml with:
```yaml
ingress.traefik.enabled
ingress.traefik.entryPoint
```

Added fallback logic for service name and port, with clear failures when missing.

# Why

Allows deployments using Traefik to work natively with its CRDs while keeping full backward compatibility for environments using standard Ingress controllers.

# Compatibility

No breaking changes.

Existing setups using NGINX or other Ingress controllers continue working without modifications.