### PR TITLE
[#993][IMP] timeline visualization pivots and improves the UX/workflow

### DIFF
--- a/source/app/blueprints/pages/case/templates/case_graph_timeline.html
+++ b/source/app/blueprints/pages/case/templates/case_graph_timeline.html
@@ -26,7 +26,16 @@
                         <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}">No group</a>
                     </li>
                     <li class="nav-item hidden-caret">
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=ioc">Group by IOC</a>
+                    </li>
+                    <li class="nav-item hidden-caret">
                         <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=asset"><span class="text-decoration-none">Group by asset</span></a>
+                    </li>
+                    <li class="nav-item hidden-caret">
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=color">Group by color</a>
+                    </li>
+                    <li class="nav-item hidden-caret">
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=tag">Group by tag</a>
                     </li>
                     <li class="nav-item hidden-caret">
                         <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=category">Group by category</a>

--- a/source/app/blueprints/pages/case/templates/case_graph_timeline.html
+++ b/source/app/blueprints/pages/case/templates/case_graph_timeline.html
@@ -67,6 +67,18 @@
                 </div>
             </div>
         </div>
+
+        <div class="modal shadow-lg" tabindex="-1" id="modal_add_event" data-backdrop="static">
+            <div class="modal-xl modal-dialog" role="document">
+                <div class="modal-content" id="modal_add_event_content"></div>
+            </div>
+        </div>
+
+        <div class="modal" role="dialog" tabindex="-1" id="modal_comment" data-backdrop="false">
+            <div class="modal-lg modal-dialog modal-comment" role="document">
+                <div class="modal-content shadow-xl" id="modal_comment_content"></div>
+            </div>
+        </div>
     </div>
         {% include 'includes/footer.html' %}
 </div>
@@ -82,6 +94,7 @@
 <script src="/static/assets/js/plugin/select/bootstrap-select.min.js"></script>
 
 <script src="/static/assets/js/iris/case.common.js"></script>
+<script src="/static/assets/js/iris/comments.js"></script>
 <script src="/static/assets/js/iris/case.timeline.visu.js"></script>
 <script src="/static/assets/js/plugin/vis/vis.graph.js"></script>
 <script>

--- a/source/app/blueprints/pages/case/templates/case_graph_timeline.html
+++ b/source/app/blueprints/pages/case/templates/case_graph_timeline.html
@@ -20,25 +20,30 @@
 <div class="main-panel">
     <div class="content">
         <nav class="navbar navbar-header navbar-expand-lg bg-primary-gradient">
+            {% set group_by = request.args.get('group-by') %}
+            {% set include_children = request.args.get('include-children', 'true')|lower in ['1', 'true', 'yes', 'on'] %}
             <ul class="container-fluid mt-3 mb--2">
                 <ul class="navbar-nav">
                     <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}">No group</a>
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&include-children={{ 'true' if include_children else 'false' }}">No group</a>
                     </li>
                     <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=ioc">Group by IOC</a>
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=ioc&include-children={{ 'true' if include_children else 'false' }}">Group by IOC</a>
                     </li>
                     <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=asset"><span class="text-decoration-none">Group by asset</span></a>
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=asset&include-children={{ 'true' if include_children else 'false' }}"><span class="text-decoration-none">Group by asset</span></a>
                     </li>
                     <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=color">Group by color</a>
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=color&include-children={{ 'true' if include_children else 'false' }}">Group by color</a>
                     </li>
                     <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=tag">Group by tag</a>
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=tag&include-children={{ 'true' if include_children else 'false' }}">Group by tag</a>
                     </li>
                     <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=category">Group by category</a>
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=category&include-children={{ 'true' if include_children else 'false' }}">Group by category</a>
+                    </li>
+                    <li class="nav-item hidden-caret">
+                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}{% if group_by %}&group-by={{ group_by }}{% endif %}&include-children={{ 'false' if include_children else 'true' }}">Toggle children ({{ 'On' if include_children else 'Off' }})</a>
                     </li>
                  </ul>
                 <ul class="navbar-nav topbar-nav ml-md-auto align-items-center page-navigation page-navigation-style-2 page-navigation-secondary">

--- a/source/app/blueprints/pages/case/templates/case_graph_timeline.html
+++ b/source/app/blueprints/pages/case/templates/case_graph_timeline.html
@@ -46,6 +46,11 @@
                             <span class="text-white text-sm mr-2" id="last_resfresh">Loading</span>
                     </li>
                     <li class="nav-item hidden-caret">
+                        <button class="btn btn-primary btn-sm" onclick="reset_timeline_graph();">
+                            <span class="menu-title">Reset</span>
+                        </button>
+                    </li>
+                    <li class="nav-item hidden-caret">
                         <button class="btn btn-primary btn-sm" onclick="refresh_timeline_graph();">
                             <span class="menu-title">Refresh</span>
                         </button>

--- a/source/app/blueprints/pages/case/templates/case_graph_timeline.html
+++ b/source/app/blueprints/pages/case/templates/case_graph_timeline.html
@@ -23,42 +23,33 @@
             {% set group_by = request.args.get('group-by') %}
             {% set include_children = request.args.get('include-children', 'true')|lower in ['1', 'true', 'yes', 'on'] %}
             <ul class="container-fluid mt-3 mb--2">
