### PR TITLE
[#1024][IMP] Improve custom dashboards for case-based widgets and time override UX

### DIFF
--- a/source/app/blueprints/custom_dashboard/templates/custom_dashboards/index.html
+++ b/source/app/blueprints/custom_dashboard/templates/custom_dashboards/index.html
@@ -158,43 +158,7 @@
             <small class="form-text text-muted">Edit the full dashboard payload. Switch back to the visual builder to continue using the guided UI.</small>
           </div>
 
-          <datalist id="dashboardBuilderColumnOptions">
-            <option value="alerts.alert_id">
-            <option value="alerts.alert_uuid">
-            <option value="alerts.alert_title">
-            <option value="alerts.alert_source">
-            <option value="alerts.alert_source_ref">
-            <option value="alerts.alert_description">
-            <option value="alerts.alert_creation_time">
-            <option value="alerts.alert_source_event_time">
-            <option value="alerts.alert_customer_id">
-            <option value="alerts.alert_resolution_status_id">
-            <option value="alerts.alert_status_id">
-            <option value="alerts.alert_severity_id">
-            <option value="alerts.alert_classification_id">
-            <option value="client.client_id">
-            <option value="client.name">
-            <option value="alert_resolution_status.resolution_status_id">
-            <option value="alert_resolution_status.resolution_status_name">
-            <option value="alert_status.status_id">
-            <option value="alert_status.status_name">
-            <option value="severities.severity_id">
-            <option value="severities.severity_name">
-            <option value="case_classification.id">
-            <option value="case_classification.name">
-            <option value="case_classification.name_expanded">
-            <option value="cases.case_id">
-            <option value="cases.name">
-            <option value="cases.owner_id">
-            <option value="cases.creator_id">
-            <option value="cases.reviewer_id">
-            <option value="cases.review_status_id">
-            <option value="case_reviewer.id">
-            <option value="case_reviewer.username">
-            <option value="case_reviewer.name">
-            <option value="review_status.id">
-            <option value="review_status.status_name">
-          </datalist>
+          <datalist id="dashboardBuilderColumnOptions"></datalist>
         </form>
       </div>
       <div class="modal-footer">

--- a/source/app/datamgmt/custom_dashboard/query_engine.py
+++ b/source/app/datamgmt/custom_dashboard/query_engine.py
@@ -15,7 +15,7 @@ from app.datamgmt.manage.manage_access_control_db import get_user_clients_id
 from app.iris_engine.access_control.utils import ac_current_user_has_permission, ac_get_fast_user_cases_access
 from app.models.alerts import Alert, AlertResolutionStatus, AlertStatus, Severity
 from app.models.alerts import AlertCaseAssociation
-from app.models.cases import Cases, CaseTags, CasesEvent
+from app.models.cases import Cases, CaseState, CaseTags, CasesEvent
 from app.models.authorization import Permissions, User
 from app.models.models import (
     CaseClassification,
@@ -28,7 +28,9 @@ from app.models.models import (
     IocLink,
     Notes,
     CaseTasks,
-    ReviewStatus
+    ReviewStatus,
+    alert_assets_association,
+    alert_iocs_association
 )
 
 
@@ -46,6 +48,102 @@ class WidgetQueryResult:
 
 
 _MAX_TIME_BUCKET_POINTS = 2000
+_DEFAULT_BASE_TABLE = 'alerts'
+_BASE_TIME_COLUMNS = {
+    'alerts': 'alerts.alert_creation_time',
+    'cases': 'cases.initial_date'
+}
+_ALERT_BASE_FAMILY_TABLES: Set[str] = {
+    'alerts',
+    'client',
+    'alert_resolution_status',
+    'alert_status',
+    'severities',
+    'case_classification',
+    'alert_owner',
+    'alert_assets',
+    'alert_asset_types',
+    'alert_iocs',
+    'alert_ioc_types'
+}
+_CASE_BASE_FAMILY_TABLES: Set[str] = {
+    'cases',
+    'case_client',
+    'case_classification_lookup',
+    'case_severity',
+    'case_state',
+    'case_tags',
+    'case_owner',
+    'case_creator',
+    'case_reviewer',
+    'tags',
+    'case_assets',
+    'case_asset_types',
+    'case_iocs',
+    'case_ioc_types',
+    'case_events',
+    'case_notes',
+    'case_tasks',
+    'review_status'
+}
+
+
+def _parse_table_name_from_reference(value: Any) -> Optional[str]:
+    if not isinstance(value, str) or '.' not in value:
+        return None
+    table_name, _ = value.split('.', 1)
+    normalized = table_name.strip()
+    return normalized or None
+
+
+def _collect_widget_tables(definition: Optional[Dict[str, Any]]) -> Set[str]:
+    if not isinstance(definition, dict):
+        return set()
+
+    referenced_tables: Set[str] = set()
+
+    for field in definition.get('fields') or []:
+        if not isinstance(field, dict):
+            continue
+        table_name = field.get('table')
+        if isinstance(table_name, str) and table_name.strip():
+            referenced_tables.add(table_name.strip())
+        inline_filter = field.get('filter')
+        if isinstance(inline_filter, dict):
+            inline_table = inline_filter.get('table')
+            if isinstance(inline_table, str) and inline_table.strip():
+                referenced_tables.add(inline_table.strip())
+
+    for group_entry in definition.get('group_by') or []:
+        table_name = _parse_table_name_from_reference(group_entry)
+        if table_name:
+            referenced_tables.add(table_name)
+
+    for filter_entry in definition.get('filters') or []:
+        if not isinstance(filter_entry, dict):
+            continue
+        table_name = filter_entry.get('table')
+        if isinstance(table_name, str) and table_name.strip():
+            referenced_tables.add(table_name.strip())
+
+    options = definition.get('options') or {}
+    if isinstance(options, dict):
+        time_table_name = _parse_table_name_from_reference(options.get('time_column'))
+        if time_table_name:
+            referenced_tables.add(time_table_name)
+
+    return referenced_tables
+
+
+def _infer_widget_base_table(definition: Optional[Dict[str, Any]]) -> str:
+    referenced_tables = _collect_widget_tables(definition)
+
+    if referenced_tables & _ALERT_BASE_FAMILY_TABLES:
+        return 'alerts'
+    if referenced_tables & _CASE_BASE_FAMILY_TABLES:
+        return 'cases'
+
+    return _DEFAULT_BASE_TABLE
 
 
 def _ensure_numeric(value: Any) -> Optional[float]:
@@ -224,6 +322,9 @@ CaseOwnerUser = aliased(User, name='case_owner_user')
 CaseCreatorUser = aliased(User, name='case_creator_user')
 CaseReviewerUser = aliased(User, name='case_reviewer_user')
 AlertOwnerUser = aliased(User, name='alert_owner_user')
+CaseClient = aliased(Client, name='case_client')
+CaseClassificationLookup = aliased(CaseClassification, name='case_classification_lookup')
+CaseSeverity = aliased(Severity, name='case_severity')
 AlertAsset = aliased(CaseAssets, name='alert_asset')
 CaseAsset = aliased(CaseAssets, name='case_asset')
 AlertAssetType = aliased(AssetsType, name='alert_asset_type')
@@ -236,6 +337,35 @@ CaseIocLink = aliased(IocLink, name='case_ioc_link')
 CaseEventAlias = aliased(CasesEvent, name='case_event')
 CaseNoteAlias = aliased(Notes, name='case_note')
 CaseTaskAlias = aliased(CaseTasks, name='case_task')
+
+AlertAssetCount = func.coalesce(
+    select(func.count(func.distinct(alert_assets_association.c.asset_id)))
+    .where(alert_assets_association.c.alert_id == Alert.alert_id)
+    .correlate(Alert.__table__)
+    .scalar_subquery(),
+    0
+)
+AlertIocCount = func.coalesce(
+    select(func.count(func.distinct(alert_iocs_association.c.ioc_id)))
+    .where(alert_iocs_association.c.alert_id == Alert.alert_id)
+    .correlate(Alert.__table__)
+    .scalar_subquery(),
+    0
+)
+CaseAssetCount = func.coalesce(
+    select(func.count(func.distinct(CaseAssets.asset_id)))
+    .where(CaseAssets.case_id == Cases.case_id)
+    .correlate(Cases.__table__)
+    .scalar_subquery(),
+    0
+)
+CaseIocCount = func.coalesce(
+    select(func.count(func.distinct(IocLink.ioc_id)))
+    .where(IocLink.case_id == Cases.case_id)
+    .correlate(Cases.__table__)
+    .scalar_subquery(),
+    0
+)
 
 
 def _join_cases(query):
@@ -312,6 +442,22 @@ def _join_case_tasks(query):
     return query.outerjoin(CaseTaskAlias, CaseTaskAlias.task_case_id == Cases.case_id)
 
 
+def _join_case_state(query):
+    return query.outerjoin(CaseState, Cases.state)
+
+
+def _join_case_client(query):
+    return query.outerjoin(CaseClient, Cases.client)
+
+
+def _join_case_classification_lookup(query):
+    return query.outerjoin(CaseClassificationLookup, Cases.classification)
+
+
+def _join_case_severity(query):
+    return query.outerjoin(CaseSeverity, Cases.severity)
+
+
 _AGGREGATIONS = {
     'count': lambda column: func.count(column),
     'sum': lambda column: func.sum(column),
@@ -385,7 +531,7 @@ def _between_dates(column, start: Optional[datetime], end: Optional[datetime]):
 class WidgetQueryExecutor:
     """Builds and executes SQLAlchemy queries for dashboard widgets."""
 
-    _BASE_TABLE = 'alerts'
+    _BASE_TABLE = _DEFAULT_BASE_TABLE
 
     _TABLES: Dict[str, Dict[str, Any]] = {
         'alerts': {
@@ -396,16 +542,28 @@ class WidgetQueryExecutor:
                 'alert_title': Alert.alert_title,
                 'alert_source': Alert.alert_source,
                 'alert_source_ref': Alert.alert_source_ref,
+                'alert_source_link': Alert.alert_source_link,
                 'alert_description': Alert.alert_description,
+                'alert_note': Alert.alert_note,
                 'alert_creation_time': Alert.alert_creation_time,
                 'alert_source_event_time': Alert.alert_source_event_time,
                 'alert_customer_id': Alert.alert_customer_id,
+                'alert_customer_name': Client.name,
                 'alert_resolution_status_id': Alert.alert_resolution_status_id,
+                'alert_resolution_status_name': AlertResolutionStatus.resolution_status_name,
                 'alert_status_id': Alert.alert_status_id,
+                'alert_status_name': AlertStatus.status_name,
                 'alert_severity_id': Alert.alert_severity_id,
+                'alert_severity_name': Severity.severity_name,
                 'alert_owner_id': Alert.alert_owner_id,
+                'alert_owner_username': AlertOwnerUser.user,
+                'alert_owner_name': AlertOwnerUser.name,
                 'alert_classification_id': Alert.alert_classification_id,
-                'alert_tags': Alert.alert_tags
+                'alert_classification_name': CaseClassification.name,
+                'alert_classification_name_expanded': CaseClassification.name_expanded,
+                'alert_tags': Alert.alert_tags,
+                'asset_count': AlertAssetCount,
+                'ioc_count': AlertIocCount
             },
             'default_time_column': Alert.alert_creation_time
         },
@@ -454,13 +612,75 @@ class WidgetQueryExecutor:
             'model': Cases,
             'columns': {
                 'case_id': Cases.case_id,
+                'case_uuid': Cases.case_uuid,
+                'soc_id': Cases.soc_id,
+                'client_id': Cases.client_id,
+                'client_name': CaseClient.name,
                 'name': Cases.name,
+                'description': Cases.description,
+                'open_date': Cases.open_date,
+                'close_date': Cases.close_date,
+                'initial_date': Cases.initial_date,
+                'closing_note': Cases.closing_note,
                 'owner_id': Cases.owner_id,
+                'owner_username': CaseOwnerUser.user,
+                'owner_name': CaseOwnerUser.name,
                 'creator_id': Cases.user_id,
+                'user_id': Cases.user_id,
+                'creator_username': CaseCreatorUser.user,
+                'creator_name': CaseCreatorUser.name,
+                'status_id': Cases.status_id,
+                'state_id': Cases.state_id,
+                'state_name': CaseState.state_name,
+                'classification_id': Cases.classification_id,
+                'classification_name': CaseClassificationLookup.name,
+                'classification_name_expanded': CaseClassificationLookup.name_expanded,
                 'reviewer_id': Cases.reviewer_id,
-                'review_status_id': Cases.review_status_id
+                'reviewer_username': CaseReviewerUser.user,
+                'reviewer_name': CaseReviewerUser.name,
+                'review_status_id': Cases.review_status_id,
+                'review_status_name': ReviewStatus.status_name,
+                'severity_id': Cases.severity_id,
+                'severity_name': CaseSeverity.severity_name,
+                'asset_count': CaseAssetCount,
+                'ioc_count': CaseIocCount
             },
             'join': _join_cases
+        },
+        'case_client': {
+            'model': CaseClient,
+            'columns': {
+                'client_id': CaseClient.client_id,
+                'name': CaseClient.name
+            },
+            'join': _join_case_client
+        },
+        'case_classification_lookup': {
+            'model': CaseClassificationLookup,
+            'columns': {
+                'id': CaseClassificationLookup.id,
+                'name': CaseClassificationLookup.name,
+                'name_expanded': CaseClassificationLookup.name_expanded
+            },
+            'join': _join_case_classification_lookup
+        },
+        'case_severity': {
+            'model': CaseSeverity,
+            'columns': {
+                'severity_id': CaseSeverity.severity_id,
+                'severity_name': CaseSeverity.severity_name
+            },
+            'join': _join_case_severity
+        },
+        'case_state': {
+            'model': CaseState,
+            'columns': {
+                'state_id': CaseState.state_id,
+                'state_name': CaseState.state_name,
+                'state_description': CaseState.state_description,
+                'protected': CaseState.protected
+            },
+            'join': _join_case_state
         },
         'case_tags': {
             'model': CaseTags,
@@ -532,7 +752,8 @@ class WidgetQueryExecutor:
                 'case_id': AlertAsset.case_id,
                 'date_added': AlertAsset.date_added,
                 'date_update': AlertAsset.date_update,
-                'user_id': AlertAsset.user_id
+                'user_id': AlertAsset.user_id,
+                'analysis_status_id': AlertAsset.analysis_status_id
             },
             'join': _join_alert_assets
         },
@@ -590,7 +811,8 @@ class WidgetQueryExecutor:
                 'case_id': CaseAsset.case_id,
                 'date_added': CaseAsset.date_added,
                 'date_update': CaseAsset.date_update,
-                'user_id': CaseAsset.user_id
+                'user_id': CaseAsset.user_id,
+                'analysis_status_id': CaseAsset.analysis_status_id
             },
             'join': _join_case_assets
         },
