### PR TITLE
[#640][IMP] Enable image pasting in timeline description editor by moving 'handle_ed_paste' in 'case.common.js'

### DIFF
--- a/ui/src/pages/case.common.js
+++ b/ui/src/pages/case.common.js
@@ -36,3 +36,42 @@ $(document).ready(function(){
         collab_case.emit('join-case-obj-notif', { 'channel': 'case-' + get_caseid() });
     }
 });
+
+function handle_ed_paste(event, editor) {
+    let filename = null;
+    const { items } = event.originalEvent.clipboardData;
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i];
+
+      if (item.kind === 'string') {
+        item.getAsString(function (s){
+            filename = $.trim(s.replace(/\t|\n|\r/g, '')).substring(0, 40);
+        });
+      }
+
+      if (item.kind === 'file') {
+        const blob = item.getAsFile();
+
+        if (blob !== null) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                notify_success('The file is uploading in background. Don\'t leave the page');
+
+                if (filename === null) {
+                    filename = random_filename(25);
+                }
+
+                upload_interactive_data(e.target.result, filename, function(data){
+                    url = data.data.file_url + case_param();
+                    event.preventDefault();
+                    editor.insertSnippet(`\n![${filename}](${url} =100%x40%)\n`);
+                });
+
+            };
+            reader.readAsDataURL(blob);
+        } else {
+            notify_error('Unsupported direct paste of this item. Use datastore to upload.');
+        }
+      }
+    }
+}

--- a/ui/src/pages/case.notes.js
+++ b/ui/src/pages/case.notes.js
@@ -451,7 +451,7 @@ async function note_detail(id) {
             ed_details.off('paste');
             ed_details.on('paste', (event) => {
                 event.preventDefault();
-                handle_ed_paste(event);
+                handle_ed_paste(event, note_editor);
             });
 
             setSharedLink(id);
@@ -1055,47 +1055,6 @@ function createDirectoryListItem(directory, directoryMap) {
 
     return listItem;
 }
-
-
-function handle_ed_paste(event) {
-    let filename = null;
-    const { items } = event.originalEvent.clipboardData;
-    for (let i = 0; i < items.length; i += 1) {
-      const item = items[i];
-
-      if (item.kind === 'string') {
-        item.getAsString(function (s){
-            filename = $.trim(s.replace(/\t|\n|\r/g, '')).substring(0, 40);
-        });
-      }
-
-      if (item.kind === 'file') {
-        const blob = item.getAsFile();
-
-        if (blob !== null) {
-            const reader = new FileReader();
-            reader.onload = (e) => {
-                notify_success('The file is uploading in background. Don\'t leave the page');
-
-                if (filename === null) {
-                    filename = random_filename(25);
-                }
-
-                upload_interactive_data(e.target.result, filename, function(data){
-                    url = data.data.file_url + case_param();
-                    event.preventDefault();
-                    note_editor.insertSnippet(`\n![${filename}](${url} =100%x40%)\n`);
-                });
-
-            };
-            reader.readAsDataURL(blob);
-        } else {
-            notify_error('Unsupported direct paste of this item. Use datastore to upload.');
-        }
-      }
-    }
-}
-
 
 function note_interval_pinger() {
     if (new Date() - last_ping > 2000) {

--- a/ui/src/pages/case.timeline.js
+++ b/ui/src/pages/case.timeline.js
@@ -107,6 +107,13 @@ function add_event(parent_event_id = null) {
         $('#modal_add_event').modal({ show: true });
         $('#event_title').focus();
 
+        let ed_event_description = $('#event_description');
+        ed_event_description.off('paste');
+        ed_event_description.on('paste', (event) => {
+            event.preventDefault();
+            handle_ed_paste(event, g_event_desc_editor);
+        });
+
     });
 }
 


### PR DESCRIPTION
Hi,

I added this simple feature to easily paste images into case timeline event descriptions.
I simply moved the existing function that handles it for `case.notes.js` into the `case.common.js` file.
I also added an `editor` argument to the function to specify the editor object in which to put the image link.
Then, as in `case.notes.js`, I overrode the paste handler with the function.

This could close :
- #640 

Hope this helps a little!