-                <ul class="navbar-nav">
-                    <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&include-children={{ 'true' if include_children else 'false' }}">No group</a>
-                    </li>
-                    <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=ioc&include-children={{ 'true' if include_children else 'false' }}">Group by IOC</a>
-                    </li>
-                    <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=asset&include-children={{ 'true' if include_children else 'false' }}"><span class="text-decoration-none">Group by asset</span></a>
-                    </li>
-                    <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=color&include-children={{ 'true' if include_children else 'false' }}">Group by color</a>
-                    </li>
-                    <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=tag&include-children={{ 'true' if include_children else 'false' }}">Group by tag</a>
-                    </li>
-                    <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}&group-by=category&include-children={{ 'true' if include_children else 'false' }}">Group by category</a>
-                    </li>
-                    <li class="nav-item hidden-caret">
-                        <a class="menu-title btn btn-dark btn-sm" href="visualize?cid={{session['current_case'].case_id}}{% if group_by %}&group-by={{ group_by }}{% endif %}&include-children={{ 'false' if include_children else 'true' }}">Toggle children ({{ 'On' if include_children else 'Off' }})</a>
-                    </li>
-                 </ul>
                 <ul class="navbar-nav topbar-nav ml-md-auto align-items-center page-navigation page-navigation-style-2 page-navigation-secondary">
                     <li class="nav-item ml-2">
                             <span class="text-white text-sm mr-2" id="last_resfresh">Loading</span>
                     </li>
                     <li class="nav-item hidden-caret">
-                        <button class="btn btn-primary btn-sm" onclick="reset_timeline_graph();">
-                            <span class="menu-title">Reset</span>
-                        </button>
-                    </li>
-                    <li class="nav-item hidden-caret">
                         <button class="btn btn-primary btn-sm" onclick="refresh_timeline_graph();">
                             <span class="menu-title">Refresh</span>
                         </button>
+                    </li>
+                    <li class="nav-item">
+                        <div class="dropdown">
+                          <button class="btn btn-sm btn-border btn-black" id="dropdownVisualizationMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                              <span class="menu-title"><i class="fas fa-ellipsis-v"></i></span>
+                          </button>
+                          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownVisualizationMenuButton">
+                              <a class="dropdown-item" href="visualize?cid={{session['current_case'].case_id}}&include-children={{ 'true' if include_children else 'false' }}">No group</a>
+                              <a class="dropdown-item" href="visualize?cid={{session['current_case'].case_id}}&group-by=ioc&include-children={{ 'true' if include_children else 'false' }}">Group by IOC</a>
+                              <a class="dropdown-item" href="visualize?cid={{session['current_case'].case_id}}&group-by=asset&include-children={{ 'true' if include_children else 'false' }}">Group by asset</a>
+                              <a class="dropdown-item" href="visualize?cid={{session['current_case'].case_id}}&group-by=color&include-children={{ 'true' if include_children else 'false' }}">Group by color</a>
+                              <a class="dropdown-item" href="visualize?cid={{session['current_case'].case_id}}&group-by=tag&include-children={{ 'true' if include_children else 'false' }}">Group by tag</a>
+                              <a class="dropdown-item" href="visualize?cid={{session['current_case'].case_id}}&group-by=category&include-children={{ 'true' if include_children else 'false' }}">Group by category</a>
+                              <div class="dropdown-divider"></div>
+                              <a class="dropdown-item" href="visualize?cid={{session['current_case'].case_id}}{% if group_by %}&group-by={{ group_by }}{% endif %}&include-children={{ 'false' if include_children else 'true' }}">Toggle children ({{ 'On' if include_children else 'Off' }})</a>
+                              <div class="dropdown-divider"></div>
+                              <a class="dropdown-item" href="#" onclick="reset_timeline_graph(); return false;">Reset visualization</a>
+                          </div>
+                        </div>
                     </li>
                 </ul>
             </ul>

--- a/source/app/blueprints/pages/case/templates/case_timeline.html
+++ b/source/app/blueprints/pages/case/templates/case_timeline.html
@@ -53,9 +53,9 @@
                             </button>
                         </li>
                          <li class="nav-item hidden-caret">
-                            <button class="btn btn-dark btn-sm" onclick="toggle_tree_view();">
-                                <span class="menu-title">Toggle view</span>
-                            </button>
+                            <a class="btn btn-dark btn-sm" href="timeline/visualize?cid={{session['current_case'].case_id}}">
+                                <span class="menu-title">Visualize</span>
+                            </a>
                         </li>
                         <li class="nav-item">
                             <div class="dropdown">
@@ -67,7 +67,10 @@
                                   <a class="dropdown-item" href="javascript:void(0);" onclick="toggle_compact_view();"> Toggle compact view</a>
                                   <div class="dropdown-divider"></div>
                                   <a class="dropdown-item" href="timeline/visualize?cid={{session['current_case'].case_id}}"> Visualize</a>
+                                  <a class="dropdown-item" href="timeline/visualize?cid={{session['current_case'].case_id}}&group-by=ioc"> Visualize by IOC</a>
                                   <a class="dropdown-item" href="timeline/visualize?cid={{session['current_case'].case_id}}&group-by=asset"> Visualize by asset</a>
+                                  <a class="dropdown-item" href="timeline/visualize?cid={{session['current_case'].case_id}}&group-by=color"> Visualize by color</a>
+                                  <a class="dropdown-item" href="timeline/visualize?cid={{session['current_case'].case_id}}&group-by=tag"> Visualize by tag</a>
                                   <a class="dropdown-item" href="timeline/visualize?cid={{session['current_case'].case_id}}&group-by=category">Visualize by category</a>
                                   <div class="dropdown-divider"></div>
                                   <a class="dropdown-item" href="#" onclick="timelineToCsv();"><small class="fa fa-download mr-2"></small> Download as CSV</a>