@@ -703,11 +925,24 @@ class WidgetQueryExecutor:
         self.definition = definition or {}
         self.builder = _WidgetQueryBuilder()
         options = self.definition.get('options') or {}
-        self.time_column_spec = options.get('time_column') or 'alerts.alert_creation_time'
+        self._explicit_time_column_spec = options.get('time_column')
+        self._base_table = self._infer_base_table()
+        self.time_column_spec = self._resolve_time_column_spec()
         self._normalized_time_column_spec = self._normalize_table_column_value(self.time_column_spec)
         raw_time_bucket = self.definition.get('time_bucket')
         self.time_bucket = raw_time_bucket.strip().lower() if isinstance(raw_time_bucket, str) else ''
         self._time_bucket_label = ''
+
+    def _infer_base_table(self) -> str:
+        inferred_base = _infer_widget_base_table(self.definition)
+        if inferred_base not in self._TABLES:
+            return self._BASE_TABLE
+        return inferred_base
+
+    def _resolve_time_column_spec(self) -> str:
+        if isinstance(self._explicit_time_column_spec, str) and self._explicit_time_column_spec.strip():
+            return self._explicit_time_column_spec
+        return _BASE_TIME_COLUMNS.get(self._base_table, _BASE_TIME_COLUMNS[self._BASE_TABLE])
 
     def execute(self, timeframe: Tuple[Optional[datetime], Optional[datetime]]) -> WidgetQueryResult:
         widgets_fields = self.definition.get('fields') or []
