### PR TITLE
Add new OIDC users to default group

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -49,7 +49,7 @@ IRIS_AUTHENTICATION_TYPE=local
 #IRIS_ADM_API_KEY=B8BA5D730210B50F41C06941582D7965D57319D5685440587F98DFDC45A01594
 #IRIS_ADM_EMAIL=admin@localhost
 #IRIS_ADM_USERNAME=administrator
-# requests the just-in-time creation of users with ldap authentification (see https://github.com/dfir-iris/iris-web/issues/203)
+# requests the just-in-time creation of users with ldap / oidc authentification (see https://github.com/dfir-iris/iris-web/issues/203)
 #IRIS_AUTHENTICATION_CREATE_USER_IF_NOT_EXIST=True
 # the group to which newly created users are initially added, default value is Analysts
 #IRIS_NEW_USERS_DEFAULT_GROUP=

--- a/source/app/blueprints/pages/login/login_routes.py
+++ b/source/app/blueprints/pages/login/login_routes.py
@@ -41,6 +41,8 @@ from app.blueprints.responses import response_error
 from app.business.auth import validate_ldap_login, _retrieve_user_by_username, wrap_login_user
 from app.datamgmt.manage.manage_users_db import create_user
 from app.datamgmt.manage.manage_users_db import get_user
+from app.datamgmt.manage.manage_users_db import add_user_to_group
+from app.datamgmt.manage.manage_groups_db import get_group_by_name
 from app.forms import LoginForm, MFASetupForm
 from app.iris_engine.utils.tracker import track_activity
 
@@ -214,6 +216,10 @@ if is_authentication_oidc():
                         user_active=True,
                         user_is_service_account=False
                 )
+
+            initial_group = get_group_by_name(app.config.get('IRIS_NEW_USERS_DEFAULT_GROUP'))
+            add_user_to_group(user.id, initial_group.group_id)
+            log.info(f"Adding new user {user_name} to default initial group {initial_group}.")
 
         if user and not user.active:
             return response_error("User not active in IRIS", 403)


### PR DESCRIPTION
Closes https://github.com/dfir-iris/iris-web/issues/1104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users created through OIDC sign-in are now automatically added to the configured default group.

* **Documentation**
  * Updated authentication configuration guidance to clarify that just-in-time user creation applies to both LDAP and OIDC authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->