### PR TITLE
Added support for calling from a new Svelte UI.

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -108,7 +108,7 @@ services:
     working_dir: /app
     environment:
       - IRIS_SVELTEKIT_FRONTEND_DIR=${IRIS_SVELTEKIT_FRONTEND_DIR:-../iris-frontend}
-      - PUBLIC_EXTERNAL_API_URL=${PUBLIC_EXTERNAL_API_URL:-https://127.0.0.1}
+      - PUBLIC_EXTERNAL_API_URL=${PUBLIC_EXTERNAL_API_URL:-http://127.0.0.1:8000}
       - PUBLIC_INTERNAL_API_URL=http://${IRIS_UPSTREAM_SERVER}:${IRIS_UPSTREAM_PORT}
       - PUBLIC_USE_MOCK_API_DATA=false
       - ORIGIN=https://127.0.0.1

--- a/docker/nginx/nginx-newui.conf
+++ b/docker/nginx/nginx-newui.conf
@@ -26,7 +26,7 @@ events {
 
 http {
     map $request_uri $csp_header {
-        default "default-src 'self' https://analytics.dfir-iris.org https://127.0.0.1 http://app:8000; script-src 'self' 'unsafe-inline' https://analytics.dfir-iris.org; style-src 'self' 'unsafe-inline'; img-src 'self' data:;";
+        default "default-src 'self' https://analytics.dfir-iris.org https://127.0.0.1 http://app:8000; script-src 'self' 'unsafe-inline' https://analytics.dfir-iris.org; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://127.0.0.1:8000;";
     }
     include /etc/nginx/mime.types;
 


### PR DESCRIPTION
New Svelte UI requires HTTP access on port 8000.