### PR TITLE
[FIX] Fix duplicate cid parameter in context/set request URL

### DIFF
--- a/ui/src/pages/common.js
+++ b/ui/src/pages/common.js
@@ -1834,7 +1834,7 @@ $(document).ready(function(){
             $('#modal_switch_context').modal('hide');
             return;
     }
-    post_request_api(`/context/set?cid=${data_sent.ctx}`, data_sent)
+    post_request_api('/context/set', data_sent, false, undefined, data_sent.ctx)
     .done((data) => {
             if (api_request_failed(data)) {
                 return true;


### PR DESCRIPTION
## Problem

Switching cases generated a malformed URL with two `cid` query parameters:

`/context/set?cid=2?cid=1`

The request still workes, but noticed this while troubleshooting issues caused by our WAF, which rejected the malformed request.

## Fix

Use the helper's `cid` argument instead of adding `?cid=` directly to the URL.