### PR TITLE
[#1049][#1050][#1052][FIX] Fix manage-case state transition behavior for Closed/Open lifecycle and edit-dialog action conflicts

### DIFF
--- a/source/app/blueprints/graphql/cases.py
+++ b/source/app/blueprints/graphql/cases.py
@@ -181,6 +181,7 @@ class CaseUpdate(Mutation):
         permissions_check_current_user_has_some_case_access(case_id, [CaseAccessLevel.full_access])
 
         case = cases_get_by_identifier(case_id)
+        previous_state_id = case.state_id
 
         # If user tries to update the customer, check if the user has access to the new customer
         if request.get('case_customer') and request.get('case_customer') != case.client_id:
@@ -197,5 +198,5 @@ class CaseUpdate(Mutation):
         updated_case = add_case_schema.load(request, instance=case, partial=True)
         protagonists = request.get('protagonists')
         tags = request.get('case_tags')
-        case = cases_update(case, updated_case, protagonists, tags)
+        case = cases_update(case, updated_case, protagonists, tags, previous_state_id=previous_state_id)
         return CaseUpdate(case=case)

--- a/source/app/blueprints/pages/manage/templates/modal_case_info_from_case.html
+++ b/source/app/blueprints/pages/manage/templates/modal_case_info_from_case.html
@@ -394,14 +394,14 @@
 </datalist>
 
 <div class="modal-footer">
-    <button type="button" class="btn btn-outline-danger " onclick="remove_case('{{ data.case_id }}');"
+    <button type="button" class="btn btn-outline-danger case-info-readonly-action" onclick="remove_case('{{ data.case_id }}');"
             id="delete_case_info">Delete case</button>
 
     {% if not data.close_date %}
-        <button type="button" class="btn btn-outline-warning mr-auto" onclick="close_case('{{ data.case_id }}');"
+        <button type="button" class="btn btn-outline-warning mr-auto case-info-readonly-action" onclick="close_case('{{ data.case_id }}');"
                 id="close_case_info">Close case</button>
     {% else %}
-        <button type="button" class="btn btn-success" onclick="reopen_case('{{ data.case_id }}');"
+        <button type="button" class="btn btn-success mr-auto case-info-readonly-action" onclick="reopen_case('{{ data.case_id }}');"
                 id="reopen_case_info">Reopen case</button>
     {% endif %}
     <button type="button" class="btn btn-outline-dark mr-2" style="display:none;" id="cancel_case_info"  onclick="cancel_case_edit();">Cancel</button>

--- a/source/app/blueprints/rest/manage/manage_cases_routes.py
+++ b/source/app/blueprints/rest/manage/manage_cases_routes.py
@@ -278,6 +278,7 @@ def update_case_info(identifier):
     case_schema = CaseSchema()
     try:
         case = cases_get_by_identifier(identifier)
+        previous_state_id = case.state_id
 
         request_data = request.get_json()
         # If user tries to update the customer, check if the user has access to the new customer
@@ -296,7 +297,7 @@ def update_case_info(identifier):
 
         protagonists = request_data.get('protagonists')
         tags = request_data.get('case_tags')
-        case = cases_update(case, updated_case, protagonists, tags)
+        case = cases_update(case, updated_case, protagonists, tags, previous_state_id=previous_state_id)
         return response_success('Updated', data=case_schema.dump(case))
     except ValidationError as e:
         return response_error('Data error', e.messages)

--- a/source/app/blueprints/rest/v2/cases.py
+++ b/source/app/blueprints/rest/v2/cases.py
@@ -129,6 +129,7 @@ class CasesOperations:
 
         try:
             case = cases_get_by_identifier(identifier)
+            previous_state_id = case.state_id
 
             request_data = request.get_json()
 
@@ -151,7 +152,7 @@ class CasesOperations:
 
             protagonists = request_data.get('protagonists')
             tags = request_data.get('case_tags')
-            case = cases_update(case, updated_case, protagonists, tags)
+            case = cases_update(case, updated_case, protagonists, tags, previous_state_id=previous_state_id)
             result = self._schema.dump(case)
             return response_api_success(result)
         except ValidationError as e:

--- a/source/app/business/cases.py
+++ b/source/app/business/cases.py
@@ -161,10 +161,10 @@ def cases_delete(case_identifier):
         raise BusinessProcessingError('Cannot delete the case. Please check server logs for additional informations')
 
 
-def cases_update(case: Cases, updated_case, protagonists, tags) -> Cases:
+def cases_update(case: Cases, updated_case, protagonists, tags, previous_state_id=None) -> Cases:
     try:
         closed_state_id = get_case_state_by_name('Closed').state_id
-        previous_case_state = case.state_id
+        previous_case_state = case.state_id if previous_state_id is None else previous_state_id
         case_previous_reviewer_id = case.reviewer_id
         db.session.commit()
 
@@ -198,7 +198,7 @@ def cases_update(case: Cases, updated_case, protagonists, tags) -> Cases:
 
             elif previous_case_state == closed_state_id and updated_case.state_id != closed_state_id:
                 track_activity('case re-opened', caseid=case.case_id)
-                res = reopen_case(case.case_id)
+                res = reopen_case(case.case_id, updated_case.state_id)
                 if not res:
                     raise BusinessProcessingError('Tried to re-open an non-existing case')
 

--- a/source/app/datamgmt/manage/manage_cases_db.py
+++ b/source/app/datamgmt/manage/manage_cases_db.py
@@ -222,7 +222,7 @@ def map_alert_resolution_to_case_status(case_status_id):
     return None
 
 
-def reopen_case(case_id):
+def reopen_case(case_id, state_id=None):
     res = Cases.query.filter(
         Cases.case_id == case_id
     ).first()
@@ -230,7 +230,10 @@ def reopen_case(case_id):
     if res:
         res.close_date = None
 
-        res.state_id = get_case_state_by_name('Open').state_id
+        if state_id is None:
+            state_id = get_case_state_by_name('Open').state_id
+
+        res.state_id = state_id
 
         db.session.commit()
         return res

--- a/tests/tests_rest_cases.py
+++ b/tests/tests_rest_cases.py
@@ -27,6 +27,32 @@ def _get_case_with_identifier(response, identifier):
     raise ValueError('Case not found')
 
 
+def _get_case_state_identifier_by_name(subject, state_name):
+    response = subject.get('/manage/case-states/list').json()
+    for case_state in response['data']:
+        if case_state['state_name'].lower() == state_name.lower():
+            return case_state['state_id']
+
+    raise ValueError(f'Case state {state_name} not found')
+
+
+def _get_non_closed_case_state_identifier(subject):
+    response = subject.get('/manage/case-states/list').json()
+    open_state_identifier = None
+
+    for case_state in response['data']:
+        state_name = case_state['state_name'].lower()
+        if state_name == 'open':
+            open_state_identifier = case_state['state_id']
+        if state_name not in ('closed', 'open'):
+            return case_state['state_id']
+
+    if open_state_identifier is not None:
+        return open_state_identifier
+
+    raise ValueError('No non-closed case state found')
+
+
 class TestsRestCases(TestCase):
 
     def setUp(self) -> None:
@@ -252,3 +278,43 @@ class TestsRestCases(TestCase):
         identifier = self._subject.create_dummy_case()
         response = self._subject.create(f'/manage/cases/close/{identifier}', {}).json()
         self.assertIsNotNone(response['data']['close_date'])
+
+    def test_update_case_state_to_closed_should_set_closing_date(self):
+        identifier = self._subject.create_dummy_case()
+        closed_state_identifier = _get_case_state_identifier_by_name(self._subject, 'Closed')
+        response = self._subject.update(f'/api/v2/cases/{identifier}', {'state_id': closed_state_identifier}).json()
+
+        self.assertEqual(closed_state_identifier, response['state']['state_id'])
+        self.assertIsNotNone(response['close_date'])
+
+    def test_manage_update_case_state_to_closed_should_set_closing_date(self):
+        identifier = self._subject.create_dummy_case()
+        closed_state_identifier = _get_case_state_identifier_by_name(self._subject, 'Closed')
+        response = self._subject.create(
+            f'/manage/cases/update/{identifier}',
+            {'state_id': closed_state_identifier}
+        ).json()
+
+        self.assertEqual(closed_state_identifier, response['data']['state_id'])
+        self.assertIsNotNone(response['data']['close_date'])
+
+    def test_update_case_state_to_non_closed_should_clear_closing_date(self):
+        identifier = self._subject.create_dummy_case()
+        reopened_state_identifier = _get_non_closed_case_state_identifier(self._subject)
+        self._subject.create(f'/manage/cases/close/{identifier}', {})
+        response = self._subject.update(f'/api/v2/cases/{identifier}', {'state_id': reopened_state_identifier}).json()
+
+        self.assertEqual(reopened_state_identifier, response['state']['state_id'])
+        self.assertIsNone(response['close_date'])
+
+    def test_manage_update_case_state_to_non_closed_should_clear_closing_date(self):
+        identifier = self._subject.create_dummy_case()
+        reopened_state_identifier = _get_non_closed_case_state_identifier(self._subject)
+        self._subject.create(f'/manage/cases/close/{identifier}', {})
+        response = self._subject.create(
+            f'/manage/cases/update/{identifier}',
+            {'state_id': reopened_state_identifier}
+        ).json()
+
+        self.assertEqual(reopened_state_identifier, response['data']['state_id'])
+        self.assertIsNone(response['data']['close_date'])

--- a/ui/src/pages/manage.cases.common.js
+++ b/ui/src/pages/manage.cases.common.js
@@ -24,7 +24,7 @@ function case_detail(id) {
 }
 
 /* Close case function */
-function close_case(id) {
+function confirm_close_case(id, on_confirm) {
     swal({
         title: "Are you sure?",
         text: "Case ID " + id + " will be closed and will not appear in contexts anymore",
@@ -36,15 +36,21 @@ function close_case(id) {
         confirmButtonText: 'Yes, close it!'
     })
     .then((willClose) => {
-        if (willClose) {
-            post_request_api(`/manage/cases/close/${id}`)
-            .done((data) => {
-                if (!refresh_case_table()) {
-                    window.location.reload();
-                }
-                $('#modal_case_detail').modal('hide');
-            });
+        if (willClose && on_confirm) {
+            on_confirm();
         }
+    });
+}
+
+function close_case(id) {
+    confirm_close_case(id, function () {
+        post_request_api(`/manage/cases/close/${id}`)
+        .done((data) => {
+            if (!refresh_case_table()) {
+                window.location.reload();
+            }
+            $('#modal_case_detail').modal('hide');
+        });
     });
 }
 
@@ -150,23 +156,15 @@ function save_case_edit(case_id) {
         var is_reopening_case = previous_state_identifier === closed_state_identifier &&
             selected_state_identifier !== closed_state_identifier;
 
-        if (is_closing_case || is_reopening_case) {
-            var case_action = is_closing_case ? 'close' : 'reopen';
-            swal({
-                title: "Are you sure?",
-                text: `Saving this change will ${case_action} the case`,
-                icon: "warning",
-                buttons: true,
-                dangerMode: true,
-                confirmButtonColor: '#3085d6',
-                cancelButtonColor: '#d33'
-            })
-            .then((willApplyStateTransition) => {
-                if (willApplyStateTransition) {
-                    submit_case_edit(case_id);
-                }
+        if (is_closing_case) {
+            confirm_close_case(case_id, function () {
+                submit_case_edit(case_id);
             });
+            return;
+        }
 
+        if (is_reopening_case) {
+            submit_case_edit(case_id);
             return;
         }
     }

--- a/ui/src/pages/manage.cases.common.js
+++ b/ui/src/pages/manage.cases.common.js
@@ -107,6 +107,9 @@ function remove_case(id) {
 function edit_case_info() {
     $('#case_gen_info_content').hide();
     $('#case_gen_info_edit').show();
+    if ($('#case_state').attr('data-initial-state-id') === undefined) {
+        $('#case_state').attr('data-initial-state-id', $('#case_state').val());
+    }
     $('.case-info-readonly-action').hide();
     $('#cancel_case_info').show();
     $('#save_case_info').show();
@@ -122,8 +125,56 @@ function cancel_case_edit() {
     $('#case_info').show();
 }
 
-function save_case_edit(case_id) {
+function get_closed_case_state_identifier() {
+    var closed_state_option = $('#case_state option').filter(function () {
+        return $(this).text().trim().toLowerCase() === 'closed';
+    }).first();
 
+    if (closed_state_option.length === 0) {
+        return NaN;
+    }
+
+    return parseInt(closed_state_option.val(), 10);
+}
+
+function save_case_edit(case_id) {
+    var previous_state_identifier = parseInt($('#case_state').attr('data-initial-state-id'), 10);
+    var selected_state_identifier = parseInt($('#case_state').val(), 10);
+    var closed_state_identifier = get_closed_case_state_identifier();
+
+    if (!Number.isNaN(previous_state_identifier) &&
+        !Number.isNaN(selected_state_identifier) &&
+        !Number.isNaN(closed_state_identifier)) {
+        var is_closing_case = previous_state_identifier !== closed_state_identifier &&
+            selected_state_identifier === closed_state_identifier;
+        var is_reopening_case = previous_state_identifier === closed_state_identifier &&
+            selected_state_identifier !== closed_state_identifier;
+
+        if (is_closing_case || is_reopening_case) {
+            var case_action = is_closing_case ? 'close' : 'reopen';
+            swal({
+                title: "Are you sure?",
+                text: `Saving this change will ${case_action} the case`,
+                icon: "warning",
+                buttons: true,
+                dangerMode: true,
+                confirmButtonColor: '#3085d6',
+                cancelButtonColor: '#d33'
+            })
+            .then((willApplyStateTransition) => {
+                if (willApplyStateTransition) {
+                    submit_case_edit(case_id);
+                }
+            });
+
+            return;
+        }
+    }
+
+    submit_case_edit(case_id);
+}
+
+function submit_case_edit(case_id) {
     var data_sent = $('form#form_update_case').serializeObject();
     var map_protagonists = Object();
 

--- a/ui/src/pages/manage.cases.common.js
+++ b/ui/src/pages/manage.cases.common.js
@@ -107,6 +107,7 @@ function remove_case(id) {
 function edit_case_info() {
     $('#case_gen_info_content').hide();
     $('#case_gen_info_edit').show();
+    $('.case-info-readonly-action').hide();
     $('#cancel_case_info').show();
     $('#save_case_info').show();
     $('#case_info').hide();
@@ -115,6 +116,7 @@ function edit_case_info() {
 function cancel_case_edit() {
     $('#case_gen_info_content').show();
     $('#case_gen_info_edit').hide();
+    $('.case-info-readonly-action').show();
     $('#cancel_case_info').hide();
     $('#save_case_info').hide();
     $('#case_info').show();


### PR DESCRIPTION
## Related Issues
- Closes #1049
- Closes #1050
- Closes #1052

## Summary
This PR aligns manage-case behavior with the intended case lifecycle model:

- `Closed` state means truly closed (`close_date` is set)
- any non-`Closed` state means open (`close_date` is cleared)
- edit dialog no longer shows conflicting destructive/lifecycle actions while editing

It also ensures state-transition behavior is consistent across:
- Manage update REST endpoint
- API v2 update endpoint
- GraphQL case update mutation

## What Changed

### Backend lifecycle/state transition fixes
- Preserve and pass `previous_state_id` into business update logic before schema load mutates the model instance.
- Fix transition detection in `cases_update()` to correctly detect:
  - non-Closed -> Closed (close flow)
  - Closed -> non-Closed (reopen flow)
- Update `reopen_case()` to preserve the selected target non-Closed state (instead of forcing `Open`) when reopening via state change.

### Frontend/manage dialog fixes
- Remove conflicting footer actions in edit mode (`Delete/Close/Reopen` hidden while editing).
- Keep `Reopen` button alignment consistent with `Close`/`Delete`.
- Reuse existing close-confirmation flow from the close button when save causes a transition to `Closed` (no custom new confirmation dialog behavior).
- Keep reopen-on-save behavior aligned with existing reopen action semantics.

### Test coverage
- Add regression tests for state transitions through:
  - `/api/v2/cases/<id>` update
  - `/manage/cases/update/<id>`
- Assert:
  - transitioning to `Closed` sets `close_date`
  - transitioning from `Closed` to non-Closed clears `close_date`
  - selected non-Closed state is retained

## Validation Performed
- Manual/UI:
  - Built UI assets and reloaded docker app/nginx.
  - Verified edit dialog action visibility and close/reopen transition behavior.
- API/cURL:
  - Verified authenticated reads and state transitions on case `35`.
  - Confirmed:
    - `state_id: 9 (Closed)` => `close_date` set
    - `state_id: non-Closed` => `close_date` cleared
  - Verified both:
    - `PUT /api/v2/cases/<id>`
    - `POST /manage/cases/update/<id>`

## Notes
- Local automated test execution in this environment had auth/environment constraints in the existing test harness, but API behavior was validated directly with authenticated curl checks and manual UI testing.

## Checklist
- [x] Backend lifecycle transition logic fixed
- [x] Frontend edit-dialog conflicts resolved
- [x] Existing close-confirmation flow reused (no new custom flow)
- [x] Regression tests added for transition cases
- [x] Changes pushed to fork branch `fix/1049-1050-1052-manage-case-state-dialog`
