### PR TITLE
[#1090][FIX] alerts: support updating IOCs via alert update routes

### DIFF
--- a/source/app/blueprints/rest/alerts_routes.py
+++ b/source/app/blueprints/rest/alerts_routes.py
@@ -361,6 +361,7 @@ def alerts_update_route(alert_id) -> Response:
         # any other processing so these values never reach the activity log
         # or the ORM.
         data = _strip_readonly_update_fields(request.get_json())
+        iocs_list = data.pop('alert_iocs', None)
 
         activity_data = []
         for key, value in data.items():
@@ -390,6 +391,11 @@ def alerts_update_route(alert_id) -> Response:
 
         if data.get('alert_owner_id') == "-1" or data.get('alert_owner_id') == -1:
             updated_alert.alert_owner_id = None
+
+        if iocs_list is not None:
+            ioc_schema = IocSchema()
+            updated_alert.iocs = ioc_schema.load(iocs_list, many=True, partial=True)
+            activity_data.append('"alert_iocs"')
 
         # Save the changes
         db.session.commit()

--- a/source/app/blueprints/rest/v2/alerts.py
+++ b/source/app/blueprints/rest/v2/alerts.py
@@ -272,6 +272,7 @@ class AlertsOperations:
             # customer the caller cannot see hides it from the rightful
             # owner and plants it under another tenant's view.
             request_data = _strip_readonly_alert_fields(request.get_json())
+            iocs_list = request_data.pop('alert_iocs', None)
             updated_alert = self._schema.load(request_data, instance=alert, partial=True)
             activity_data = []
 
@@ -293,6 +294,12 @@ class AlertsOperations:
 
             if request_data.get('alert_owner_id') == "-1" or request_data.get('alert_owner_id') == -1:
                 updated_alert.alert_owner_id = None
+
+            if iocs_list is not None:
+                ioc_schema = IocSchema()
+                updated_alert.iocs = ioc_schema.load(iocs_list, many=True, partial=True)
+                activity_data.append('"alert_iocs"')
+
             result = alerts_update(alert, updated_alert, activity_data)
             return response_api_success(self._schema.dump(result))
 


### PR DESCRIPTION
## Summary

Fixes #1090.

`POST /alerts/update/<id>` and `PUT /api/v2/alerts/<id>` both silently ignored `alert_iocs` in the request body. The field never reached the ORM: `AlertSchema` has `unknown = EXCLUDE`, so `alert_iocs` — which doesn't match the schema's `iocs` key — was stripped before any relationship assignment could happen. IOCs were effectively immutable after alert creation.

**Root cause:** `alert_iocs` in the payload is never mapped to `alert.iocs` on update, unlike at creation where `alerts_add_route` explicitly pops `alert_iocs`, deserializes it with `IocSchema`, and passes the result directly to `alerts_create`.

**Fix:** Mirror the creation pattern in both update routes:

1. Pop `alert_iocs` from the request data before schema load (so the `unknown=EXCLUDE` policy doesn't swallow it and it doesn't pollute the activity log).
2. After schema load, if `alert_iocs` was present in the payload, deserialize the list with `IocSchema` and assign it to `updated_alert.iocs`.

Omitting `alert_iocs` from the payload leaves existing IOCs unchanged. Passing an empty list (`"alert_iocs": []`) clears all IOCs on the alert.

## Changes

- `source/app/blueprints/rest/alerts_routes.py` — legacy `POST /alerts/update/<id>`
- `source/app/blueprints/rest/v2/alerts.py` — v2 `PUT /api/v2/alerts/<id>`

## Test plan

- [ ] `POST /alerts/update/<id>` with `alert_iocs`: verify IOCs are updated on the alert
- [ ] `PUT /api/v2/alerts/<id>` with `alert_iocs`: same verification on the v2 endpoint
- [ ] Request without `alert_iocs` field: existing IOCs must remain unchanged
- [ ] Request with `"alert_iocs": []`: existing IOCs must be cleared
- [ ] Invalid IOC payload (bad `ioc_type_id`, missing `ioc_value`): verify 400 / validation error is returned