### PR TITLE
security: enforce user ownership on global tasks (Fix IDOR)

### DIFF
--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -17,6 +17,7 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import marshmallow
+from sqlalchemy import or_
 from datetime import datetime
 from datetime import timedelta
 from oic.oauth2.exception import GrantError
@@ -157,7 +158,7 @@ def get_gtasks():
 @dashboard_rest_blueprint.route('/global/tasks/<int:cur_id>', methods=['GET'])
 @ac_api_requires()
 def view_gtask(cur_id):
-    task = get_global_task(task_id=cur_id)
+    task = GlobalTasks.query.filter(GlobalTasks.id == cur_id).filter(or_(GlobalTasks.task_userid_open == current_user.id, GlobalTasks.task_assignee_id == current_user.id)).first()
     if not task:
         return response_error(f'Global task ID {cur_id} not found')
 

--- a/source/app/blueprints/rest/dashboard_routes.py
+++ b/source/app/blueprints/rest/dashboard_routes.py
@@ -242,7 +242,7 @@ def add_gtask(caseid):
 @ac_requires_case_identifier()
 def edit_gtask(cur_id, caseid):
     form = CaseGlobalTaskForm()
-    task = GlobalTasks.query.filter(GlobalTasks.id == cur_id).first()
+    task = GlobalTasks.query.filter(GlobalTasks.id == cur_id).filter(or_(GlobalTasks.task_userid_open == current_user.id, GlobalTasks.task_assignee_id == current_user.id)).first()
     form.task_assignee_id.choices = [(user.id, user.name) for user in User.query.filter(
         User.active == True).order_by(User.name).all()]
     form.task_status_id.choices = [(a.id, a.status_name)
@@ -285,11 +285,11 @@ def gtask_delete(cur_id, caseid):
     if not cur_id:
         return response_error("Missing parameter")
 
-    data = GlobalTasks.query.filter(GlobalTasks.id == cur_id).first()
+    data = GlobalTasks.query.filter(GlobalTasks.id == cur_id).filter(or_(GlobalTasks.task_userid_open == current_user.id, GlobalTasks.task_assignee_id == current_user.id)).first()
     if not data:
         return response_error("Invalid global task ID")
 
-    GlobalTasks.query.filter(GlobalTasks.id == cur_id).delete()
+    GlobalTasks.query.filter(GlobalTasks.id == cur_id).filter(or_(GlobalTasks.task_userid_open == current_user.id, GlobalTasks.task_assignee_id == current_user.id)).delete()
     db.session.commit()
 
     call_modules_hook('on_postload_global_task_delete',


### PR DESCRIPTION
Ensures that global tasks can only be viewed, updated, or deleted by the task owner or assignee. Linked to issue #1034.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Viewing, editing, and deleting global tasks now only succeeds when the current user is the task opener or the task assignee. Attempts by other users will return the same not-found/invalid responses as before and will not perform any changes, ensuring task actions are limited to relevant users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->