--- a/source/app/blueprints/pages/case/templates/modal_add_case_event.html
+++ b/source/app/blueprints/pages/case/templates/modal_add_case_event.html
@@ -172,7 +172,7 @@
                                         <div class="form-check">
                                             <label class="form-check-label mt-3">
                                                 {{ form.event_in_summary(class="form-check-input", type="checkbox") }}
-                                                <span class="form-check-sign"> Add to summary
+                                                <span class="form-check-sign"> Add to visualization
                                                     <i class="ml-1 mt-1 fa-regular fa-circle-question" title="If checked, the event will be integrated in the Timeline Visualization" style="cursor:pointer;"></i>
                                                 </span>
                                             </label>

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -174,25 +174,97 @@ def case_get_timeline_state(caseid):
     return response_error('No timeline state for this case. Add an event to begin')
 
 
+def _get_visualization_event(row, group_name):
+    content = row.event_content.replace('\n', '<br/>') if row.event_content else ''
+    visualized_event = {
+        'date': row.event_date,
+        'group': group_name,
+        'content': row.event_title,
+        'title': f"<small>{row.event_date.strftime('%Y-%m-%dT%H:%M:%S')}</small><br/>{content}",
+        'unique_id': row.event_id
+    }
+
+    if row.event_color:
+        visualized_event['style'] = f'background-color: {row.event_color};'
+
+    return visualized_event
+
+
+def _expand_timeline_by_group(timeline, events_groups, fallback_group):
+    tim = []
+    for row in timeline:
+        grouped_values = events_groups.get(row.event_id, []) or [fallback_group]
+        for group_name in grouped_values:
+            tim.append(_get_visualization_event(row, group_name))
+
+    return tim
+
+
+def _build_events_groups(rows, value_key):
+    events_groups = {}
+    for row in rows:
+        event_id = row.event_id
+        group_value = getattr(row, value_key, None)
+        if not group_value:
+            continue
+
+        events_groups.setdefault(event_id, [])
+        if group_value not in events_groups[event_id]:
+            events_groups[event_id].append(group_value)
+
+    return events_groups
+
+
+def _get_event_color_group_name(event_color):
+    event_color_map = {
+        '#fff': 'White',
+        '#1572e899': 'Blue',
+        '#6861ce99': 'Purple',
+        '#48abf799': 'Light blue',
+        '#31ce3699': 'Green',
+        '#f2596199': 'Red',
+        '#ffad4699': 'Orange'
+    }
+
+    if not event_color:
+        return 'No color'
+
+    return event_color_map.get(event_color.lower(), event_color)
+
+
 @case_timeline_rest_blueprint.route('/case/timeline/visualize/data/by-asset', methods=['GET'])
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_getgraph_assets(caseid):
-    assets_cache = get_assets_by_case(caseid)
     timeline = get_events_by_case(caseid)
+    assets_cache = get_assets_by_case(caseid)
+    events_assets = _build_events_groups(assets_cache, 'asset_name')
 
-    tim = []
-    for row in timeline:
-        for asset in assets_cache:
-            if asset.event_id == row.event_id:
-                tmp = {'date': row.event_date, 'group': asset.asset_name, 'content': row.event_title,
-                       'title': f"{row.event_date.strftime('%Y-%m-%dT%H:%M:%S')} - {row.event_content}"}
+    tim = _expand_timeline_by_group(timeline, events_assets, 'No linked assets')
 
-                if row.event_color:
-                    tmp['style'] = f'background-color: {row.event_color};'
+    res = {
+        "events": tim
+    }
 
