### PR TITLE
[#849][FIX] ioc json popover

### DIFF
--- a/e2e/tests/administrator/case/ioc.spec.js
+++ b/e2e/tests/administrator/case/ioc.spec.js
@@ -28,6 +28,40 @@ test('should be able to update IOC', async ({ page }) => {
     await expect(page.getByRole('link', { name: newIocValue })).toBeVisible();
 });
 
+test('should open IOC editor when IOC description is JSON', async ({ page, rest }) => {
+    const caseIdentifier = await Api.createCase(rest);
+    const iocValue = `IOC value - ${crypto.randomUUID()}`;
+    const iocDescription = JSON.stringify({
+        error: '',
+        name: 'sampleLookupNumber',
+        parameters: {
+            add_on: 'telo_cnam',
+            caller_name: true,
+            carrier: true,
+            pstn: '19999999999'
+        }
+    });
+
+    const pageErrors = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    await rest.post(`/api/v2/cases/${caseIdentifier}/iocs`, {
+        data: {
+            ioc_type_id: 1,
+            ioc_value: iocValue,
+            ioc_tlp_id: 2,
+            ioc_description: iocDescription,
+            ioc_tags: ''
+        }
+    });
+
+    await page.goto(`/case/ioc?cid=${caseIdentifier}`);
+    await page.getByRole('link', { name: iocValue }).click();
+
+    await expect(page.getByRole('button', { name: 'Update' })).toBeVisible();
+    expect(pageErrors.filter(error => error.includes('TOOLTIP: Option "content"')).length).toBe(0);
+});
+
 test('should not be able to create an IOC with the same type and value', async ({ page }) => {
     const iocValue = `IOC value - ${crypto.randomUUID()}`;
 

--- a/ui/src/pages/case.ioc.js
+++ b/ui/src/pages/case.ioc.js
@@ -150,10 +150,21 @@ function get_case_ioc() {
         Table.clear();
         Table.rows.add(data.data);
 
-        $('#ioc_table_wrapper').on('click', function(e){
-            if($('.popover').length>1)
-                $('.popover').popover('hide');
-                $(e.target).popover('toggle');
+        $('#ioc_table_wrapper')
+            .off('click', '[data-toggle="popover"]')
+            .on('click', '[data-toggle="popover"]', function(event) {
+                event.preventDefault();
+
+                if ($('.popover').length > 1) {
+                    $('.popover').popover('hide');
+                }
+
+                $(this).popover({
+                    content: function() {
+                        const content = this.getAttribute('data-content');
+                        return content === null ? '' : content;
+                    }
+                }).popover('toggle');
             });
 
         $('#ioc_table_wrapper').show();


### PR DESCRIPTION
## Summary
Closes #849

Fixes a case IOC UI bug where clicking an IOC could fail to open the editor when an IOC description contained JSON-like content. In that scenario, Bootstrap popover parsing could treat `data-content` as an object, trigger a `TOOLTIP` type error, and break expected click behavior.

## Changes
- `ui/src/pages/case.ioc.js`
  - Scoped the click handler to popover elements only.
  - Prevented default link behavior for popover clicks.
  - Initialized popovers with a `content` function that always returns a string from `data-content`.
  - Kept popover toggle behavior while avoiding invalid `content` typing.
- `e2e/tests/administrator/case/ioc.spec.js`
  - Added regression test: create IOC with JSON description, click IOC value, verify edit modal opens, and assert no `TOOLTIP: Option "content"` page error is raised.

## Validation
- Manual validation: IOC editor opens correctly for IOCs with JSON descriptions.
- Automated coverage: new e2e regression test added for this exact scenario.
