### PR TITLE
Retrieve and add image extension via Pillow to prevent corrupted docx…

### DIFF
--- a/source/app/iris_engine/reporter/ImageHandler.py
+++ b/source/app/iris_engine/reporter/ImageHandler.py
@@ -56,7 +56,19 @@ class ImageHandler(PictureGlobals):
                 raise RenderingError(self._logger, f'File {dsf.file_local_name} does not exists on the server. Update or delete virtual entry')
 
             file_ext = os.path.splitext(dsf.file_original_name)[1]
+            if not file_ext:
+                file_ext = self._sniff_image_extension(dsf.file_local_name)
             file_name = os.path.join(self._output_path, str(uuid.uuid4())) + file_ext
             return_value = shutil.copy(dsf.file_local_name, file_name)
             return return_value
         return super()._process_remote(image_path)
+
+    @staticmethod
+    def _sniff_image_extension(file_path: str) -> str:
+        try:
+            from PIL import Image
+            with Image.open(file_path) as im:
+                fmt = (im.format or 'PNG').lower()
+            return '.jpg' if fmt == 'jpeg' else f'.{fmt}'
+        except Exception:
+            return '.png'


### PR DESCRIPTION
ImageHandler._process_remote derived the destination file extension solely from dsf.file_original_name. Datastore files saved without an extension (clipboard-pasted screenshots, API uploads stripping extensions) yielded a copy with no extension, producing word/media/imageN. in the generated DOCX with a missing/incorrect  content-type entry. Word then refused to open the report.
Fall back to Pillow-based format sniffing when the original name has no extension; default to .png if sniffing fails.                    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image file handling by automatically detecting the correct format when the original filename lacks an extension, ensuring images receive the appropriate file extension during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->