-                tmp['unique_id'] = row.event_id
-                tim.append(tmp)
+    return response_success("", data=res)
+
+
+@case_timeline_rest_blueprint.route('/case/timeline/visualize/data/by-ioc', methods=['GET'])
+@ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
+@ac_api_requires()
+def case_getgraph_iocs(caseid):
+    timeline = get_events_by_case(caseid)
+    iocs_cache = CaseEventsIoc.query.with_entities(
+        CaseEventsIoc.event_id,
+        Ioc.ioc_value
+    ).join(
+        CaseEventsIoc.ioc
+    ).filter(
+        CaseEventsIoc.case_id == caseid
+    ).all()
+    events_iocs = _build_events_groups(iocs_cache, 'ioc_value')
+
+    tim = _expand_timeline_by_group(timeline, events_iocs, 'No linked IOCs')
 
     res = {
         "events": tim
@@ -206,24 +278,50 @@ def case_getgraph_assets(caseid):
 @ac_api_requires()
 def case_getgraph(caseid):
     timeline = get_events_by_case(caseid)
-
-    tim = []
+    events_categories = {}
     for row in timeline:
+        group_name = row.category[0].name if row.category else 'Uncategorized'
+        events_categories[row.event_id] = [group_name]
 
-        tmp = {'date': row.event_date, 'group': row.category[0].name if row.category else 'Uncategorized', 'content': row.event_title}
+    tim = _expand_timeline_by_group(timeline, events_categories, 'Uncategorized')
 
-        if row.event_content:
-            content = row.event_content.replace('\n', '<br/>')
-        else:
-            content = ''
+    res = {
+        "events": tim
+    }
 
-        tmp['title'] = f"<small>{row.event_date.strftime('%Y-%m-%dT%H:%M:%S')}</small><br/>{content}"
+    return response_success("", data=res)
 
-        if row.event_color:
-            tmp['style'] = f'background-color: {row.event_color};'
 
-        tmp['unique_id'] = row.event_id
-        tim.append(tmp)
+@case_timeline_rest_blueprint.route('/case/timeline/visualize/data/by-tag', methods=['GET'])
+@ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
+@ac_api_requires()
+def case_getgraph_tags(caseid):
+    timeline = get_events_by_case(caseid)
+    events_tags = {}
+    for row in timeline:
+        tags = [tag.strip() for tag in (row.event_tags or '').split(',') if tag.strip()]
+        events_tags[row.event_id] = list(dict.fromkeys(tags))
+
+    tim = _expand_timeline_by_group(timeline, events_tags, 'No tags')
+
+    res = {
+        "events": tim
+    }
+
+    return response_success("", data=res)
+
+
+@case_timeline_rest_blueprint.route('/case/timeline/visualize/data/by-color', methods=['GET'])
+@ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
+@ac_api_requires()
+def case_getgraph_colors(caseid):
+    timeline = get_events_by_case(caseid)
+    events_colors = {}
+    for row in timeline:
+        color_name = _get_event_color_group_name(row.event_color)
+        events_colors[row.event_id] = [color_name]
+
+    tim = _expand_timeline_by_group(timeline, events_colors, 'No color')
 
     res = {
         "events": tim

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -176,6 +176,16 @@ def case_get_timeline_state(caseid):
 
 def _get_visualization_event(row, group_name):
     content = row.event_content.replace('\n', '<br/>') if row.event_content else ''
+    styles = []
+
+    if row.event_color:
+        styles.append(f'background-color: {row.event_color};')
+
+    # Highlight child events in visualization with a dashed outline.
+    if row.parent_event_id is not None:
+        styles.append('border: 1px dashed #6c757d;')
+        styles.append('box-sizing: border-box;')
+
     visualized_event = {
         'date': row.event_date,
         'group': group_name,
@@ -184,8 +194,8 @@ def _get_visualization_event(row, group_name):
         'unique_id': row.event_id
     }
 
-    if row.event_color:
-        visualized_event['style'] = f'background-color: {row.event_color};'
+    if styles:
+        visualized_event['style'] = ' '.join(styles)
 
     return visualized_event
 

--- a/source/app/blueprints/rest/case/case_timeline_routes.py
+++ b/source/app/blueprints/rest/case/case_timeline_routes.py
@@ -232,11 +232,33 @@ def _get_event_color_group_name(event_color):
     return event_color_map.get(event_color.lower(), event_color)
 
 
+def _is_include_children():
+    include_children = request.args.get('include-children')
+    if include_children is None:
+        return True
+
+    normalized_value = str(include_children).strip().lower()
+    if '?' in normalized_value:
+        normalized_value = normalized_value.split('?', maxsplit=1)[0]
+    if '&' in normalized_value:
+        normalized_value = normalized_value.split('&', maxsplit=1)[0]
+
+    return normalized_value in ('1', 'true', 'yes', 'on')
+
+
+def _get_visualization_timeline(caseid):
+    timeline = get_events_by_case(caseid)
+    if _is_include_children():
+        return timeline
+
+    return [row for row in timeline if row.parent_event_id is None]
+
+
 @case_timeline_rest_blueprint.route('/case/timeline/visualize/data/by-asset', methods=['GET'])
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_getgraph_assets(caseid):
-    timeline = get_events_by_case(caseid)
+    timeline = _get_visualization_timeline(caseid)
     assets_cache = get_assets_by_case(caseid)
     events_assets = _build_events_groups(assets_cache, 'asset_name')
 
@@ -253,7 +275,7 @@ def case_getgraph_assets(caseid):
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_getgraph_iocs(caseid):
-    timeline = get_events_by_case(caseid)
+    timeline = _get_visualization_timeline(caseid)
     iocs_cache = CaseEventsIoc.query.with_entities(
         CaseEventsIoc.event_id,
         Ioc.ioc_value
@@ -277,7 +299,7 @@ def case_getgraph_iocs(caseid):
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_getgraph(caseid):
-    timeline = get_events_by_case(caseid)
+    timeline = _get_visualization_timeline(caseid)
     events_categories = {}
     for row in timeline:
         group_name = row.category[0].name if row.category else 'Uncategorized'
@@ -296,7 +318,7 @@ def case_getgraph(caseid):
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_getgraph_tags(caseid):
-    timeline = get_events_by_case(caseid)
+    timeline = _get_visualization_timeline(caseid)
     events_tags = {}
     for row in timeline:
         tags = [tag.strip() for tag in (row.event_tags or '').split(',') if tag.strip()]
@@ -315,7 +337,7 @@ def case_getgraph_tags(caseid):
 @ac_requires_case_identifier(CaseAccessLevel.read_only, CaseAccessLevel.full_access)
 @ac_api_requires()
 def case_getgraph_colors(caseid):
-    timeline = get_events_by_case(caseid)
+    timeline = _get_visualization_timeline(caseid)
     events_colors = {}
     for row in timeline:
         color_name = _get_event_color_group_name(row.event_color)

--- a/source/app/forms.py
+++ b/source/app/forms.py
@@ -183,7 +183,7 @@ class CaseEventForm(FlaskForm):
     event_assets = SelectField(u'Event Asset')
     event_category_id = SelectField(u'Event Category')
     event_tz = StringField(u'Event Timezone', validators=[DataRequired()])
-    event_in_summary = BooleanField(u'Add to summary')
+    event_in_summary = BooleanField(u'Add to visualization')
     event_tags = StringField(u'Event Tags')
     event_in_graph = BooleanField(u'Display in graph')
 

--- a/ui/src/pages/case.timeline.visu.js
+++ b/ui/src/pages/case.timeline.visu.js
@@ -1,3 +1,261 @@
+var timeline = null;
+var timeline_items = null;
+var g_event_id = null;
+var g_event_desc_editor = null;
+var current_timeline = [];
+
+function get_timeline_events_cache(callback) {
+    get_request_api('/case/timeline/events/list')
+    .done((data) => {
+        if (data.status === 'success' && data.data && data.data.timeline) {
+            current_timeline = data.data.timeline;
+        } else {
+            current_timeline = [];
+        }
+
+        if (callback) {
+            callback();
+        }
+    });
+}
+
+function edit_in_event_desc() {
+    if ($('#container_event_desc_content').is(':visible')) {
+        $('#container_event_description').show(100);
+        $('#container_event_desc_content').hide(100);
+        $('#event_edition_btn').hide(100);
+        $('#event_preview_button').hide(100);
+    } else {
+        $('#event_preview_button').show(100);
+        $('#event_edition_btn').show(100);
+        $('#container_event_desc_content').show(100);
+        $('#container_event_description').hide(100);
+    }
+}
+
+function preview_event_description(no_btn_update) {
+    if (!$('#container_event_description').is(':visible')) {
+        event_desc = g_event_desc_editor.getValue();
+        converter = get_showdown_convert();
+        html = converter.makeHtml(do_md_filter_xss(event_desc));
+        event_desc_html = do_md_filter_xss(html);
+        $('#target_event_desc').html(event_desc_html);
+        $('#container_event_description').show();
+        if (!no_btn_update) {
+            $('#event_preview_button').html('<i class="fa-solid fa-eye-slash"></i>');
+        }
+        $('#container_event_desc_content').hide();
+    } else {
+        $('#container_event_description').hide();
+        if (!no_btn_update) {
+            $('#event_preview_button').html('<i class="fa-solid fa-eye"></i>');
+        }
+
+        $('#event_preview_button').html('<i class="fa-solid fa-eye"></i>');
+        $('#container_event_desc_content').show();
+    }
+}
+
+function show_time_converter() {
+    $('#event_date_convert').show();
+    $('#event_date_convert_input').focus();
+    $('#event_date_inputs').hide();
+}
+
+function hide_time_converter() {
+    $('#event_date_convert').hide();
+    $('#event_date_inputs').show();
+    $('#event_date').focus();
+}
+
+function time_converter() {
+    let date_val = $('#event_date_convert_input').val();
+
+    var data_sent = Object();
+    data_sent['date_value'] = date_val;
+    data_sent['csrf_token'] = $('#csrf_token').val();
+
+    post_request_api('/case/timeline/events/convert-date', JSON.stringify(data_sent))
+    .done(function(data) {
+        if (notify_auto_api(data)) {
+            $('#event_date').val(data.data.date);
+            $('#event_time').val(data.data.time);
+            $('#event_tz').val(data.data.tz);
+            hide_time_converter();
+            $('#convert_bad_feedback').text('');
+        }
+    })
+    .fail(function() {
+        $('#convert_bad_feedback').text('Unable to find a matching pattern for the date');
+    });
+}
+
+function duplicate_event(id) {
+    window.location.hash = id;
+    clear_api_error();
+
+    get_request_api(`/case/timeline/events/duplicate/${id}`)
+    .done((data) => {
+        if (notify_auto_api(data)) {
+            refresh_timeline_graph();
+        }
+    });
+}
+
+function delete_event(id) {
+    window.location.hash = id;
+    do_deletion_prompt("You are about to delete event #" + id)
+    .then((doDelete) => {
+        if (doDelete) {
+            post_request_api(`/case/timeline/events/delete/${id}`)
+            .done(function(data) {
+                if (notify_auto_api(data)) {
+                    refresh_timeline_graph();
+                    $('#modal_add_event').modal('hide');
+                }
+            });
+        }
+    });
+}
+
+function update_event(event_id) {
+    update_event_ext(event_id, true);
+}
+
+function update_event_ext(event_id, do_close) {
+    if (event_id === undefined || event_id === null) {
+        event_id = g_event_id;
+    }
+
+    window.location.hash = event_id;
+    clear_api_error();
+    var data_sent = $('#form_new_event').serializeObject();
+    data_sent['event_date'] = `${$('#event_date').val()}T${$('#event_time').val()}`;
+    data_sent['event_in_summary'] = $('#event_in_summary').is(':checked');
+    data_sent['event_in_graph'] = $('#event_in_graph').is(':checked');
+    data_sent['event_sync_iocs_assets'] = $('#event_sync_iocs_assets').is(':checked');
+    data_sent['event_tags'] = $('#event_tags').val();
+    data_sent['event_assets'] = $('#event_assets').val();
+    data_sent['event_iocs'] = $('#event_iocs').val();
+    data_sent['event_tz'] = $('#event_tz').val();
+    data_sent['event_content'] = g_event_desc_editor.getValue();
+    data_sent['parent_event_id'] = $('#parent_event_id').val() || null;
+
+    ret = get_custom_attributes_fields();
+    has_error = ret[0].length > 0;
+    attributes = ret[1];
+
+    if (has_error) {
+        return false;
+    }
+
+    data_sent['custom_attributes'] = attributes;
+
+    post_request_api(`/case/timeline/events/update/${event_id}`, JSON.stringify(data_sent), true)
+    .done(function(data) {
+        if (notify_auto_api(data)) {
+            refresh_timeline_graph();
+
+            if (do_close !== undefined && do_close === true) {
+                $('#modal_add_event').modal('hide');
+            }
+
+            $('#submit_new_event').text("Saved").addClass('btn-outline-success').removeClass('btn-outline-danger').removeClass('btn-outline-warning');
+            $('#last_saved').removeClass('btn-danger').addClass('btn-success');
+            $('#last_saved > i').attr('class', "fa-solid fa-file-circle-check");
+        }
+    });
+}
+
+function edit_event(id) {
+    const url = '/case/timeline/events/' + id + '/modal' + case_param();
+    window.location.hash = id;
+
+    $('#modal_add_event_content').load(url, function(response, status, xhr) {
+        hide_minimized_modal_box();
+        if (status !== "success") {
+            ajax_notify_error(xhr, url);
+            return false;
+        }
+
+        g_event_id = id;
+        g_event_desc_editor = get_new_ace_editor('event_description', 'event_desc_content', 'target_event_desc',
+            function() {
+                $('#last_saved').addClass('btn-danger').removeClass('btn-success');
+                $('#last_saved > i').attr('class', "fa-solid fa-file-circle-exclamation");
+            }, null);
+
+        g_event_desc_editor.setOption("minLines", "6");
+        preview_event_description(true);
+        headers = get_editor_headers('g_event_desc_editor', null, 'event_edition_btn');
+        $('#event_edition_btn').append(headers);
+        edit_in_event_desc();
+
+        get_timeline_events_cache(function() {
+            let parent_selector = $('#parent_event_id');
+
+            // Add empty option
+            let option = $('<option>');
+            option.attr('value', '');
+            option.text('No parent event');
+            parent_selector.append(option);
+
+            let target_idx = null;
+            // Add all events to the parent selector and remove the current event
+            for (let idx in current_timeline) {
+                let event = current_timeline[idx];
+
+                if (event.event_id === id) {
+                    target_idx = event.parent_event_id;
+                    continue;
+                }
+
+                let selector_option = $('<option>');
+                selector_option.attr('value', event.event_id);
+                selector_option.text(`${event.event_title}`);
+                parent_selector.append(selector_option);
+            }
+
+            parent_selector.selectpicker({
+                liveSearch: true,
+                size: 10,
+                width: '100%',
+                title: 'Select a parent event',
+                style: 'btn-light',
+                noneSelectedText: 'No event selected',
+            });
+
+            if (target_idx !== null) {
+                parent_selector.selectpicker('val', target_idx);
+                parent_selector.selectpicker("refresh");
+            }
+
+            load_menu_mod_options_modal(id, 'event', $("#event_modal_quick_actions"));
+            $('#modal_add_event').modal({ show: true });
+        });
+    });
+}
+
+function setup_visualization_click_handler() {
+    if (!timeline || !timeline_items) {
+        return;
+    }
+
+    timeline.off('select');
+    timeline.on('select', function(properties) {
+        if (!properties.items || properties.items.length === 0) {
+            return;
+        }
+
+        const selected_item = timeline_items.get(properties.items[0]);
+        if (!selected_item || !selected_item.event_id) {
+            return;
+        }
+
+        edit_event(selected_item.event_id);
+    });
+}
+
 function visualizeTimeline(group) {
     const groupedModes = ['ioc', 'asset', 'color', 'tag', 'category'];
     const groupToEndpoint = {
@@ -32,7 +290,8 @@ function visualizeTimeline(group) {
                         groups_l.push(event.group);
                     }
                     items.add({
-                        id: index,
+                        id: `${event.unique_id}-${index}`,
+                        event_id: event.unique_id,
                         group: groups_l.indexOf(event.group),
                         start: event.date,
                         content: event.content,
@@ -61,6 +320,8 @@ function visualizeTimeline(group) {
                 timeline.setGroups(groups);
               }
               timeline.setItems(items);
+              timeline_items = items;
+              setup_visualization_click_handler();
               hide_loader();
 
         }
@@ -74,3 +335,9 @@ function refresh_timeline_graph(){
     group = urlParams.get('group-by');
     visualizeTimeline(group);
 }
+
+$(document).ready(function() {
+    $('#modal_add_event').off('hidden.bs.modal.visu').on('hidden.bs.modal.visu', function() {
+        refresh_timeline_graph();
+    });
+});

--- a/ui/src/pages/case.timeline.visu.js
+++ b/ui/src/pages/case.timeline.visu.js
@@ -4,6 +4,7 @@ var g_event_id = null;
 var g_event_desc_editor = null;
 var current_timeline = [];
 var current_visualization_group = null;
+var current_visualization_include_children = true;
 
 function get_visualization_state_key() {
     return `timeline.visualization.state:${get_caseid()}`;
@@ -32,12 +33,21 @@ function save_visualization_state() {
         const state = {
             start: window_data.start.toISOString(),
             end: window_data.end.toISOString(),
-            group: current_visualization_group
+            group: current_visualization_group,
+            include_children: current_visualization_include_children
         };
         localStorage.setItem(get_visualization_state_key(), JSON.stringify(state));
     } catch (error) {
         // Ignore storage failures (private mode/quota), timeline still works without persistence.
     }
+}
+
+function query_bool(value, default_value) {
+    if (value === null || value === undefined) {
+        return default_value;
+    }
+
+    return ['1', 'true', 'yes', 'on'].includes(String(value).toLowerCase());
 }
 
 function clear_visualization_state() {
@@ -311,8 +321,9 @@ function setup_visualization_range_handler() {
     });
 }
 
-function visualizeTimeline(group) {
+function visualizeTimeline(group, include_children) {
     current_visualization_group = group || null;
+    current_visualization_include_children = include_children !== false;
     const groupedModes = ['ioc', 'asset', 'color', 'tag', 'category'];
     const groupToEndpoint = {
         ioc: '/case/timeline/visualize/data/by-ioc',
@@ -321,9 +332,12 @@ function visualizeTimeline(group) {
         tag: '/case/timeline/visualize/data/by-tag',
         category: '/case/timeline/visualize/data/by-category'
     };
-    const src = groupToEndpoint[group] || groupToEndpoint.category;
+    const src_path = groupToEndpoint[group] || groupToEndpoint.category;
+    const src = `${src_path}?include-children=${current_visualization_include_children ? 'true' : 'false'}`;
+    const separator = src.includes('?') ? '&' : '?';
+    const src_with_case = `${src}${separator}cid=${encodeURIComponent(get_caseid())}`;
 
-    get_request_api(src)
+    get_raw_request_api(src_with_case)
     .done((data) => {
         if (data.status == 'success') {
               var items = new vis.DataSet();
@@ -388,10 +402,11 @@ function visualizeTimeline(group) {
 
 function refresh_timeline_graph(){
     show_loader();
-    queryString = window.location.search;
-    urlParams = new URLSearchParams(queryString);
-    group = urlParams.get('group-by');
-    visualizeTimeline(group);
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    const group = urlParams.get('group-by');
+    const include_children = query_bool(urlParams.get('include-children'), true);
+    visualizeTimeline(group, include_children);
 }
 
 function reset_timeline_graph() {
@@ -399,6 +414,7 @@ function reset_timeline_graph() {
 
     const url = new URL(window.location.href);
     url.searchParams.delete('group-by');
+    url.searchParams.delete('include-children');
     url.hash = '';
 
     const query_string = url.searchParams.toString();

--- a/ui/src/pages/case.timeline.visu.js
+++ b/ui/src/pages/case.timeline.visu.js
@@ -3,6 +3,50 @@ var timeline_items = null;
 var g_event_id = null;
 var g_event_desc_editor = null;
 var current_timeline = [];
+var current_visualization_group = null;
+
+function get_visualization_state_key() {
+    return `timeline.visualization.state:${get_caseid()}`;
+}
+
+function get_visualization_state() {
+    try {
+        const raw_state = localStorage.getItem(get_visualization_state_key());
+        if (!raw_state) {
+            return null;
+        }
+
+        return JSON.parse(raw_state);
+    } catch (error) {
+        return null;
+    }
+}
+
+function save_visualization_state() {
+    if (!timeline) {
+        return;
+    }
+
+    try {
+        const window_data = timeline.getWindow();
+        const state = {
+            start: window_data.start.toISOString(),
+            end: window_data.end.toISOString(),
+            group: current_visualization_group
+        };
+        localStorage.setItem(get_visualization_state_key(), JSON.stringify(state));
+    } catch (error) {
+        // Ignore storage failures (private mode/quota), timeline still works without persistence.
+    }
+}
+
+function clear_visualization_state() {
+    try {
+        localStorage.removeItem(get_visualization_state_key());
+    } catch (error) {
+        // Ignore storage failures.
+    }
+}
 
 function get_timeline_events_cache(callback) {
     get_request_api('/case/timeline/events/list')
@@ -241,7 +285,6 @@ function setup_visualization_click_handler() {
         return;
     }
 
-    timeline.off('select');
     timeline.on('select', function(properties) {
         if (!properties.items || properties.items.length === 0) {
             return;
@@ -256,7 +299,20 @@ function setup_visualization_click_handler() {
     });
 }
 
+function setup_visualization_range_handler() {
+    if (!timeline) {
+        return;
+    }
+
+    timeline.on('rangechanged', function(properties) {
+        if (properties.byUser) {
+            save_visualization_state();
+        }
+    });
+}
+
 function visualizeTimeline(group) {
+    current_visualization_group = group || null;
     const groupedModes = ['ioc', 'asset', 'color', 'tag', 'category'];
     const groupToEndpoint = {
         ioc: '/case/timeline/visualize/data/by-ioc',
@@ -302,12 +358,13 @@ function visualizeTimeline(group) {
                 }
 
               // specify options
+              const state = get_visualization_state();
               var options = {
                 stack: true,
                 minHeight: '400px',
                 maxHeight: $(window).height() - 250,
-                start: data.data.events[0].date,
-                end: data.data.events[data.data.events.length - 1].date,
+                start: state && state.start ? state.start : data.data.events[0].date,
+                end: state && state.end ? state.end : data.data.events[data.data.events.length - 1].date,
               };
 
               // create a Timeline
@@ -322,6 +379,7 @@ function visualizeTimeline(group) {
               timeline.setItems(items);
               timeline_items = items;
               setup_visualization_click_handler();
+              setup_visualization_range_handler();
               hide_loader();
 
         }
@@ -334,6 +392,17 @@ function refresh_timeline_graph(){
     urlParams = new URLSearchParams(queryString);
     group = urlParams.get('group-by');
     visualizeTimeline(group);
+}
+
+function reset_timeline_graph() {
+    clear_visualization_state();
+
+    const url = new URL(window.location.href);
+    url.searchParams.delete('group-by');
+    url.hash = '';
+
+    const query_string = url.searchParams.toString();
+    window.location.href = query_string ? `${url.pathname}?${query_string}` : url.pathname;
 }
 
 $(document).ready(function() {

--- a/ui/src/pages/case.timeline.visu.js
+++ b/ui/src/pages/case.timeline.visu.js
@@ -1,10 +1,13 @@
 function visualizeTimeline(group) {
-    ggr = ['asset', 'category']
-    if (group == 'asset') {
-        src = '/case/timeline/visualize/data/by-asset';
-    } else {
-        src = '/case/timeline/visualize/data/by-category';
-    }
+    const groupedModes = ['ioc', 'asset', 'color', 'tag', 'category'];
+    const groupToEndpoint = {
+        ioc: '/case/timeline/visualize/data/by-ioc',
+        asset: '/case/timeline/visualize/data/by-asset',
+        color: '/case/timeline/visualize/data/by-color',
+        tag: '/case/timeline/visualize/data/by-tag',
+        category: '/case/timeline/visualize/data/by-category'
+    };
+    const src = groupToEndpoint[group] || groupToEndpoint.category;
 
     get_request_api(src)
     .done((data) => {
@@ -54,7 +57,7 @@ function visualizeTimeline(group) {
               container.innerHTML = '';
               $('#card_main_load').show();
               timeline = new vis.Timeline(container, null, options);
-              if (ggr.includes(group)) {
+              if (groupedModes.includes(group)) {
                 timeline.setGroups(groups);
               }
               timeline.setItems(items);


### PR DESCRIPTION
## Related issue
Closes #993

## Summary
This PR expands timeline visualization pivots and improves the visualization UX/workflow.  
It adds grouping by IOC, Tag, and Color (alongside existing Asset/Category), introduces child-event include/exclude control, and improves edit/refresh/state persistence behavior in the visualization view.

## What changed

### `source/app/blueprints/rest/case/case_timeline_routes.py`
- Added visualization data routes for:
  - `/case/timeline/visualize/data/by-ioc`
  - `/case/timeline/visualize/data/by-tag`
  - `/case/timeline/visualize/data/by-color`
- Refactored visualization grouping helpers to reuse common event expansion logic.
- Added include-children handling for visualization datasets:
  - `include-children=true|false` query support
  - Shared timeline selection helper for all visualization endpoints
- Hardened include-children parsing for malformed query values.
- Added child-event visual differentiation in visualization item style:
  - Dashed border styling for child events (`parent_event_id != null`)

### `ui/src/pages/case.timeline.visu.js`
- Added frontend routing for group-by modes:
  - `ioc`, `asset`, `color`, `tag`, `category`
- Added visualization state persistence in local storage:
  - Stores current window start/end and active grouping mode
  - Preserves timeline zoom/resolution across refreshes
- Added reset workflow:
  - Clears persisted visualization state
  - Clears grouping and include-children URL params
- Added event click behavior:
  - Click visualization event -> open event edit modal
  - On modal close -> refresh visualization
- Added include-children query support in data requests.
- Fixed request construction for visualization API calls:
  - Use `get_raw_request_api` with explicit `cid` to avoid query corruption.

### `source/app/blueprints/pages/case/templates/case_timeline.html`
- Updated top action button text from `Toggle view` to `Visualize`.
- Expanded timeline dropdown visualize actions:
  - Visualize by IOC
  - Visualize by asset
  - Visualize by color
  - Visualize by tag
  - Visualize by category

### `source/app/blueprints/pages/case/templates/case_graph_timeline.html`
- Added visualization controls for all group-by modes.
- Added `Toggle children` control (include/exclude children from visualization dataset).
- Added `Reset` control and retained `Refresh`.
- Refined layout to match timeline UX:
  - Moved visualization actions into right-side 3-dot overflow dropdown
  - Keep `Refresh` button on the right, followed by overflow menu
  - Organized menu with dividers

### `source/app/blueprints/pages/case/templates/modal_add_case_event.html`
### `source/app/forms.py`
- Updated label text:
  - `Add to summary` -> `Add to visualization`

## Scope / Non-goals
- No DB schema changes or migrations.
- No change to per-event `event_in_summary` semantics; child toggle only filters visualization dataset inclusion.
- No parent/child connector lines in timeline visualization (separate scope).

## Validation
- AST/syntax checks run on modified Python files.
- JS syntax check run on `ui/src/pages/case.timeline.visu.js`.
- End-to-end behavior validated through iterative UI checks and container restarts (`app`, `nginx`).
- Full test suite not run as part of this changeset.

## Commits
- `e8d821ca` `[#993][IMP] Add timeline visualization group routes`
- `6e350f26` `[#993][IMP] Route timeline visualization modes in frontend`
- `31b788c7` `[#993][IMP] Add timeline graph group controls`
- `8921f7dc` `[#993][IMP] Expand timeline visualize actions in main toolbar`
- `ce8dba78` `[#993][IMP] Rename event summary toggle label to visualization`
- `74d83197` `[#993][IMP] Enable edit modal from timeline visualization click`
- `e0bc4b56` `[#993][IMP] Persist visualization window and add reset control`
- `0b2c294b` `[#993][IMP] Add visualization toggle for child events`
- `834676a6` `[#993][IMP] Add dashed child-event styling in visualization`
- `65a074bd` `[#993][IMP] Move visualization options into overflow dropdown`
