### PR TITLE
[IMP] Reliably assign file extensions for pasted clipboard files using MIME mapping

### DIFF
--- a/ui/src/pages/case.notes.js
+++ b/ui/src/pages/case.notes.js
@@ -1078,7 +1078,8 @@ function handle_ed_paste(event) {
                 notify_success('The file is uploading in background. Don\'t leave the page');
 
                 if (filename === null) {
-                    filename = random_filename(25);
+                    let ext = get_extension_from_mime(blob.type);
+                    filename = random_filename(25) + '.' + ext;
                 }
 
                 upload_interactive_data(e.target.result, filename, function(data){

--- a/ui/src/pages/case.summary.js
+++ b/ui/src/pages/case.summary.js
@@ -94,7 +94,8 @@ function handle_ed_paste(event) {
                 notify_success('The file is uploading in background. Don\'t leave the page');
 
                 if (filename === null) {
-                    filename = random_filename(25);
+                    let ext = get_extension_from_mime(blob.type);
+                    filename = random_filename(25) + '.' + ext;
                 }
 
                 upload_interactive_data(e.target.result, filename, function(data){

--- a/ui/src/pages/common.js
+++ b/ui/src/pages/common.js
@@ -1609,6 +1609,35 @@ function random_filename(length) {
    return filename;
 }
 
+function get_extension_from_mime(mimeType) {
+    if (!mimeType || typeof mimeType !== 'string') return 'bin';
+
+    // Strip parameters (e.g., "image/png; charset=utf-8" -> "image/png") and normalize case
+    const cleanMime = mimeType.split(';')[0].trim().toLowerCase();
+
+    const mimeMap = {
+        'image/png': 'png',
+        'image/jpeg': 'jpg',
+        'image/gif': 'gif',
+        'image/webp': 'webp',
+        'image/avif': 'avif',
+        'image/svg+xml': 'svg',
+        'image/bmp': 'bmp',
+        'image/tiff': 'tiff',
+        'image/x-icon': 'ico',
+        'image/vnd.microsoft.icon': 'ico'
+    };
+    
+    let ext = mimeMap[cleanMime];
+    if (!ext) {
+        // Fallback: extract substring after "/" and before any "+", e.g., "application/pdf" -> "pdf"
+        ext = (cleanMime.split('/')[1] || 'bin').split('+')[0];
+    }
+    
+    // Ensure the extension only contains safe alphanumeric characters
+    return ext.replace(/[^a-z0-9]/g, '');
+}
+
 function createPagination(currentPage, totalPages, per_page, callback, paginationContainersNodes) {
   const maxPagesToShow = 5;
   const paginationContainers = $(paginationContainersNodes);


### PR DESCRIPTION
Problem: 
Images pasted into Markdown notes/summaries lacked file extensions. While they worked in the markdown preview, the missing extensions caused several issues. For example when you want to download them from the datastore or when you include them in reports.

Solution:
Replaced the legacy file naming method with a new get_extension_from_mime() utility. It reads the exact MIME type (e.g., image/png, image/avif) directly from the clipboard blob and maps it to the correct extension. This ensures every pasted image gets the correct file extension.

<img width="419" height="125" alt="image" src="https://github.com/user-attachments/assets/528bf734-04ff-46eb-9a36-97618f7fa068" />