### PR TITLE
[#1094][FIX] alerts: skip owner override when alert_owner_id is in updates

### DIFF
--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -473,7 +473,7 @@ def alerts_batch_update_route() -> Response:
             if not ac_current_user_has_customer_access(alert.alert_customer_id):
                 return response_error('User not entitled to update alerts for the client', status=403)
 
-            if alert.alert_owner_id is None:
+            if alert.alert_owner_id is None and 'alert_owner_id' not in updates:
                 updates['alert_owner_id'] = iris_current_user.id
 
             if data.get('alert_owner_id') == "-1" or data.get('alert_owner_id') == -1:


### PR DESCRIPTION
## Summary

Fixes #1094.

When `alerts_batch_update_route` processes an alert with `alert_owner_id = NULL`, it unconditionally falls back to `current_user.id`, ignoring any `alert_owner_id` the caller explicitly included in the payload. This causes the first **Assign → [user]** action on an ownerless alert to behave identically to **Assign to me**, requiring a second identical request to apply the intended owner.

The fix adds a guard so the fallback only fires when the caller did not supply an `alert_owner_id`:

```python
# before
if alert.alert_owner_id is None:
    updates['alert_owner_id'] = iris_current_user.id

# after
if alert.alert_owner_id is None and 'alert_owner_id' not in updates:
    updates['alert_owner_id'] = iris_current_user.id
```

## Test plan

- [ ] Batch-assign an ownerless alert to a user other than the logged-in user; verify it is assigned to the intended user on the first attempt
- [ ] Batch-assign an ownerless alert with no `alert_owner_id` in the payload (e.g. a status-only update); verify it still falls back to the current user
- [ ] Verify existing batch-update flows (status change, severity change) are unaffected