### PR TITLE
[FIX] alerts: pristine-snapshot comparison + Celery session/pool reset after fork

### DIFF
--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -48,6 +48,8 @@ from app.business.alerts import alerts_get_related
 from app.models.errors import BusinessProcessingError
 from app.models.errors import ObjectNotFoundError
 
+import copy
+
 
 # Fields that must be immutable on alert update. See GHSA-8hwq-v6vm-9grr
 # / SBA-ADV-20260128-05 / CWE-863 — re-attributing alert_customer_id lets
@@ -252,6 +254,7 @@ class AlertsOperations:
                 identifier,
                 fallback_customer_access=ac_current_user_has_customer_access
             )
+            pristine_alert = copy.copy(alert)  # shallow copy for ongoing comparison
             # Drop fields the caller must not be allowed to change on update
             # (GHSA-8hwq-v6vm-9grr / SBA-ADV-20260128-05 / CWE-863). The
             # customer_id is the worst: re-attributing an alert to a
@@ -262,7 +265,7 @@ class AlertsOperations:
             activity_data = []
 
             for key, value in request_data.items():
-                old_value = getattr(alert, key, None)
+                old_value = getattr(pristine_alert, key, None)
 
                 if type(old_value) is int:
                     old_value = str(old_value)
@@ -279,7 +282,7 @@ class AlertsOperations:
 
             if request_data.get('alert_owner_id') == "-1" or request_data.get('alert_owner_id') == -1:
                 updated_alert.alert_owner_id = None
-            result = alerts_update(alert, updated_alert, activity_data)
+            result = alerts_update(pristine_alert, updated_alert, activity_data)
             return response_api_success(self._schema.dump(result))
 
         except ValidationError as e:

--- a/source/app/iris_engine/module_handler/module_handler.py
+++ b/source/app/iris_engine/module_handler/module_handler.py
@@ -423,6 +423,10 @@ def task_hook_wrapper(self, module_name, hook_name, hook_ui_name, data, init_use
     :param caseid: Case associated
     :return: A task status JSON task_success or task_failure
     """
+    # Reset session and connection pool inherited from parent process fork
+    db.session.remove()
+    db.engine.dispose()
+    
     try:
         # Data is serialized, so deserialized
         signature, pdata = data.encode("utf-8").split(b" ")


### PR DESCRIPTION
## Summary

Two bug fixes on alert updates.

#### **`alerts.py`**  
The alert object was already reflecting new values by the time the old/new comparison ran. This produced no-op history entries (`"alert_status_id" from "4" to "4"`) and silently skipped `/alert/status-update` and `/alert/resolution-update` webhooks. 
- Fix: take a `copy.copy(alert)` snapshot before any mutations and use it as the comparison baseline.

#### **`module_handler.py`**  
Celery prefork workers inherit the parent's DB session and open connections, causing shared connections across processes. This results in interleaved queries and stale transaction state, which directly caused multiple webhook hooks to fail silently.
- Fix: call `db.session.remove()` + `db.engine.dispose()` at task entry to discard the inherited state.

## Test plan
- Updated an alert changing status and resolution -> activity history shows correct before/after values, all three webhooks fire

**BEFORE**
<img width="918" height="252" alt="BEFORE_COMPARISON" src="https://github.com/user-attachments/assets/b065d824-fd05-4446-ba6b-0aaa8f52f3c0" />
**AFTER**
<img width="931" height="211" alt="AFTER_COMPARISON" src="https://github.com/user-attachments/assets/601f6720-b763-4b04-8701-a3a58b811b9f" />

- Setting a field to its existing value no longer creates a history entry

**BEFORE**
<img width="396" height="120" alt="BEFORE_CHANGES" src="https://github.com/user-attachments/assets/cad1f93f-571b-417e-beb9-0a0d37bc15e3" />
**AFTER**
<img width="462" height="138" alt="AFTER_CHANGES" src="https://github.com/user-attachments/assets/fc0af757-afdc-4ad2-af88-81692cb54272" />


