### PR TITLE
[IMP] Add markdown rendering for alert notes

### DIFF
--- a/source/app/blueprints/alerts/templates/alerts.html
+++ b/source/app/blueprints/alerts/templates/alerts.html
@@ -280,7 +280,7 @@
           <div class="form-group">
 
             <label for="editAlertNote">Note</label>
-            <textarea class="form-control" id="editAlertNote" rows="3"></textarea>
+            <textarea class="form-control" id="editAlertNote" rows="10"></textarea>
           </div>
           <div class="form-group">
             <label for="editAlertTags">Tags</label>

--- a/source/app/static/assets/js/iris/alerts.js
+++ b/source/app/static/assets/js/iris/alerts.js
@@ -1012,6 +1012,7 @@ function renderAlert(alert, expanded=false, modulesOptionsAlertReq,
                     <div class="separator-solid"></div>
                     <h3 class="title mb-3"><strong>Alert note</strong></h3>
                     <div id="alertNote-${alert.alert_id}">${renderAlertNoteMarkdown(alert.alert_note)}</div>
+                    <pre id="alertNoteRaw-${alert.alert_id}" class="d-none">${filterXSS(alert.alert_note)}</pre>
                     
                     <!-- Alert Context section -->
                     ${
@@ -1567,7 +1568,7 @@ async function editAlert(alert_id, close=false) {
 
     alertTag.val($(`#alertTags-${alert_id}`).text())
     set_suggest_tags(`editAlertTags`);
-    $('#editAlertNote').val($(`#alertNote-${alert_id}`).text());
+    $('#editAlertNote').val($(`#alertNoteRaw-${alert_id}`).text());
 
     let alert_resolution = getAlertResolutionName(alert_id);
     if (alert_resolution === '') {

--- a/source/app/static/assets/js/iris/alerts.js
+++ b/source/app/static/assets/js/iris/alerts.js
@@ -1,5 +1,12 @@
 let sortOrder ;
 
+function renderAlertNoteMarkdown(noteText) {
+    if (!noteText) return '';
+    let converter = get_showdown_convert();
+    let html = converter.makeHtml(do_md_filter_xss(noteText));
+    return do_md_filter_xss(html);
+}
+
 function objectToQueryString(obj) {
   return Object.keys(obj)
     .filter(key => obj[key] !== undefined && obj[key] !== null && obj[key] !== '')
@@ -853,7 +860,7 @@ function renderAlert(alert, expanded=false, modulesOptionsAlertReq,
   alert.alert_source = alert.alert_description ? filterXSS(alert.alert_source) : 'No source provided';
   alert.alert_source_link = filterXSS(alert.alert_source_link);
   alert.alert_source_ref = filterXSS(alert.alert_source_ref);
-  alert.alert_note = filterXSS(alert.alert_note);
+  alert.alert_note = alert.alert_note || '';
 
   let menuOptionsHtmlAlert = '';
   const menuOptions = modulesOptionsAlertReq;
@@ -1004,7 +1011,7 @@ function renderAlert(alert, expanded=false, modulesOptionsAlertReq,
                     
                     <div class="separator-solid"></div>
                     <h3 class="title mb-3"><strong>Alert note</strong></h3>
-                    <pre id=alertNote-${alert.alert_id}>${alert.alert_note}</pre>
+                    <div id="alertNote-${alert.alert_id}">${renderAlertNoteMarkdown(alert.alert_note)}</div>
                     
                     <!-- Alert Context section -->
                     ${

--- a/source/app/static/assets/js/iris/alerts.js
+++ b/source/app/static/assets/js/iris/alerts.js
@@ -3,7 +3,7 @@ let sortOrder ;
 function renderAlertNoteMarkdown(noteText) {
     if (!noteText) return '';
     let converter = get_showdown_convert();
-    let html = converter.makeHtml(noteText);
+    let html = converter.makeHtml(do_md_filter_xss(noteText));
     return do_md_filter_xss(html);
 }
 
@@ -1012,7 +1012,6 @@ function renderAlert(alert, expanded=false, modulesOptionsAlertReq,
                     <div class="separator-solid"></div>
                     <h3 class="title mb-3"><strong>Alert note</strong></h3>
                     <div id="alertNote-${alert.alert_id}">${renderAlertNoteMarkdown(alert.alert_note)}</div>
-                    <pre id="alertNoteRaw-${alert.alert_id}" class="d-none">${filterXSS(alert.alert_note)}</pre>
                     
                     <!-- Alert Context section -->
                     ${
@@ -1568,7 +1567,9 @@ async function editAlert(alert_id, close=false) {
 
     alertTag.val($(`#alertTags-${alert_id}`).text())
     set_suggest_tags(`editAlertTags`);
-    $('#editAlertNote').val($(`#alertNoteRaw-${alert_id}`).text());
+
+    let alertData = await fetchAlert(alert_id);
+    $('#editAlertNote').val(alertData.data.alert_note || '');
 
     let alert_resolution = getAlertResolutionName(alert_id);
     if (alert_resolution === '') {

--- a/source/app/static/assets/js/iris/alerts.js
+++ b/source/app/static/assets/js/iris/alerts.js
@@ -3,7 +3,7 @@ let sortOrder ;
 function renderAlertNoteMarkdown(noteText) {
     if (!noteText) return '';
     let converter = get_showdown_convert();
-    let html = converter.makeHtml(do_md_filter_xss(noteText));
+    let html = converter.makeHtml(noteText);
     return do_md_filter_xss(html);
 }
 


### PR DESCRIPTION
## Summary
- Render alert notes as markdown using Showdown.js with XSS filtering, matching case notes, comments, tasks, and other modules
- Fetch raw markdown from API when editing to preserve formatting
- Increase note textarea from 3 to 10 rows, consistent with other edit modals

## Breaking change
Existing plain-text alert notes that relied on `<pre>` tag behavior may render differently:
- Single line breaks are no longer preserved (markdown requires a blank line for a new paragraph or two trailing spaces for a line break)
- Multiple consecutive spaces are collapsed
- Characters with markdown meaning (`*`, `_`, `#`, `[`, `` ` ``) will now be interpreted as formatting

This is the same behavior as case notes, comments, task descriptions, and all other markdown-enabled fields in the application.

## Test plan
- [x] Create/edit an alert note with markdown syntax and confirm it renders correctly
- [x] Verify XSS payloads (`<script>`, `<img onerror>`) are stripped
- [x] Verify editing preserves raw markdown (backticks, headings, etc.)
- [x] Verify empty/null notes render without errors
- [x] Check existing plain-text notes still display acceptably