### PR TITLE
[IMP] Search through case summary(description)

### DIFF
--- a/source/app/blueprints/search/search_routes.py
+++ b/source/app/blueprints/search/search_routes.py
@@ -56,6 +56,27 @@ def search_file_post():
 
     track_activity("started a global search for {} on {}".format(search_value, search_type))
 
+    if search_type == "case_summary":
+        search_value = "%{}%".format(search_value)
+        cs = Cases.query.filter(
+            and_(
+                Cases.description.like(search_value),
+                Cases.client_id == Client.client_id,
+                search_condition
+            )
+        ).with_entities(
+            Cases.name.label('case_name'),
+            Cases.case_id,
+            Cases.description.label('case_description'),
+            Client.name.label('customer_name')
+        ).join(
+            Cases.client
+        ).order_by(
+            Client.name
+        ).all()
+        files = [row._asdict() for row in cs]
+
+
     if search_type == "ioc":
         res = Ioc.query.with_entities(
                             Ioc.ioc_value.label('ioc_name'),

--- a/source/app/blueprints/search/templates/search.html
+++ b/source/app/blueprints/search/templates/search.html
@@ -28,8 +28,12 @@
                         <div class="form-group">
                             <label class="form-label mr-3">Set to search within</label>
                             <div class="selectgroup selectgroup-pills">
+				<label class="selectgroup-item">
+				    <input type="radio" name="search_type" value="case_summary" class="selectgroup-input" checked="">
+				    <span class="selectgroup-button">Case</span>
+				</label>
                                 <label class="selectgroup-item">
-                                    <input type="radio" name="search_type" value="ioc" class="selectgroup-input" checked="">
+                                    <input type="radio" name="search_type" value="ioc" class="selectgroup-input">
                                     <span class="selectgroup-button">IOC</span>
                                 </label>
                                 <label class="selectgroup-item">
@@ -43,6 +47,20 @@
                             </div>
                         </div>
                     </form>
+		    <div class="table-responsive" style="display: none;" id="search_table_wrapper_4">
+			<div class="selectgroup">
+			    <span id="table_buttons_4"></span>
+			</div>
+		      <table class="table display table table-striped table-hover" width="100%" cellspacing="0" id="case_summary_table">
+			<thead>
+		          <tr>
+			    <th>Case Name</th>
+			    <th>Summary</th>
+			    <th>Customer</th>
+			  </tr>
+			</thead>
+		      </table>
+                    </div>
                     <div class="table-responsive" style="display: none;" id="search_table_wrapper">
                         <div class="selectgroup">
                             <span id="table_buttons"></span>

--- a/source/app/static/assets/js/iris/search.js
+++ b/source/app/static/assets/js/iris/search.js
@@ -8,6 +8,52 @@ $('#search_value').keypress(function(event){
     }
 });
 
+Table_case_summary = $("#case_summary_table").DataTable({
+    dom: 'Bfrtip',
+    aaData: [],
+    aoColumns: [
+	{
+	    "data": "case_name",
+	    "render": function (data, type, row, meta) {
+		if (type === 'display') {
+		    let a_anchor = $('<a/>');
+		    a_anchor.attr('href', 'case?cid=' + row["case_id"]);
+		    a_anchor.attr('target', '_blank');
+		    a_anchor.text(data);
+		    return a_anchor[0].outerHTML;
+		}
+		return data;
+	    }
+	},
+	{
+	    "data": "case_description",
+	    "render": function (data, type, row, meta) {
+		if (type === 'display') {
+		    return data ? ret_obj_dt_description(data) : "No summary available";
+		}
+		return data;
+	    }
+	},
+	{
+	    "data": "customer_name",
+	    "render": function (data, type, row, meta) {
+		if (type === 'display') { data = sanitizeHTML(data || ""); }
+		return data;
+             }
+	}
+    ],
+    filter: true,
+    info: true,
+    ordering: true,
+    processing: true,
+    retrieve: true,
+    buttons: [
+	{ "extend": 'csvHtml5', "text": 'Export', "className": 'btn btn-primary btn-border btn-round btn-sm float-left mr-4 mt-2' },
+	{ "extend": 'copyHtml5', "text": 'Copy', "className": 'btn btn-primary btn-border btn-round btn-sm float-left mr-4 mt-2' },
+    ]
+});
+$("#case_summary_table").css("font-size", 12);
+
 
 Table_1 = $("#file_search_table_1").DataTable({
     dom: 'Bfrtip',
@@ -157,6 +203,12 @@ function search() {
                         $(e.target).popover('toggle');
                 });
             }
+	    else if (val == "case_summary") {
+	      Table_case_summary.clear();
+	      Table_case_summary.rows.add(data.data);
+	      Table_case_summary.columns.adjust().draw();
+	      $('#search_table_wrapper_4').show();
+	    }
             else if (val == "notes") {
                 for (e in data.data) {
                     let li_anchor = $('<i>');


### PR DESCRIPTION
# **Context**
Added the possibility to search for the case summary (description) in every single case.

<img width="1851" height="890" alt="1" src="https://github.com/user-attachments/assets/22b523dd-3f7b-4583-b889-191fa5b6f3b1" />
<hr>
<img width="1894" height="959" alt="2" src="https://github.com/user-attachments/assets/e0bd2994-8d84-4124-a35c-f2710e30dcd0" />

# **What Changed**

- Changed the file './source/app/static/assets/js/iris/search.js'
   - Turns a plain HTML table into a DataTable and displays three columns: case name, case description, and customer name. Includes export and copy buttons, and allows sorting, filtering, and pagination (already integrated). 

- Changed the file './source/app/blueprints/search/search_routes.py'
   - When the '/search' endpoint is called and the 'search_type' is equal to 'case_summary', the file 'search_routes.py' retrieves the following data: case name, case id, case description, customer name. All of the output is joined in a single table.

- Changed the file './source/app/blueprints/search/templates/search.html'
   - Added the button 'Case' in the '/search' page following the style of the existing buttons. The 'Case' button is already checked by default when u go to the 'Search' page. 
   - Added the formatted table to display the results and to use the same style as other tables.

# **Scope**
- Frontend change;
- Backend change;

# **Validation Performed**
Manual validation performed:
- Checked if the results are displayed corrected;
- Checked if the data are retrieved correctly;
- Checked if the frontend displays correctly, using the same style as the tables and boxes of the other search types.