@@ -760,8 +995,43 @@ class WidgetQueryExecutor:
         column = columns.get(column_name)
         if column is None:
             raise QueryExecutionError(f"Column '{column_name}' is not allowed for table '{table_name}'.")
-        if table_name in {'case_owner', 'case_creator', 'case_reviewer', 'case_tags', 'tags', 'case_assets', 'case_asset_types', 'case_iocs', 'case_ioc_types', 'case_events', 'case_notes', 'case_tasks', 'review_status'}:
-            self.builder.add_join('cases')
+        if table_name == 'alerts':
+            alert_join_dependencies = {
+                'alert_customer_name': 'client',
+                'alert_resolution_status_name': 'alert_resolution_status',
+                'alert_status_name': 'alert_status',
+                'alert_severity_name': 'severities',
+                'alert_owner_username': 'alert_owner',
+                'alert_owner_name': 'alert_owner',
+                'alert_classification_name': 'case_classification',
+                'alert_classification_name_expanded': 'case_classification'
+            }
+            join_table_name = alert_join_dependencies.get(column_name)
+            if join_table_name:
+                self.builder.add_join(join_table_name)
+        if table_name == 'cases':
+            if self._base_table != 'cases':
+                self.builder.add_join('cases')
+            case_join_dependencies = {
+                'client_name': 'case_client',
+                'owner_username': 'case_owner',
+                'owner_name': 'case_owner',
+                'creator_username': 'case_creator',
+                'creator_name': 'case_creator',
+                'state_name': 'case_state',
+                'classification_name': 'case_classification_lookup',
+                'classification_name_expanded': 'case_classification_lookup',
+                'reviewer_username': 'case_reviewer',
+                'reviewer_name': 'case_reviewer',
+                'review_status_name': 'review_status',
+                'severity_name': 'case_severity'
+            }
+            join_table_name = case_join_dependencies.get(column_name)
+            if join_table_name:
+                self.builder.add_join(join_table_name)
+        if table_name in {'case_owner', 'case_creator', 'case_reviewer', 'case_client', 'case_classification_lookup', 'case_severity', 'case_state', 'case_tags', 'tags', 'case_assets', 'case_asset_types', 'case_iocs', 'case_ioc_types', 'case_events', 'case_notes', 'case_tasks', 'review_status'}:
+            if self._base_table != 'cases':
+                self.builder.add_join('cases')
         if table_name == 'tags':
             self.builder.add_join('case_tags')
         if table_name == 'case_asset_types':
