### PR TITLE
add config option to define a OIDC JWKS URL

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -84,6 +84,7 @@ IRIS_AUTHENTICATION_TYPE=local
 # endpoints only required if provider doesn't support metadata discovery
 # OIDC_AUTH_ENDPOINT=
 # OIDC_TOKEN_ENDPOINT=
+# OIDC_JWKS_URL=
 # optional to include logout from oidc provider
 # OIDC_END_SESSION_ENDPOINT=
 # OIDC redirect URL for your IDP: https://<IRIS_SERVER_NAME>/oidc-authorize

--- a/source/app/configuration.py
+++ b/source/app/configuration.py
@@ -469,6 +469,7 @@ class Config:
         OIDC_CLIENT_SECRET = config.load('OIDC', 'CLIENT_SECRET')
         OIDC_AUTH_ENDPOINT = config.load('OIDC', 'AUTH_ENDPOINT', fallback=None)
         OIDC_TOKEN_ENDPOINT = config.load('OIDC', 'TOKEN_ENDPOINT', fallback=None)
+        OIDC_JWKS_URL = config.load('OIDC', 'JWKS_URL', fallback=None)
         OIDC_END_SESSION_ENDPOINT = config.load('OIDC', 'END_SESSION_ENDPOINT', fallback=None)
         OIDC_SCOPES = config.load('OIDC', 'SCOPES', fallback="openid email profile")
         OIDC_MAPPING_USERNAME = config.load('OIDC', 'MAPPING_USERNAME', fallback='preferred_username')

--- a/source/app/iris_engine/access_control/oidc_handler.py
+++ b/source/app/iris_engine/access_control/oidc_handler.py
@@ -36,6 +36,7 @@ def get_oidc_client(app) -> Client:
             authorization_endpoint=app.config.get("OIDC_AUTH_ENDPOINT"),
             token_endpoint=app.config.get("OIDC_TOKEN_ENDPOINT"),
             end_session_endpoint=app.config.get("OIDC_END_SESSION_ENDPOINT"),
+            jwks_uri=app.config.get("OIDC_JWKS_URL"),
         )
 
         client.handle_provider_config(op_info, op_info['issuer'])


### PR DESCRIPTION
I had lots of trouble getting OIDC running, with my organizations IDP: NetScaler with a weird configuration.

IRIS' OIDC implementation works like the following `source/app/iris_engine/access_control/oidc_handler.py:oidc_handler()` tries to get the OIDC config via `"OIDC_ISSUER_URL"/.well-known/openid-configuration`, if this fails [1] it will consult the configuration values for each of the URLs.
This is a perfectly sane and good implementation.

Now because of the weird configuration of our IDP I had to set all the URLs manually.
Going down the [exception handling branch](https://github.com/dfir-iris/iris-web/blob/a4bfedaae11033005d61ece9d82a5af677c43512/source/app/iris_engine/access_control/oidc_handler.py#L32) - which may be not commonly used.

Doing so I kept being hit with a `jwkest.jws.NoSuitableSigningKeys` Exception.
For some reason, the whole flow worked, until IRIS tried to validate that the token came from the actual IDP.
It turned out that IRIS had **0** signing keys it compared with - so of course no key matched.

After lots of debugging I figured out that passing a `jwks_uri` to the `ProviderConfigurationResponse` in `source/app/iris_engine/access_control/oidc_handler.py:oidc_handler()` solved this.

Thus I made a PR that introduces this configuration value.

[1] e.g. because my genius sysadmins have the discovery document at `https://access.company.tld/oauth/idp/.well-known/openid-configuration` (note the `/oauth/idp/` path) but the issuer still being `https://access.company.tld/` instead of respective `https://access.company.tld/oauth/idp/`.