### PR TITLE
Fix stale user identity after logout

### DIFF
--- a/e2e/tests/administrator/dashboard.spec.js
+++ b/e2e/tests/administrator/dashboard.spec.js
@@ -13,9 +13,14 @@ test('create case with empty name should present error', async ({ page }) => {
     await expect(page.getByText('Invalid data type')).toBeVisible();
 });
 
-test('logout should go back to login page', async ({ page }) => {
+test('logout should clear cached user identity and go back to login page', async ({ page }) => {
+    await page.evaluate(() => {
+        sessionStorage.setItem('userWhoami', JSON.stringify({ user_id: 1234 }));
+    });
+
     await page.getByRole('link', { name: 'administrator' }).click();
     await page.getByRole('link', { name: 'Logout' }).click();
 
     await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
-})
+    expect(await page.evaluate(() => sessionStorage.getItem('userWhoami'))).toBeNull();
+});

--- a/source/app/templates/includes/sidenav.html
+++ b/source/app/templates/includes/sidenav.html
@@ -29,7 +29,7 @@
 										</a>
 									</li>
 									<li>
-										<a href={{ url_for('dashboard_rest.logout') }}>
+										<a href="{{ url_for('dashboard_rest.logout') }}" onclick="sessionStorage.removeItem('userWhoami');">
 											<span class="link-collapse">Logout</span>
 										</a>
 									</li>


### PR DESCRIPTION
## Background

Issue #1093 reports that after a user logs out and another user logs in from the same browser tab, the Alerts "Assign to me" action can still use the previous user's cached `userWhoami` value from `sessionStorage`.

## Changes

- Clear `sessionStorage.userWhoami` when the sidebar logout link is clicked.
- Extend the existing dashboard logout e2e test to seed `userWhoami` before logout and assert it is removed afterward.

## Impact

This prevents stale browser-side identity data from carrying across logout/re-login flows and assigning alerts to the wrong analyst.

## Validation

- `git diff --check`
- `node --check e2e/tests/administrator/dashboard.spec.js` using the bundled Node runtime

Full Playwright e2e was not run locally because the Docker-backed IRIS test app and e2e dependencies were not bootstrapped in this workspace.

Closes #1093.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout behavior by clearing stored session identity information.
  * Confirmed that logging out returns users to the sign-in screen and removes stale session data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->