@@ -772,7 +1042,7 @@ class WidgetQueryExecutor:
             self.builder.add_join('alert_assets')
         if table_name == 'alert_ioc_types':
             self.builder.add_join('alert_iocs')
-        if table_name != self._BASE_TABLE:
+        if table_name != self._base_table:
             self.builder.add_join(table_name)
         return column
 
@@ -846,12 +1116,22 @@ class WidgetQueryExecutor:
         user_id = getattr(current_user, 'id', None)
         if not user_id:
             # Without a logged-in user we cannot determine scope; deny by default.
-            self.builder.filters.append(Alert.alert_id == -1)
+            if self._base_table == 'cases':
+                self.builder.filters.append(Cases.case_id == -1)
+            else:
+                self.builder.filters.append(Alert.alert_id == -1)
+            return
+
+        case_ids = ac_get_fast_user_cases_access(user_id) or []
+
+        if self._base_table == 'cases':
+            if case_ids:
+                self.builder.filters.append(Cases.case_id.in_(case_ids))
+            else:
+                self.builder.filters.append(Cases.case_id == -1)
             return
 
         client_ids = get_user_clients_id(user_id) or []
-        case_ids = ac_get_fast_user_cases_access(user_id) or []
-
         access_conditions = []
 
         if client_ids:
@@ -878,8 +1158,13 @@ class WidgetQueryExecutor:
             if not self.builder.group_labels:
                 raise QueryExecutionError('Widgets must contain at least one aggregated field or grouping column.')
 
+        base_table = self._get_table(self._base_table)
+        base_model = base_table.get('model')
+        if base_model is None:
+            raise QueryExecutionError(f"No model registered for base table '{self._base_table}'.")
+
         query = db.session.query(*self.builder.selects)
-        query = query.select_from(Alert)
+        query = query.select_from(base_model)
         for join_table in self.builder.joins:
             table = self._get_table(join_table)
             join_callable = table.get('join')
