### PR TITLE
[FIX] Custom attribute tabs not displayed in the add case modal

### DIFF
--- a/source/app/blueprints/pages/manage/templates/modal_add_case.html
+++ b/source/app/blueprints/pages/manage/templates/modal_add_case.html
@@ -51,7 +51,7 @@
                     <h4><ul class="nav nav-tabs nav-lines mr-4" role="tablist">
                             {% for ca in attributes %}
                                 <li class="nav-item submenu">
-                                    <a class="nav-link {% if loop.index == 1 %}{{"active show"}}{% endif %}"  data-toggle="tab" href="#itab_{{ loop.index }}_{{  ca.lower() | replace(' ', '_' ) }}"
+                                    <a class="nav-link {% if loop.index == 1 %}{{"active show"}}{% endif %}"  data-toggle="tab" href="#itab_{{  ca.lower() | replace(' ', '_' ) }}_{{ loop.index }}"
                                     role="tab" aria-selected="false">{{ca}}</a>
                                 </li>
                             {% endfor %}


### PR DESCRIPTION
Related to https://github.com/dfir-iris/iris-web/issues/798 — completes b72d0795 / 8103c2d7, which reordered the custom attribute tab-pane ids but missed the add case modal's hand-built nav.

## Summary

* **Bug Fixes**
  * Add case modal: align the hand-built attribute tab hrefs with the reordered tab-pane ids (`itab_<name>_<index>`) so the tabs open again.

* **Root cause (short)**
  * The attribute tab-pane ids have always started with a digit (e.g. `1_details`) — invalid CSS selectors that the old jQuery/Bootstrap (Sizzle) tolerated. The dependency upgrade (d1b5c610 on the 2.4.x release line, earlier on develop) resolves tab targets via `document.querySelector`, which rejects them. b72d0795 / 8103c2d7 fixed the shared templates on develop; this PR fixes the last remaining nav. The 2.4.x line back-ported the upgrade without those two fixes, which is why v2.4.29 regressed while v2.4.27 works.