### PR TITLE
 [IMP] Search by case summary(description)

### DIFF
--- a/source/app/blueprints/pages/search/templates/search.html
+++ b/source/app/blueprints/pages/search/templates/search.html
@@ -29,7 +29,11 @@
                             <label class="form-label mr-3">Set to search within</label>
                             <div class="selectgroup selectgroup-pills">
                                 <label class="selectgroup-item">
-                                    <input type="radio" name="search_type" value="ioc" class="selectgroup-input" checked="">
+                                    <input type="radio" name="search_type" value="case_summary" class="selectgroup-input" checked="">
+                                    <span class="selectgroup-button">Case</span>
+                                </label>
+                                <label class="selectgroup-item">
+                                    <input type="radio" name="search_type" value="ioc" class="selectgroup-input">
                                     <span class="selectgroup-button">IOC</span>
                                 </label>
                                 <label class="selectgroup-item">
@@ -43,6 +47,20 @@
                             </div>
                         </div>
                     </form>
+                    <div class="table-responsive" style="display: none;" id="search_table_wrapper_4">
+                        <div class="selectgroup">
+                            <span id="table_buttons_4"></span>
+                        </div>
+                      <table class="table display table table-striped table-hover" width="100%" cellspacing="0" id="case_summary_table">
+                        <thead>
+                          <tr>
+                            <th>Case Name</th>
+                            <th>Summary</th>
+                            <th>Customer</th>
+                          </tr>
+                        </thead>
+                      </table>
+                    </div>
                     <div class="table-responsive" style="display: none;" id="search_table_wrapper">
                         <div class="selectgroup">
                             <span id="table_buttons"></span>

--- a/source/app/business/search.py
+++ b/source/app/business/search.py
@@ -20,12 +20,15 @@ from app.iris_engine.utils.tracker import track_activity
 from app.datamgmt.comments import search_comments
 from app.datamgmt.case.case_notes_db import search_notes
 from app.datamgmt.case.case_iocs_db import search_iocs
-
+from app.datamgmt.case.case_db import search_case_summary
 
 def search(search_type, search_value):
     track_activity(f'started a global search for {search_value} on {search_type}')
 
     files = []
+    if search_type == 'case_summary':
+        files = search_case_summary(search_value)
+
     if search_type == 'ioc':
         files = search_iocs(search_value)
 

--- a/source/app/datamgmt/case/case_db.py
+++ b/source/app/datamgmt/case/case_db.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 import binascii
 from sqlalchemy import and_
+from sqlalchemy import or_
 
 from sqlalchemy import exists
 from sqlalchemy import select
@@ -53,6 +54,31 @@ def get_first_case_with_customer(customer_identifier: int) -> Optional[Cases]:
     ).first()
     return case
 
+def search_case_summary(search_value):
+    results = Cases.query.with_entities(
+        Cases.case_id.label("case_id"),
+        Cases.name.label("case_name"),
+        Cases.description.label("case_description"),
+        Client.name.label("customer_name")
+    ).join(
+        Cases.client
+    ).filter(
+        or_(
+            Cases.name.ilike(f"%{search_value}%"),
+            Cases.description.ilike(f"%{search_value}%"),
+            Client.name.ilike(f"%{search_value}%")
+        )
+    ).all()
+
+    return [
+        {
+            "case_id": r.case_id,
+            "case_name": r.case_name,
+            "case_description": r.case_description,
+            "customer_name": r.customer_name
+        }
+        for r in results
+    ]
 
 def get_case_summary(caseid):
     case_summary = Cases.query.filter(

--- a/ui/src/pages/search.js
+++ b/ui/src/pages/search.js
@@ -8,6 +8,52 @@ $('#search_value').keypress(function(event){
     }
 });
 
+Table_case_summary = $("#case_summary_table").DataTable({
+    dom: 'Bfrtip',
+    aaData: [],
+    aoColumns: [
+        {
+            "data": "case_name",
+            "render": function (data, type, row, meta) {
+                if (type === 'display') {
+                    let a_anchor = $('<a/>');
+                    a_anchor.attr('href', 'case?cid=' + row["case_id"]);
+                    a_anchor.attr('target', '_blank');
+                    a_anchor.text(data);
+                    return a_anchor[0].outerHTML;
+                }
+                return data;
+            }
+        },
+        {
+            "data": "case_description",
+            "render": function (data, type, row, meta) {
+                if (type === 'display') {
+                    return data ? ret_obj_dt_description(data) : "No summary available";
+                }
+                return data;
+            }
+        },
+        {
+            "data": "customer_name",
+            "render": function (data, type, row, meta) {
+                if (type === 'display') { data = sanitizeHTML(data || ""); }
+                return data;
+             }
+        }
+    ],
+    filter: true,
+    info: true,
+    ordering: true,
+    processing: true,
+    retrieve: true,
+    buttons: [
+        { "extend": 'csvHtml5', "text": 'Export', "className": 'btn btn-primary btn-border btn-round btn-sm float-left mr-4 mt-2' },
+        { "extend": 'copyHtml5', "text": 'Copy', "className": 'btn btn-primary btn-border btn-round btn-sm float-left mr-4 mt-2' },
+    ]
+});
+$("#case_summary_table").css("font-size", 12);
+
 
 Table_1 = $("#file_search_table_1").DataTable({
     dom: 'Bfrtip',
@@ -159,6 +205,11 @@ function search() {
                     $('.popover').popover('hide');
                     $(e.target).popover('toggle');
             });
+    	} else if (val == "case_summary") {
+      	    Table_case_summary.clear();
+      	    Table_case_summary.rows.add(data.data);
+      	    Table_case_summary.columns.adjust().draw();
+      	    $('#search_table_wrapper_4').show();
         } else if (val == "notes") {
             for (e in data.data) {
                 let li_anchor = $('<i>');


### PR DESCRIPTION
# **Context**
Added the possibility to search for the case summary (description) in every single case.

<img width="1851" height="890" alt="1" src="https://github.com/user-attachments/assets/22b523dd-3f7b-4583-b889-191fa5b6f3b1" />
<hr>
<img width="1894" height="959" alt="2" src="https://github.com/user-attachments/assets/e0bd2994-8d84-4124-a35c-f2710e30dcd0" />

# **What Changed**

- Changed the file **[./ui/src/pages/search.js]**
   - Turns a plain HTML table into a DataTable and displays three columns: case name, case description, and customer name. Includes export and copy buttons, and allows sorting, filtering, and pagination (already integrated). 

- Changed the file **[./source/app/business/search.py]**
   - When the '/search' endpoint is called and the 'search_type' is equal to 'case_summary', the file script 'search.py' .
  
- Changed the file **[./source/app/datamgmt/case/case_db.py]**
  - Search cases by keyword in case name, description, or customer name, and retrieve the data.

- Changed the file **[./source/app/blueprints/search/templates/search.html]**
   - Added the button 'Case' in the '/search' page following the style of the existing buttons. The 'Case' button is already checked by default when u go to the 'Search' page. 
   - Added the formatted table to display the results and to use the same style as other tables.

# **Scope**
- Frontend change;
- Backend change;

# **Validation Performed**
Manual validation performed:
- Checked if the results are displayed corrected;
- Checked if the data are retrieved correctly;
- Checked if the frontend displays correctly, using the same style as the tables and boxes of the other search types.