@@ -1061,7 +1346,9 @@ def format_widget_payload(
     chart_type_raw = (result.chart_type or '').lower()
     chart_type = 'line' if chart_type_raw == 'timechart' else chart_type_raw
     time_bucket = (definition.get('time_bucket') or '').strip().lower()
-    time_column_spec = options.get('time_column') or 'alerts.alert_creation_time'
+    inferred_base_table = _infer_widget_base_table(definition)
+    default_time_column = _BASE_TIME_COLUMNS.get(inferred_base_table, _BASE_TIME_COLUMNS[_DEFAULT_BASE_TABLE])
+    time_column_spec = options.get('time_column') or default_time_column
     expected_time_alias = _compute_time_alias(time_column_spec, time_bucket)
 
     timeframe_start: Optional[datetime] = None

--- a/source/app/datamgmt/custom_dashboard/query_engine.py
+++ b/source/app/datamgmt/custom_dashboard/query_engine.py
@@ -40,6 +40,8 @@ class QueryExecutionError(Exception):
 
 @dataclass
 class WidgetQueryResult:
+    """Normalized widget query output used by the response formatters."""
+
     chart_type: str
     rows: List[Dict[str, Any]]
     group_labels: Sequence[str]
@@ -96,6 +98,19 @@ def _parse_table_name_from_reference(value: Any) -> Optional[str]:
     return normalized or None
 
 
+def _normalize_table_name(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _add_table_reference(referenced_tables: Set[str], value: Any):
+    table_name = _normalize_table_name(value)
+    if table_name:
+        referenced_tables.add(table_name)
+
+
 def _collect_widget_tables(definition: Optional[Dict[str, Any]]) -> Set[str]:
     if not isinstance(definition, dict):
         return set()
@@ -105,14 +120,10 @@ def _collect_widget_tables(definition: Optional[Dict[str, Any]]) -> Set[str]:
     for field in definition.get('fields') or []:
         if not isinstance(field, dict):
             continue
-        table_name = field.get('table')
-        if isinstance(table_name, str) and table_name.strip():
-            referenced_tables.add(table_name.strip())
+        _add_table_reference(referenced_tables, field.get('table'))
         inline_filter = field.get('filter')
         if isinstance(inline_filter, dict):
-            inline_table = inline_filter.get('table')
-            if isinstance(inline_table, str) and inline_table.strip():
-                referenced_tables.add(inline_table.strip())
+            _add_table_reference(referenced_tables, inline_filter.get('table'))
 
     for group_entry in definition.get('group_by') or []:
         table_name = _parse_table_name_from_reference(group_entry)
@@ -122,9 +133,7 @@ def _collect_widget_tables(definition: Optional[Dict[str, Any]]) -> Set[str]:
     for filter_entry in definition.get('filters') or []:
         if not isinstance(filter_entry, dict):
             continue
-        table_name = filter_entry.get('table')
-        if isinstance(table_name, str) and table_name.strip():
-            referenced_tables.add(table_name.strip())
+        _add_table_reference(referenced_tables, filter_entry.get('table'))
 
     options = definition.get('options') or {}
     if isinstance(options, dict):
@@ -393,7 +402,8 @@ def _join_case_tags_table(query):
 
 
 def _join_tags_table(query):
-    # Case tags join is registered before reaching this point, so reuse its alias when linking tags.
+    # Case tags join is registered before reaching this point.
+    # Reuse its alias when linking tags.
     return query.outerjoin(Tags, Tags.id == CaseTags.tag_id)
 
 
@@ -459,11 +469,11 @@ def _join_case_severity(query):
 
 
 _AGGREGATIONS = {
-    'count': lambda column: func.count(column),
-    'sum': lambda column: func.sum(column),
-    'avg': lambda column: func.avg(column),
-    'min': lambda column: func.min(column),
-    'max': lambda column: func.max(column)
+    'count': func.count,
+    'sum': func.sum,
+    'avg': func.avg,
+    'min': func.min,
+    'max': func.max
 }
 
 _OPERATORS = {
@@ -487,6 +497,8 @@ def _capitalize_label(label: str) -> str:
 
 
 class _WidgetQueryBuilder:
+    """Mutable accumulator for SELECT, GROUP BY, JOIN and filter fragments."""
+
     def __init__(self):
         self.selects: List[Any] = []
         self.select_labels: List[str] = []
@@ -973,7 +985,7 @@ class WidgetQueryExecutor:
         query = self._apply_limit(query)
 
         rows = query.all()
-        mapped_rows = [dict(row._mapping) for row in rows]
+        mapped_rows = [dict(zip(self.builder.select_labels, row)) for row in rows]
 
         return WidgetQueryResult(
             chart_type=self.builder.chart_type,
@@ -1223,7 +1235,8 @@ class WidgetQueryExecutor:
             return query.limit(limit_value)
         return query
 
-    def _parse_table_column(self, value: str) -> Tuple[str, str]:
+    @staticmethod
+    def _parse_table_column(value: str) -> Tuple[str, str]:
         if not value or '.' not in value:
             raise QueryExecutionError('Expected table.column format in widget definition.')
         table_name, column_name = value.split('.', 1)
@@ -1252,7 +1265,8 @@ class WidgetQueryExecutor:
 
         return expression
 
-    def _build_aggregate_expression(self, aggregation: str, column, filter_expression):
+    @staticmethod
+    def _build_aggregate_expression(aggregation: str, column, filter_expression):
         normalized = aggregation.lower()
 
         if filter_expression is not None:
@@ -1296,7 +1310,8 @@ class WidgetQueryExecutor:
         if label_index < len(self.builder.group_by_exprs):
             self.builder.group_by_exprs.insert(0, self.builder.group_by_exprs.pop(label_index))
 
-    def _normalize_table_column_value(self, value: Optional[str]) -> str:
+    @staticmethod
+    def _normalize_table_column_value(value: Optional[str]) -> str:
         if not isinstance(value, str):
             return ''
         return value.replace(' ', '').lower()

--- a/source/app/static/assets/js/iris/custom_dashboards/custom_dashboards.js
+++ b/source/app/static/assets/js/iris/custom_dashboards/custom_dashboards.js
@@ -22,16 +22,28 @@
         alert_title: 'Title',
         alert_source: 'Source',
         alert_source_ref: 'Source Reference',
+        alert_source_link: 'Source Link',
         alert_description: 'Description',
+        alert_note: 'Note',
         alert_creation_time: 'Creation Time',
         alert_source_event_time: 'Source Event Time',
         alert_customer_id: 'Customer ID',
+        alert_customer_name: 'Customer Name',
         alert_resolution_status_id: 'Resolution Status ID',
+        alert_resolution_status_name: 'Resolution Status Name',
         alert_status_id: 'Status ID',
+        alert_status_name: 'Status Name',
         alert_severity_id: 'Severity ID',
+        alert_severity_name: 'Severity Name',
         alert_owner_id: 'Owner ID',
+        alert_owner_username: 'Owner Username',
+        alert_owner_name: 'Owner Name',
         alert_classification_id: 'Classification ID',
-        alert_tags: 'Tags'
+        alert_classification_name: 'Classification Name',
+        alert_classification_name_expanded: 'Classification Name (Expanded)',
+        alert_tags: 'Tags',
+        asset_count: 'Asset Count',
+        ioc_count: 'IOC Count'
       }
     },
     client: {
@@ -42,7 +54,7 @@
       }
     },
     alert_resolution_status: {
-      label: 'Resolution Status',
+      label: 'Alert Resolution Status',
       columns: {
         resolution_status_id: 'Resolution Status ID',
         resolution_status_name: 'Resolution Status Name'
@@ -74,11 +86,47 @@
       label: 'Cases',
       columns: {
         case_id: 'Case ID',
+        case_uuid: 'Case UUID',
+        soc_id: 'SOC ID',
+        client_id: 'Client ID',
+        client_name: 'Client Name',
         name: 'Case Name',
+        description: 'Case Description',
+        open_date: 'Open Date',
+        close_date: 'Close Date',
+        initial_date: 'Initial Date',
+        closing_note: 'Closing Note',
         owner_id: 'Owner ID',
+        owner_username: 'Owner Username',
+        owner_name: 'Owner Name',
         creator_id: 'Creator ID',
+        user_id: 'Creator User ID',
+        creator_username: 'Creator Username',
+        creator_name: 'Creator Name',
+        status_id: 'Status ID',
+        state_id: 'State ID',
+        state_name: 'State Name',
+        classification_id: 'Classification ID',
+        classification_name: 'Classification Name',
+        classification_name_expanded: 'Classification Name (Expanded)',
         reviewer_id: 'Reviewer ID',
-        review_status_id: 'Review Status ID'
+        reviewer_username: 'Reviewer Username',
+        reviewer_name: 'Reviewer Name',
+        review_status_id: 'Review Status ID',
+        review_status_name: 'Review Status Name',
+        severity_id: 'Severity ID',
+        severity_name: 'Severity Name',
+        asset_count: 'Asset Count',
+        ioc_count: 'IOC Count'
+      }
+    },
+    case_state: {
+      label: 'Case State',
+      columns: {
+        state_id: 'State ID',
+        state_name: 'State Name',
+        state_description: 'State Description',
+        protected: 'Protected'
       }
     },
     alert_owner: {
@@ -145,7 +193,8 @@
         case_id: 'Case ID',
         date_added: 'Date Added',
         date_update: 'Date Updated',
-        user_id: 'User ID'
+        user_id: 'User ID',
+        analysis_status_id: 'Analysis Status ID'
       }
     },
     alert_asset_types: {
@@ -199,7 +248,8 @@
         case_id: 'Case ID',
         date_added: 'Date Added',
         date_update: 'Date Updated',
-        user_id: 'User ID'
+        user_id: 'User ID',
+        analysis_status_id: 'Analysis Status ID'
       }
     },
     case_asset_types: {
@@ -641,12 +691,78 @@
     return `${prefix}-${timestamp}-${random}`;
   }
 
+  function getSortedTableDefinitions() {
+    return Object.entries(TABLE_DEFINITIONS).sort((entryA, entryB) => {
+      const labelA = (entryA[1] && entryA[1].label) || entryA[0];
+      const labelB = (entryB[1] && entryB[1].label) || entryB[0];
+      const labelCompare = labelA.localeCompare(labelB, undefined, { sensitivity: 'base' });
+      if (labelCompare !== 0) {
+        return labelCompare;
+      }
+      return entryA[0].localeCompare(entryB[0], undefined, { sensitivity: 'base' });
+    });
+  }
+
   function getTableColumns(tableName) {
     const table = TABLE_DEFINITIONS[tableName];
     if (!table || !table.columns) {
       return [];
     }
-    return Object.entries(table.columns).map(([column, label]) => ({ value: column, label }));
+    return Object.entries(table.columns)
+      .map(([column, label]) => ({ value: column, label }))
+      .sort((columnA, columnB) => {
+        const labelCompare = columnA.label.localeCompare(columnB.label, undefined, { sensitivity: 'base' });
+        if (labelCompare !== 0) {
+          return labelCompare;
+        }
+        return columnA.value.localeCompare(columnB.value, undefined, { sensitivity: 'base' });
+      });
+  }
+
+  function isTimeSeriesColumnName(columnName) {
+    if (!columnName || typeof columnName !== 'string') {
+      return false;
+    }
+    const normalized = columnName.toLowerCase();
+    if (/(^|_)(time|timestamp|date)(_|$)/.test(normalized)) {
+      return true;
+    }
+    return normalized.includes('creationdate')
+      || normalized.includes('lastupdate')
+      || normalized.includes('last_update')
+      || normalized.endsWith('_added');
+  }
+
+  function getTimeSeriesColumns(tableName) {
+    return getTableColumns(tableName).filter((column) => isTimeSeriesColumnName(column.value));
+  }
+
+  function getTimeSeriesTables() {
+    return getSortedTableDefinitions().filter(([tableName]) => getTimeSeriesColumns(tableName).length > 0);
+  }
+
+  function buildTimeSeriesTableOptions(selectedTable) {
+    return getTimeSeriesTables().map(([tableName, tableDef]) => {
+      const option = document.createElement('option');
+      option.value = tableName;
+      option.textContent = (tableDef && tableDef.label) || tableName;
+      if (tableName === selectedTable) {
+        option.selected = true;
+      }
+      return option;
+    });
+  }
+
+  function buildTimeSeriesColumnOptions(selectedTable, selectedColumn) {
+    return getTimeSeriesColumns(selectedTable).map((column) => {
+      const option = document.createElement('option');
+      option.value = column.value;
+      option.textContent = column.label;
+      if (column.value === selectedColumn) {
+        option.selected = true;
+      }
+      return option;
+    });
   }
 
   function getColumnLabel(tableName, columnName) {
@@ -693,6 +809,30 @@
       return { table: trimmed, column: '' };
     }
     return { table, column };
+  }
+
+  function populateBuilderColumnDatalist() {
+    const datalist = document.getElementById('dashboardBuilderColumnOptions');
+    if (!datalist) {
+      return;
+    }
+
+    datalist.innerHTML = '';
+    const values = new Set();
+    Object.entries(TABLE_DEFINITIONS).forEach(([tableName, tableDef]) => {
+      if (!tableDef || !tableDef.columns) {
+        return;
+      }
+      Object.keys(tableDef.columns).forEach((columnName) => {
+        values.add(`${tableName}.${columnName}`);
+      });
+    });
+
+    Array.from(values).sort().forEach((value) => {
+      const option = document.createElement('option');
+      option.value = value;
+      datalist.appendChild(option);
+    });
   }
 
   function createEmptyField(overrides = {}) {
@@ -1601,7 +1741,7 @@
     tableSelect.attr('data-section-id', sectionId);
     tableSelect.attr('data-widget-id', widgetId);
     tableSelect.attr('data-field-id', field.id);
-    Object.entries(TABLE_DEFINITIONS).forEach(([tableName, tableDef]) => {
+    getSortedTableDefinitions().forEach(([tableName, tableDef]) => {
       const option = document.createElement('option');
       option.value = tableName;
       option.textContent = tableDef.label;
@@ -1676,7 +1816,7 @@
     tableSelect.attr('data-section-id', sectionId);
     tableSelect.attr('data-widget-id', widgetId);
     tableSelect.attr('data-group-id', group.id);
-    Object.entries(TABLE_DEFINITIONS).forEach(([tableName, tableDef]) => {
+    getSortedTableDefinitions().forEach(([tableName, tableDef]) => {
       const option = document.createElement('option');
       option.value = tableName;
       option.textContent = tableDef.label;
@@ -1716,6 +1856,62 @@
     return row;
   }
 
+  function renderTimeOverrideRow(sectionId, widgetId, timeColumnSpec) {
+    const parsedTimeColumn = parseTableColumn(timeColumnSpec || '');
+    const availableTimeTables = getTimeSeriesTables().map(([tableName]) => tableName);
+    const hasSelectedTable = parsedTimeColumn.table && availableTimeTables.includes(parsedTimeColumn.table);
+    const selectedTable = hasSelectedTable ? parsedTimeColumn.table : '';
+    const availableColumns = selectedTable ? getTimeSeriesColumns(selectedTable) : [];
+    const hasSelectedColumn = parsedTimeColumn.column
+      && availableColumns.some((column) => column.value === parsedTimeColumn.column);
+    const selectedColumn = hasSelectedColumn ? parsedTimeColumn.column : '';
+
+    const row = $('<div class="form-row align-items-end dashboard-builder-time-row"></div>');
+
+    const tableGroup = $('<div class="form-group col-md-4"></div>');
+    tableGroup.append('<label class="small text-muted text-uppercase">Table</label>');
+    const tableSelect = $('<select class="form-control form-control-sm builder-widget-time-column-table"></select>');
+    tableSelect.attr('data-section-id', sectionId);
+    tableSelect.attr('data-widget-id', widgetId);
+
+    const defaultTableOption = document.createElement('option');
+    defaultTableOption.value = '';
+    defaultTableOption.textContent = 'Auto';
+    if (!selectedTable) {
+      defaultTableOption.selected = true;
+    }
+    tableSelect.append(defaultTableOption);
+    buildTimeSeriesTableOptions(selectedTable).forEach((option) => tableSelect.append(option));
+    tableGroup.append(tableSelect);
+
+    const columnGroup = $('<div class="form-group col-md-8"></div>');
+    columnGroup.append('<label class="small text-muted text-uppercase">Column</label>');
+    const columnSelect = $('<select class="form-control form-control-sm builder-widget-time-column-column"></select>');
+    columnSelect.attr('data-section-id', sectionId);
+    columnSelect.attr('data-widget-id', widgetId);
+
+    const defaultColumnOption = document.createElement('option');
+    defaultColumnOption.value = '';
+    defaultColumnOption.textContent = selectedTable ? 'Select column' : 'Auto';
+    if (!selectedColumn) {
+      defaultColumnOption.selected = true;
+    }
+    columnSelect.append(defaultColumnOption);
+
+    if (selectedTable) {
+      const columnOptions = buildTimeSeriesColumnOptions(selectedTable, selectedColumn);
+      columnOptions.forEach((option) => columnSelect.append(option));
+      columnSelect.prop('disabled', columnOptions.length === 0);
+    } else {
+      columnSelect.prop('disabled', true);
+    }
+
+    columnGroup.append(columnSelect);
+    row.append(tableGroup, columnGroup);
+
+    return row;
+  }
+
   function renderFilterRow(sectionId, widgetId, filter) {
     const row = $('<div class="form-row align-items-end dashboard-builder-filter-row"></div>');
 
@@ -1725,7 +1921,7 @@
     tableSelect.attr('data-section-id', sectionId);
     tableSelect.attr('data-widget-id', widgetId);
     tableSelect.attr('data-filter-id', filter.id);
-    Object.entries(TABLE_DEFINITIONS).forEach(([tableName, tableDef]) => {
+    getSortedTableDefinitions().forEach(([tableName, tableDef]) => {
       const option = document.createElement('option');
       option.value = tableName;
       option.textContent = tableDef.label;
@@ -2053,14 +2249,16 @@
     basicRow.append(nameGroup, chartGroup, sizeGroup, bucketGroup);
     body.append(basicRow);
 
-    const timeColumnGroup = $('<div class="form-group"></div>');
-    timeColumnGroup.append('<label class="small text-muted text-uppercase">Time column override</label>');
-    const timeColumnInput = $('<input type="text" class="form-control form-control-sm builder-widget-time-column" list="dashboardBuilderColumnOptions" placeholder="alerts.alert_creation_time">');
-    timeColumnInput.attr('data-section-id', section.id);
-    timeColumnInput.attr('data-widget-id', widget.id);
-    timeColumnInput.val(widget.timeColumn || '');
-    timeColumnGroup.append(timeColumnInput);
-    body.append(timeColumnGroup);
+    const timeOverrideSection = createWidgetDetailSection({
+      sectionId: section.id,
+      widgetId: widget.id,
+      key: 'timeOverride',
+      title: 'Time override',
+      iconClass: 'fas fa-clock'
+    });
+    timeOverrideSection.body.append(renderTimeOverrideRow(section.id, widget.id, widget.timeColumn || ''));
+    timeOverrideSection.body.append('<div class="text-muted small">Use Auto to apply the default timeframe column for the selected dataset.</div>');
+    body.append(timeOverrideSection.container);
 
     const fieldsSection = createWidgetDetailSection({
       sectionId: section.id,
@@ -2897,14 +3095,58 @@
       widget.timeBucket = $(this).val();
     });
 
-    $(document).on('input', '.builder-widget-time-column', function () {
+    $(document).on('change', '.builder-widget-time-column-table', function () {
       const sectionId = $(this).data('section-id');
       const widgetId = $(this).data('widget-id');
       const { widget } = findWidget(sectionId, widgetId);
       if (!widget) {
         return;
       }
-      widget.timeColumn = $(this).val();
+      const selectedTable = $(this).val();
+      if (!selectedTable) {
+        widget.timeColumn = '';
+        rerenderWidget(sectionId, widgetId);
+        return;
+      }
+
+      const columns = getTimeSeriesColumns(selectedTable);
+      if (!columns.length) {
+        widget.timeColumn = '';
+        rerenderWidget(sectionId, widgetId);
+        return;
+      }
+
+      const currentSelection = parseTableColumn(widget.timeColumn || '');
+      const selectedColumn = currentSelection.table === selectedTable && currentSelection.column
+        && columns.some((column) => column.value === currentSelection.column)
+        ? currentSelection.column
+        : columns[0].value;
+
+      widget.timeColumn = formatTableColumn(selectedTable, selectedColumn);
+      rerenderWidget(sectionId, widgetId);
+    });
+
+    $(document).on('change', '.builder-widget-time-column-column', function () {
+      const sectionId = $(this).data('section-id');
+      const widgetId = $(this).data('widget-id');
+      const { widget } = findWidget(sectionId, widgetId);
+      if (!widget) {
+        return;
+      }
+
+      const selectedColumn = $(this).val();
+      const selectedTable = $(this)
+        .closest('.form-row')
+        .find('.builder-widget-time-column-table')
+        .first()
+        .val();
+
+      if (!selectedTable || !selectedColumn) {
+        widget.timeColumn = '';
+        return;
+      }
+
+      widget.timeColumn = formatTableColumn(selectedTable, selectedColumn);
     });
 
     $(document).on('click', '.builder-add-field', function () {
@@ -5679,6 +5921,7 @@
     if (shareInput.length) {
       canShareDashboards = shareInput.val() === '1';
     }
+    populateBuilderColumnDatalist();
     setDefaultTimeframe();
     bindEvents();
     updateDashboardActionsState();


### PR DESCRIPTION
## Summary

Implements #1024 by improving custom dashboard widget configuration and query execution for case-focused analytics.

### Why This Targets `hotfix_v2.4.27` Instead of `develop`

This change is being submitted against `hotfix_v2.4.27` intentionally because issue `#1024` applies to the custom dashboard implementation that currently exists in the hotfix line used for this deployment path.

Submitting to `develop` would require a broader feature backport/reintroduction of custom dashboard baseline components that are not present there in the same form, which is out of scope for this issue and would significantly increase risk and review surface.

To keep this fix focused, low-risk, and aligned with the affected release path, this PR is scoped to `hotfix_v2.4.27`.

### What changed

- Improved widget time-column behavior in the backend query engine:
  - Dynamically infers widget base context (`alerts` vs `cases`) from selected fields/grouping/filters/options.
  - Allows case-only widgets to execute correctly without requiring alert-table fields.
  - Keeps compatibility with existing `options.time_column` values while applying sensible defaults.

- Improved dashboard builder UX for table/time configuration:
  - Aligns time-column selection behavior with the same structured table/column pattern used elsewhere in widget configuration.
  - Restricts time-column choices to valid time-series-compatible columns.

- Improved dropdown usability:
  - Sorts table labels alphabetically.
  - Sorts selectable columns alphabetically.
  - Adds/expands join-friendly display fields (e.g., related “name” fields for ID-oriented data), including Cases and Alerts contexts.

## Files changed

- `source/app/datamgmt/custom_dashboard/query_engine.py`
- `source/app/static/assets/js/iris/custom_dashboards/custom_dashboards.js`
- `source/app/blueprints/custom_dashboard/templates/custom_dashboards/index.html`

## Validation

- Python syntax check passed for updated query engine module.
- Manual validation focus:
  - Cases-only widgets render without alert fields.
  - Time series widgets use valid time-column selection in builder.
  - Table/column dropdowns are alphabetically sorted.
  - ID-related selections expose expected human-readable joined columns.
